### PR TITLE
Type providers: move launcher from dotnet folder

### DIFF
--- a/ReSharper.FSharp/src/FSharp.Fantomas.Protocol/src/FantomasProcess.cs
+++ b/ReSharper.FSharp/src/FSharp.Fantomas.Protocol/src/FantomasProcess.cs
@@ -19,7 +19,7 @@ namespace JetBrains.ReSharper.Plugins.FSharp.Fantomas.Protocol
     protected override string Name => "Fantomas";
 
     private static readonly FileSystemPath FantomasDirectory =
-      typeof(FantomasProcess).Assembly.GetPath().Directory.Parent.Combine("fantomas");
+      typeof(FantomasProcess).Assembly.GetPath().Directory.Parent / "fantomas";
 
     protected override RdFantomasModel CreateModel(Lifetime lifetime, IProtocol protocol) =>
       new RdFantomasModel(lifetime, protocol);
@@ -32,7 +32,7 @@ namespace JetBrains.ReSharper.Plugins.FSharp.Fantomas.Protocol
 
     protected override ProcessStartInfo GetProcessStartInfo(Lifetime lifetime, int port)
     {
-      var launchPath = FantomasDirectory.Combine(FantomasProtocolConstants.PROCESS_FILENAME);
+      var launchPath = FantomasDirectory / FantomasProtocolConstants.PROCESS_FILENAME;
       Assertion.Assert(launchPath.ExistsFile, $"can't find '{launchPath}'");
 
       return new ProcessStartInfo

--- a/ReSharper.FSharp/src/FSharp.Fantomas.Protocol/src/FantomasProtocolConstants.cs
+++ b/ReSharper.FSharp/src/FSharp.Fantomas.Protocol/src/FantomasProtocolConstants.cs
@@ -7,6 +7,6 @@ namespace JetBrains.ReSharper.Plugins.FSharp.Fantomas.Protocol
   {
     public const string PROCESS_FILENAME = "JetBrains.ReSharper.Plugins.FSharp.Fantomas.Host.exe";
     public const string PARENT_PROCESS_PID_ENV_VARIABLE = "FSHARP_FANTOMAS_PROCESS_PID";
-    public static readonly FileSystemPath LogFolder = Logger.LogFolderPath.Combine("Fantomas");
+    public static readonly FileSystemPath LogFolder = Logger.LogFolderPath / "Fantomas";
   }
 }

--- a/ReSharper.FSharp/src/FSharp.TypeProviders.Host/FSharp.TypeProviders.Host.csproj
+++ b/ReSharper.FSharp/src/FSharp.TypeProviders.Host/FSharp.TypeProviders.Host.csproj
@@ -12,7 +12,7 @@
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-        <AssemblyName>JetBrains.ReSharper.Plugins.FSharp.TypeProviders.Host.Core</AssemblyName>
+        <AssemblyName>JetBrains.ReSharper.Plugins.FSharp.TypeProviders.Host.NetCore</AssemblyName>
     </PropertyGroup>
 
     <ItemGroup>

--- a/ReSharper.FSharp/src/FSharp.TypeProviders.Protocol/src/TypeProvidersExternalProcess.cs
+++ b/ReSharper.FSharp/src/FSharp.TypeProviders.Protocol/src/TypeProvidersExternalProcess.cs
@@ -25,7 +25,7 @@ namespace JetBrains.ReSharper.Plugins.FSharp.TypeProviders.Protocol
     protected override string Name => "Out-of-Process TypeProviders";
 
     private static readonly FileSystemPath TypeProvidersDirectory =
-      typeof(TypeProvidersExternalProcess).Assembly.GetPath().Directory.Parent.Combine("typeProviders");
+      typeof(TypeProvidersExternalProcess).Assembly.GetPath().Directory.Parent / "typeProviders";
 
     protected override RdFSharpTypeProvidersModel CreateModel(Lifetime lifetime, IProtocol protocol) =>
       new RdFSharpTypeProvidersModel(lifetime, protocol);
@@ -47,8 +47,8 @@ namespace JetBrains.ReSharper.Plugins.FSharp.TypeProviders.Protocol
     private ProcessStartInfo GetCoreProcessStartInfo(int port, FileSystemPath basePath)
     {
       var sdkMajorVersion = myNuGetVersion.Major.Clamp(3, 6);
-      var runtimeConfigPath = basePath.Combine(TypeProvidersProtocolConstants.CoreRuntimeConfigFilename(sdkMajorVersion));
-      var fileSystemPath = basePath.Combine(TypeProvidersProtocolConstants.TypeProvidersHostCoreFilename);
+      var runtimeConfigPath = basePath / TypeProvidersProtocolConstants.CoreRuntimeConfigFilename(sdkMajorVersion);
+      var fileSystemPath = basePath / TypeProvidersProtocolConstants.TypeProvidersHostCoreFilename;
       var dotnetArgs = $"--runtimeconfig \"{runtimeConfigPath}\"";
 
       Assertion.Assert(fileSystemPath.ExistsFile, $"can't find '{fileSystemPath.FullPath}'");
@@ -66,7 +66,7 @@ namespace JetBrains.ReSharper.Plugins.FSharp.TypeProviders.Protocol
 
     private static ProcessStartInfo GetFrameworkProcessStartInfo(int port, FileSystemPath basePath)
     {
-      var fileSystemPath = basePath.Combine(TypeProvidersProtocolConstants.TypeProvidersHostFrameworkFilename);
+      var fileSystemPath = basePath / TypeProvidersProtocolConstants.TypeProvidersHostFrameworkFilename;
       Assertion.Assert(fileSystemPath.ExistsFile, $"can't find '{fileSystemPath.FullPath}'");
 
       var processStartInfo = new ProcessStartInfo

--- a/ReSharper.FSharp/src/FSharp.TypeProviders.Protocol/src/TypeProvidersExternalProcess.cs
+++ b/ReSharper.FSharp/src/FSharp.TypeProviders.Protocol/src/TypeProvidersExternalProcess.cs
@@ -39,12 +39,10 @@ namespace JetBrains.ReSharper.Plugins.FSharp.TypeProviders.Protocol
         processUnexpectedExited);
     }
 
-    protected override ProcessStartInfo GetProcessStartInfo(Lifetime lifetime, int port)
-    {
-      return myRequest.RuntimeType == JetProcessRuntimeType.DotNetCore
+    protected override ProcessStartInfo GetProcessStartInfo(Lifetime lifetime, int port) =>
+      myRequest.RuntimeType == JetProcessRuntimeType.DotNetCore
         ? GetCoreProcessStartInfo(port, TypeProvidersDirectory)
         : GetFrameworkProcessStartInfo(port, TypeProvidersDirectory);
-    }
 
     private ProcessStartInfo GetCoreProcessStartInfo(int port, FileSystemPath basePath)
     {

--- a/ReSharper.FSharp/src/FSharp.TypeProviders.Protocol/src/TypeProvidersExternalProcess.cs
+++ b/ReSharper.FSharp/src/FSharp.TypeProviders.Protocol/src/TypeProvidersExternalProcess.cs
@@ -21,7 +21,11 @@ namespace JetBrains.ReSharper.Plugins.FSharp.TypeProviders.Protocol
     private readonly JetProcessRuntimeRequest myRequest;
     private readonly NuGetVersion myNuGetVersion;
     private Lifetime myLifetime;
+
     protected override string Name => "Out-of-Process TypeProviders";
+
+    private static readonly FileSystemPath TypeProvidersDirectory =
+      typeof(TypeProvidersExternalProcess).Assembly.GetPath().Directory.Parent.Combine("typeProviders");
 
     protected override RdFSharpTypeProvidersModel CreateModel(Lifetime lifetime, IProtocol protocol) =>
       new RdFSharpTypeProvidersModel(lifetime, protocol);
@@ -37,11 +41,9 @@ namespace JetBrains.ReSharper.Plugins.FSharp.TypeProviders.Protocol
 
     protected override ProcessStartInfo GetProcessStartInfo(Lifetime lifetime, int port)
     {
-      var basePath = GetType().Assembly.GetPath().Directory;
-
       return myRequest.RuntimeType == JetProcessRuntimeType.DotNetCore
-        ? GetCoreProcessStartInfo(port, basePath)
-        : GetFrameworkProcessStartInfo(port, basePath);
+        ? GetCoreProcessStartInfo(port, TypeProvidersDirectory)
+        : GetFrameworkProcessStartInfo(port, TypeProvidersDirectory);
     }
 
     private ProcessStartInfo GetCoreProcessStartInfo(int port, FileSystemPath basePath)

--- a/ReSharper.FSharp/src/FSharp.TypeProviders.Protocol/src/TypeProvidersProtocolConstants.cs
+++ b/ReSharper.FSharp/src/FSharp.TypeProviders.Protocol/src/TypeProvidersProtocolConstants.cs
@@ -12,7 +12,7 @@ namespace JetBrains.ReSharper.Plugins.FSharp.TypeProviders.Protocol
       "JetBrains.ReSharper.Plugins.FSharp.TypeProviders.Host.exe";
 
     public static string TypeProvidersHostCoreFilename =>
-      "JetBrains.ReSharper.Plugins.FSharp.TypeProviders.Host.Core.dll";
+      "JetBrains.ReSharper.Plugins.FSharp.TypeProviders.Host.NetCore.dll";
 
     public static string CoreRuntimeConfigFilename(int majorVersion) =>
       "tploader." +

--- a/ReSharper.FSharp/src/FSharp.TypeProviders.Protocol/src/TypeProvidersProtocolConstants.cs
+++ b/ReSharper.FSharp/src/FSharp.TypeProviders.Protocol/src/TypeProvidersProtocolConstants.cs
@@ -24,6 +24,6 @@ namespace JetBrains.ReSharper.Plugins.FSharp.TypeProviders.Protocol
       } +
       $".{(PlatformUtil.IsRunningUnderWindows ? "win" : "unix")}.runtimeconfig.json";
 
-    public static readonly FileSystemPath LogFolder = Logger.LogFolderPath.Combine("TypeProvidersHost");
+    public static readonly FileSystemPath LogFolder = Logger.LogFolderPath / "TypeProvidersHost";
   }
 }

--- a/rider-fsharp/build.gradle.kts
+++ b/rider-fsharp/build.gradle.kts
@@ -246,31 +246,28 @@ tasks {
             files = files + listOf("$testHostName.dll", "$testHostName.pdb")
         }
 
-        files.forEach {
-            from(it) { into("${intellij.pluginName}/dotnet") }
+        fun moveToPlugin(files: List<String>, destFolder: String) {
+            files.forEach {
+                from(it) { into("${intellij.pluginName}/$destFolder") }
+            }
         }
 
-        fantomasFiles.forEach {
-            from(it) { into("${intellij.pluginName}/fantomas") }
-        }
-
-        typeProvidersFiles.forEach {
-            from(it) { into("${intellij.pluginName}/typeProviders") }
-        }
-
-        into("${intellij.pluginName}/projectTemplates") {
-            from("projectTemplates")
-        }
+        moveToPlugin(files, "dotnet")
+        moveToPlugin(fantomasFiles, "fantomas")
+        moveToPlugin(typeProvidersFiles, "typeProviders")
+        moveToPlugin(listOf("projectTemplates"), "projectTemplates")
 
         doLast {
-            fun validateFile(path: String, destFolder: String) {
-                val file = file(path)
-                if (!file.exists()) throw RuntimeException("File $file does not exist")
-                logger.warn("$name: ${file.name} -> $destinationDir/${intellij.pluginName}/$destFolder")
+            fun validateFiles(files: List<String>, destFolder: String) {
+                files.forEach {
+                    val file = file(it)
+                    if (!file.exists()) throw RuntimeException("File $file does not exist")
+                    logger.warn("$name: ${file.name} -> $destinationDir/${intellij.pluginName}/$destFolder")
+                }
             }
-            files.forEach { validateFile(it, "dotnet") }
-            fantomasFiles.forEach { validateFile(it, "fantomas") }
-            typeProvidersFiles.forEach { validateFile(it, "typeProviders") }
+            validateFiles(files, "dotnet")
+            validateFiles(fantomasFiles, "fantomas")
+            validateFiles(typeProvidersFiles, "typeProviders")
         }
     }
 

--- a/rider-fsharp/build.gradle.kts
+++ b/rider-fsharp/build.gradle.kts
@@ -117,16 +117,15 @@ val pluginFiles = listOf(
         "FSharp.Common/$outputRelativePath/JetBrains.ReSharper.Plugins.FSharp.Common",
         "FSharp.Psi/$outputRelativePath/JetBrains.ReSharper.Plugins.FSharp.Psi",
         "FSharp.Psi.Features/$outputRelativePath/JetBrains.ReSharper.Plugins.FSharp.Psi.Features",
-        "FSharp.Fantomas.Protocol/$outputRelativePath/JetBrains.ReSharper.Plugins.FSharp.Fantomas.Protocol")
+        "FSharp.Fantomas.Protocol/$outputRelativePath/JetBrains.ReSharper.Plugins.FSharp.Fantomas.Protocol",
+        "FSharp.TypeProviders.Protocol/$outputRelativePath/JetBrains.ReSharper.Plugins.FSharp.TypeProviders.Protocol")
 
 val typeProvidersFiles = listOf(
-        "FSharp.TypeProviders.Protocol/$outputRelativePath/JetBrains.ReSharper.Plugins.FSharp.TypeProviders.Protocol.dll",
-        "FSharp.TypeProviders.Protocol/$outputRelativePath/JetBrains.ReSharper.Plugins.FSharp.TypeProviders.Protocol.pdb",
         "FSharp.TypeProviders.Host/$outputRelativePath/JetBrains.ReSharper.Plugins.FSharp.TypeProviders.Host.exe",
         "FSharp.TypeProviders.Host/$outputRelativePath/JetBrains.ReSharper.Plugins.FSharp.TypeProviders.Host.pdb",
         "FSharp.TypeProviders.Host/$outputRelativePath/JetBrains.ReSharper.Plugins.FSharp.TypeProviders.Host.exe.config",
-        "FSharp.TypeProviders.Host/bin/$buildConfiguration/netcoreapp3.1/JetBrains.ReSharper.Plugins.FSharp.TypeProviders.Host.Core.dll",
-        "FSharp.TypeProviders.Host/bin/$buildConfiguration/netcoreapp3.1/JetBrains.ReSharper.Plugins.FSharp.TypeProviders.Host.Core.pdb",
+        "FSharp.TypeProviders.Host/bin/$buildConfiguration/netcoreapp3.1/JetBrains.ReSharper.Plugins.FSharp.TypeProviders.Host.NetCore.dll",
+        "FSharp.TypeProviders.Host/bin/$buildConfiguration/netcoreapp3.1/JetBrains.ReSharper.Plugins.FSharp.TypeProviders.Host.NetCore.pdb",
         "FSharp.TypeProviders.Host/bin/$buildConfiguration/netcoreapp3.1/tploader.netcoreapp31.win.runtimeconfig.json",
         "FSharp.TypeProviders.Host/bin/$buildConfiguration/netcoreapp3.1/tploader.netcoreapp31.unix.runtimeconfig.json",
         "FSharp.TypeProviders.Host/bin/$buildConfiguration/netcoreapp3.1/tploader.net5.win.runtimeconfig.json",
@@ -236,9 +235,10 @@ configure<RdGenExtension> {
 
 tasks {
     withType<PrepareSandboxTask> {
-        var files = libFiles + pluginFiles.map { "$it.dll" } + pluginFiles.map { "$it.pdb" } + typeProvidersFiles
+        var files = libFiles + pluginFiles.map { "$it.dll" } + pluginFiles.map { "$it.pdb" }
         files = files.map { "$resharperPluginPath/src/$it" }
         val fantomasFiles = fantomasFiles.map { "$resharperPluginPath/src/$it" }
+        val typeProvidersFiles = typeProvidersFiles.map { "$resharperPluginPath/src/$it" }
 
         if (name == IntelliJPlugin.PREPARE_TESTING_SANDBOX_TASK_NAME) {
             val testHostPath = "$resharperPluginPath/test/src/FSharp.Tests.Host/$outputRelativePath"
@@ -254,6 +254,10 @@ tasks {
             from(it) { into("${intellij.pluginName}/fantomas") }
         }
 
+        typeProvidersFiles.forEach {
+            from(it) { into("${intellij.pluginName}/typeProviders") }
+        }
+
         into("${intellij.pluginName}/projectTemplates") {
             from("projectTemplates")
         }
@@ -266,6 +270,7 @@ tasks {
             }
             files.forEach { validateFile(it, "dotnet") }
             fantomasFiles.forEach { validateFile(it, "fantomas") }
+            typeProvidersFiles.forEach { validateFile(it, "typeProviders") }
         }
     }
 


### PR DESCRIPTION
Type providers launchers should not be loaded into the Rider.Backend process, so we need to move them from "dotnet" to a separate folder