### PR TITLE
LambdaAnalyzer: fix for call-by-name semantic

### DIFF
--- a/ReSharper.FSharp/src/FSharp.Psi.Features/src/Daemon/Analyzers/LambdaAnalyzer.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Features/src/Daemon/Analyzers/LambdaAnalyzer.fs
@@ -103,19 +103,20 @@ type LambdaAnalyzer() =
             argDeclType.HasTypeDefinition && (getAbbreviatedEntity argDeclType.TypeDefinition).IsDelegate
         | _ -> false
 
-    let isExpressionApplicable (expr: IFSharpExpression) =
+    let isApplicable (expr: IFSharpExpression) (pats: TreeNodeCollection<IFSharpPattern>) =
         match expr with
         | :? IPrefixAppExpr
         | :? IReferenceExpr
         | :? ITupleExpr
-        | :? IUnitExpr -> true
+        | :? IUnitExpr ->
+            if pats.Count = 1 && pats.First().IgnoreInnerParens() :? IUnitPat then false else true
         | _ -> false
 
     override x.Run(lambda, _, consumer) =
         let expr = lambda.Expression.IgnoreInnerParens()
-        if not (isExpressionApplicable expr) then () else
-
         let pats = lambda.Patterns
+
+        if not (isApplicable expr pats) then () else
 
         let warning = 
             match compareArgs pats expr with

--- a/ReSharper.FSharp/src/FSharp.Psi.Features/src/Daemon/Analyzers/LambdaAnalyzer.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Features/src/Daemon/Analyzers/LambdaAnalyzer.fs
@@ -108,8 +108,7 @@ type LambdaAnalyzer() =
         | :? IPrefixAppExpr
         | :? IReferenceExpr
         | :? ITupleExpr
-        | :? IUnitExpr ->
-            if pats.Count = 1 && pats.First().IgnoreInnerParens() :? IUnitPat then false else true
+        | :? IUnitExpr -> not (pats.Count = 1 && pats.First().IgnoreInnerParens() :? IUnitPat)
         | _ -> false
 
     override x.Run(lambda, _, consumer) =

--- a/ReSharper.FSharp/test/data/features/daemon/lambdaAnalyzer/Id.fs
+++ b/ReSharper.FSharp/test/data/features/daemon/lambdaAnalyzer/Id.fs
@@ -1,5 +1,4 @@
 fun x -> x
-fun () -> ()
 fun (x, y) -> (x, y)
 fun struct(a, b) -> struct(a, b)
 fun (a, b) (c, d, e) -> (c, d, e)

--- a/ReSharper.FSharp/test/data/features/daemon/lambdaAnalyzer/Id.fs.gold
+++ b/ReSharper.FSharp/test/data/features/daemon/lambdaAnalyzer/Id.fs.gold
@@ -1,12 +1,10 @@
 ﻿|fun x -> x|(0)
-|fun () -> ()|(1)
-|fun (x, y) -> (x, y)|(2)
-|fun struct(a, b) -> struct(a, b|(3))
-|fun (a, b) (c, d, e) -> (c, d, e)|(4)
+|fun (x, y) -> (x, y)|(1)
+|fun struct(a, b) -> struct(a, b)|(2)
+|fun (a, b) (c, d, e) -> (c, d, e)|(3)
 
 ---------------------------------------------------------
 (0): ReSharper Hint: Lambda can be replaced with 'id'
 (1): ReSharper Hint: Lambda can be replaced with 'id'
 (2): ReSharper Hint: Lambda can be replaced with 'id'
-(3): ReSharper Hint: Lambda can be replaced with 'id'
-(4): ReSharper Hint: Lambda body can be replaced with 'id'
+(3): ReSharper Hint: Lambda body can be replaced with 'id'

--- a/ReSharper.FSharp/test/data/features/daemon/lambdaAnalyzer/Not available.fs
+++ b/ReSharper.FSharp/test/data/features/daemon/lambdaAnalyzer/Not available.fs
@@ -1,5 +1,8 @@
 ﻿let f x y = ()
 
+fun () -> ()
+fun (()) -> ()
+
 fun x -> -x
 fun x -> ~~x
 

--- a/ReSharper.FSharp/test/data/features/daemon/lambdaAnalyzer/Not available.fs
+++ b/ReSharper.FSharp/test/data/features/daemon/lambdaAnalyzer/Not available.fs
@@ -2,6 +2,7 @@
 
 fun () -> ()
 fun (()) -> ()
+fun () -> id ()
 
 fun x -> -x
 fun x -> ~~x

--- a/ReSharper.FSharp/test/data/features/daemon/lambdaAnalyzer/Not available.fs.gold
+++ b/ReSharper.FSharp/test/data/features/daemon/lambdaAnalyzer/Not available.fs.gold
@@ -1,5 +1,8 @@
 ﻿let f x y = ()
 
+fun () -> ()
+fun (()) -> ()
+
 fun x -> -x
 fun x -> ~~x
 

--- a/ReSharper.FSharp/test/data/features/daemon/lambdaAnalyzer/Not available.fs.gold
+++ b/ReSharper.FSharp/test/data/features/daemon/lambdaAnalyzer/Not available.fs.gold
@@ -2,6 +2,7 @@
 
 fun () -> ()
 fun (()) -> ()
+fun () -> id ()
 
 fun x -> -x
 fun x -> ~~x


### PR DESCRIPTION
Fix for https://youtrack.jetbrains.com/issue/RIDER-60632

P.S. 
This fix covers only the most common case when the only argument is IUnitPat.
