### PR TITLE
FunctionAnnotation: fix returnTypeInfo and check IUnitPat as annotated

### DIFF
--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/availability/Let bindings - Module 01.fs
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/availability/Let bindings - Module 01.fs
@@ -10,3 +10,5 @@ let{off} ((x4{off}: int)): int = 1
 
 {off}[<CompiledName{off}("Foo")>]{off}
 let{on} foo{on} {off}x {off}= {off}()
+
+let{off} f{off} {off}(): unit = ()


### PR DESCRIPTION
Fix for https://youtrack.jetbrains.com/issue/RIDER-67228