### PR TITLE
Type Providers: fix races in TypeProvidersManager & ExtensionTypingProviderShim

### DIFF
--- a/ReSharper.FSharp/src/FSharp.Common/src/Shim/TypeProviders/ExtensionTypingProviderShim.fs
+++ b/ReSharper.FSharp/src/FSharp.Common/src/Shim/TypeProviders/ExtensionTypingProviderShim.fs
@@ -42,12 +42,12 @@ type ExtensionTypingProviderShim(solution: ISolution, toolset: ISolutionToolset,
         if isConnectionAlive () then () else
 
         lock createProcessLockObj (fun () ->
+            if isConnectionAlive () then () else
 
-        if isConnectionAlive () then () else
-
-        typeProvidersHostLifetime <- Lifetime.Define(lifetime)
-        connection <- typeProvidersLoadersFactory.Create(typeProvidersHostLifetime.Lifetime).Run()
-        typeProvidersManager <- TypeProvidersManager(connection) :?> _)
+            typeProvidersHostLifetime <- Lifetime.Define(lifetime)
+            let newConnection = typeProvidersLoadersFactory.Create(typeProvidersHostLifetime.Lifetime).Run()
+            typeProvidersManager <- TypeProvidersManager(newConnection) :?> _
+            connection <- newConnection)
 
     do
         lifetime.Bracket((fun () -> ExtensionTypingProvider <- this),

--- a/rider-fsharp/src/test/kotlin/Extensions.kt
+++ b/rider-fsharp/src/test/kotlin/Extensions.kt
@@ -1,9 +1,11 @@
+import com.intellij.execution.process.impl.ProcessListUtil
 import com.intellij.openapi.project.Project
 import com.jetbrains.rdclient.protocol.protocolHost
 import com.jetbrains.rider.inTests.TestHost
 import com.jetbrains.rider.plugins.fsharp.rdFSharpModel
 import com.jetbrains.rider.projectView.solution
 import com.jetbrains.rider.test.base.BaseTestWithSolution
+import com.jetbrains.rider.test.framework.frameworkLogger
 import com.jetbrains.rider.test.scriptingApi.dumpSevereHighlighters
 import java.io.PrintStream
 
@@ -25,7 +27,16 @@ fun withSetting(project: Project, setting: String, function: () -> Unit) {
 }
 
 fun BaseTestWithSolution.withTypeProviders(function: () -> Unit) {
-    withSetting(project, "FSharp/FSharpOptions/FSharpExperimentalFeatures/OutOfProcessTypeProviders/@EntryValue", function)
+    withSetting(project, "FSharp/FSharpOptions/FSharpExperimentalFeatures/OutOfProcessTypeProviders/@EntryValue") {
+        try {
+            function()
+        } finally {
+            val tpProcessCount = ProcessListUtil
+                    .getProcessList()
+                    .count { it.executableName.startsWith("JetBrains.ReSharper.Plugins.FSharp.TypeProviders.Host") }
+            if (tpProcessCount != 1) frameworkLogger.warn("Expected single type providers process, but was $tpProcessCount")
+        }
+    }
 }
 
 fun withEditorConfig(project: Project, function: () -> Unit) {

--- a/rider-fsharp/src/test/kotlin/typeProviders/TypeProvidersCacheTest.kt
+++ b/rider-fsharp/src/test/kotlin/typeProviders/TypeProvidersCacheTest.kt
@@ -77,10 +77,7 @@ class TypeProvidersCacheTest : BaseTestWithSolution() {
             withOpenedEditor(project, sourceFile) {
                 waitForDaemon()
                 typeWithLatency("//")
-                waitForDaemon()
-                executeWithGold(testGoldFile) {
-                    dumpTypeProviders(it)
-                }
+                checkTypeProviders()
             }
         }
     }


### PR DESCRIPTION
Fixed cases:

1. Concurrent unsynchronized creation of the TypeProvidersConnection, leading to data loss
2. Concurrent creation  of type providers would cause the requested type provider to be missing from the  in-process TypeProvidersCache