### PR TITLE
Typing assist: implement typing assist on delete/backspace inside records

### DIFF
--- a/ReSharper.FSharp/src/FSharp.Psi.Features/src/FSharpTypingAssist.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Features/src/FSharpTypingAssist.fs
@@ -1315,20 +1315,13 @@ type FSharpTypingAssist(lifetime, solution, settingsStore, cachingLexerService, 
 
     member x.TryDeleteRecordFieldWhitespaces(textControl: ITextControl, prev: ITreeNode, next: ITreeNode) =
         let newlineExists =
-            this.GetSiblingsBetween(prev, next)
+            TreeNodeExtensions.NextTokens prev
+            |> Seq.takeWhile ((!=) next)
             |> Seq.exists (getTokenType >> (==) FSharpTokenType.NEW_LINE)
         if not newlineExists then false else
         let replaceRange = TextRange(prev.GetTreeEndOffset().Offset, next.GetTreeStartOffset().Offset)
         textControl.Document.ReplaceText(replaceRange, "; ")
         true
-
-    member x.GetSiblingsBetween(first: ITreeNode, second: ITreeNode) =
-        seq {
-            let mutable current = first
-            while current != second do
-                yield current
-                current <- current.NextSibling
-        }
 
     member x.HandleSurroundTyping(typingContext, lChar, rChar, lTokenType, rTokenType, shouldNotSurround) =
         base.HandleSurroundTyping(typingContext, lChar, rChar, lTokenType, rTokenType, shouldNotSurround)

--- a/ReSharper.FSharp/src/FSharp.Psi.Features/src/FSharpTypingAssist.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Features/src/FSharpTypingAssist.fs
@@ -543,6 +543,7 @@ type FSharpTypingAssist(lifetime, solution, settingsStore, cachingLexerService, 
 
         manager.AddActionHandler(lifetime, TextControlActions.ActionIds.Enter, this, Func<_,_>(handleEnter), isActionHandlerAvailable)
         manager.AddActionHandler(lifetime, TextControlActions.ActionIds.Backspace, this, Func<_,_>(this.HandleBackspacePressed), isActionHandlerAvailable)
+        manager.AddActionHandler(lifetime, TextControlActions.ActionIds.Delete, this, Func<_,_>(this.HandleDeletePressed), isActionHandlerAvailable)
         manager.AddActionHandler(lifetime, TextControlActions.ActionIds.Tab, this, Func<_,_>(this.HandleTabPressed), isActionHandlerAvailable)
         manager.AddActionHandler(lifetime, TextControlActions.ActionIds.TabLeft, this, Func<_,_>(this.HandleTabLeftPressed), isActionHandlerAvailable)
         manager.AddTypingHandler(lifetime, ' ', this, Func<_,_>(handleSpace), isTypingHandlerAvailable)
@@ -1147,6 +1148,7 @@ type FSharpTypingAssist(lifetime, solution, settingsStore, cachingLexerService, 
 
         if this.HandleBackspaceInInterpolatedString(context) then true else
         if this.HandleBackspaceInTripleQuotedString(textControl) then true else
+        if this.HandleBackspaceInRecords(textControl) then true else
 
         this.DoHandleBackspacePressed
             (textControl,
@@ -1205,6 +1207,128 @@ type FSharpTypingAssist(lifetime, solution, settingsStore, cachingLexerService, 
             true
 
         else false
+
+    member x.HandleBackspaceInRecords(textControl: ITextControl) =
+        let offset = textControl.Caret.Offset()
+        let mutable lexer = Unchecked.defaultof<_>
+
+        if not (x.GetCachingLexer(textControl, &lexer)) then false else
+        if not (lexer.FindTokenAt(offset)) then false else
+        if not FSharpTokenType.Identifiers.[lexer.TokenType] && lexer.TokenType != FSharpTokenType.LBRACK_LESS then false else
+
+        match x.CommitPsiOnlyAndProceedWithDirtyCaches(textControl, id).AsFSharpFile() with
+        | null -> false
+        | fsFile ->
+
+        let document = textControl.Document
+        let documentOffset = DocumentOffset(document, offset)
+        let token = fsFile.FindTokenAt(documentOffset)
+
+        let processRecordDeclarations (declarations: IRecordFieldDeclarationList) =
+            declarations.FieldDeclarationsEnumerable
+            |> Seq.pairwise
+            |> Seq.tryFind (fun (_, second) -> second.GetTreeStartOffset().Offset = offset)
+            |> Option.map (fun (prev, next) ->
+                this.DeleteRecordAttributesWhitespaces(textControl, next)
+                this.TryDeleteRecordFieldWhitespaces(textControl, prev, next))
+            |> Option.defaultValue false
+
+        let processRecordBinding (bindings: IRecordFieldBindingList) =
+            bindings.FieldBindingsEnumerable
+            |> Seq.pairwise
+            |> Seq.tryFind (fun (_, second) -> second.GetTreeStartOffset().Offset = offset)
+            |> Option.map (fun (prev, next) ->
+                this.TryDeleteRecordFieldWhitespaces(textControl, prev, next))
+            |> Option.defaultValue false
+
+        let declarations = token.GetContainingNode<IRecordFieldDeclarationList>()
+        if isNotNull declarations && processRecordDeclarations declarations then true else
+
+        let bindings = token.GetContainingNode<IRecordFieldBindingList>()
+        if isNotNull bindings && processRecordBinding bindings then true else
+
+        false
+
+    member x.HandleDeletePressed(context: IActionContext) =
+        let textControl = context.TextControl
+        if textControl.Selection.OneDocRangeWithCaret().Length > 0 then false else
+
+        if this.HandleDeleteInRecords(textControl) then true else
+
+        false
+
+    member x.HandleDeleteInRecords(textControl: ITextControl) =
+        let offset = textControl.Caret.Offset()
+        let mutable lexer = Unchecked.defaultof<_>
+
+        if not (x.GetCachingLexer(textControl, &lexer)) then false else
+        if not (lexer.FindTokenAt(offset)) then false else
+        if lexer.TokenType != FSharpTokenType.NEW_LINE then false else
+
+        match x.CommitPsiOnlyAndProceedWithDirtyCaches(textControl, id).AsFSharpFile() with
+        | null -> false
+        | fsFile ->
+
+        let document = textControl.Document
+        let documentOffset = DocumentOffset(document, offset)
+        let token = fsFile.FindTokenAt(documentOffset)
+
+        let processRecordDeclarations (declarations: IRecordFieldDeclarationList) =
+            declarations.FieldDeclarationsEnumerable
+            |> Seq.pairwise
+            |> Seq.tryFind (fun (first, second) ->
+                offset >= first.GetTreeEndOffset().Offset && offset < second.GetTreeStartOffset().Offset)
+            |> Option.map (fun (prev, next) ->
+                this.DeleteRecordAttributesWhitespaces(textControl, next)
+                this.TryDeleteRecordFieldWhitespaces(textControl, prev, next))
+            |> Option.defaultValue false
+
+        let processRecordBinding (bindings: IRecordFieldBindingList) =
+            bindings.FieldBindingsEnumerable
+            |> Seq.pairwise
+            |> Seq.tryFind (fun (first, second) ->
+                offset >= first.GetTreeEndOffset().Offset && offset < second.GetTreeStartOffset().Offset)
+            |> Option.map (fun (prev, next) ->
+                this.TryDeleteRecordFieldWhitespaces(textControl, prev, next))
+            |> Option.defaultValue false
+
+        let declarations = token.GetContainingNode<IRecordFieldDeclarationList>()
+        if isNotNull declarations && processRecordDeclarations declarations then true else
+
+        let bindings = token.GetContainingNode<IRecordFieldBindingList>()
+        if isNotNull bindings && processRecordBinding bindings then true else
+
+        false
+
+    member x.DeleteRecordAttributesWhitespaces(textControl: ITextControl, declaration: IRecordFieldDeclaration) =
+        let mutable removalOffset = 0
+        declaration.AttributeListsEnumerable
+        |> Seq.map (fun current -> (current, TreeNodeExtensions.GetNextNonWhitespaceToken current))
+        |> Seq.filter (snd >> isNotNull)
+        |> Seq.iter (fun (current, next) ->
+            let firstOffset = current.GetTreeEndOffset().Offset
+            let lastOffset = next.GetTreeStartOffset().Offset
+            let replaceRange = TextRange(removalOffset + firstOffset, removalOffset + lastOffset)
+            let replacement = " "
+            textControl.Document.ReplaceText(replaceRange, replacement)
+            removalOffset <- removalOffset - (replaceRange.Length - replacement.Length))
+
+    member x.TryDeleteRecordFieldWhitespaces(textControl: ITextControl, prev: ITreeNode, next: ITreeNode) =
+        let newlineExists =
+            this.GetSiblingsBetween(prev, next)
+            |> Seq.exists (getTokenType >> (==) FSharpTokenType.NEW_LINE)
+        if not newlineExists then false else
+        let replaceRange = TextRange(prev.GetTreeEndOffset().Offset, next.GetTreeStartOffset().Offset)
+        textControl.Document.ReplaceText(replaceRange, "; ")
+        true
+
+    member x.GetSiblingsBetween(first: ITreeNode, second: ITreeNode) =
+        seq {
+            let mutable current = first
+            while current != second do
+                yield current
+                current <- current.NextSibling
+        }
 
     member x.HandleSurroundTyping(typingContext, lChar, rChar, lTokenType, rTokenType, shouldNotSurround) =
         base.HandleSurroundTyping(typingContext, lChar, rChar, lTokenType, rTokenType, shouldNotSurround)

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Backspace - Record - Anonymous 01.fs
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Backspace - Record - Anonymous 01.fs
@@ -1,0 +1,7 @@
+﻿// ${CHAR:Backspace}
+module Module
+
+let someRecord =
+   {| field1 = "Quick"
+      field2 = "Brown"
+      {caret}field3 = "Fox" |}

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Backspace - Record - Anonymous 01.fs.gold
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Backspace - Record - Anonymous 01.fs.gold
@@ -1,0 +1,6 @@
+﻿// ${CHAR:Backspace}
+module Module
+
+let someRecord =
+   {| field1 = "Quick"
+      field2 = "Brown"; {caret}field3 = "Fox" |}

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Backspace - Record - Definition 01.fs
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Backspace - Record - Definition 01.fs
@@ -1,0 +1,7 @@
+﻿// ${CHAR:Backspace}
+module Module
+
+type SomeRecord =
+   { field1: string
+     field2: string
+     {caret}field3: string }

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Backspace - Record - Definition 01.fs.gold
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Backspace - Record - Definition 01.fs.gold
@@ -1,0 +1,6 @@
+﻿// ${CHAR:Backspace}
+module Module
+
+type SomeRecord =
+   { field1: string
+     field2: string; {caret}field3: string }

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Backspace - Record - Definition 02.fs
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Backspace - Record - Definition 02.fs
@@ -1,0 +1,9 @@
+﻿// ${CHAR:Backspace}
+module Module
+
+type SomeRecord =
+   { field1: string
+     field2: string
+     {caret}[<SomeAttribute1>]
+     [<SomeAttribute2>]
+     field3: string }

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Backspace - Record - Definition 02.fs.gold
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Backspace - Record - Definition 02.fs.gold
@@ -1,0 +1,6 @@
+﻿// ${CHAR:Backspace}
+module Module
+
+type SomeRecord =
+   { field1: string
+     field2: string; {caret}[<SomeAttribute1>] [<SomeAttribute2>] field3: string }

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Backspace - Record - Definition 03 - Comment.fs
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Backspace - Record - Definition 03 - Comment.fs
@@ -1,0 +1,8 @@
+﻿// ${CHAR:Backspace}
+module Module
+
+type SomeRecord =
+   { field1: string
+     field2: string
+     // Some cool comment
+     {caret}field3: string }

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Backspace - Record - Definition 03 - Comment.fs.gold
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Backspace - Record - Definition 03 - Comment.fs.gold
@@ -1,0 +1,8 @@
+﻿// ${CHAR:Backspace}
+module Module
+
+type SomeRecord =
+   { field1: string
+     field2: string
+     // Some cool comment
+    {caret}field3: string }

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Backspace - Record - Definition 04 - Empty line 01.fs
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Backspace - Record - Definition 04 - Empty line 01.fs
@@ -1,0 +1,8 @@
+﻿// ${CHAR:Backspace}
+module Module
+
+type SomeRecord =
+   { field1: string
+     field2: string
+
+     {caret}field3: string }

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Backspace - Record - Definition 04 - Empty line 01.fs.gold
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Backspace - Record - Definition 04 - Empty line 01.fs.gold
@@ -1,0 +1,7 @@
+﻿// ${CHAR:Backspace}
+module Module
+
+type SomeRecord =
+   { field1: string
+     field2: string
+     {caret}field3: string }

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Backspace - Record - Definition 05 - Empty line 02.fs
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Backspace - Record - Definition 05 - Empty line 02.fs
@@ -1,0 +1,10 @@
+﻿// ${CHAR:Backspace}
+module Module
+
+type SomeRecord =
+   { field1: string
+     field2: string
+
+     {caret}[<SomeAttribute1>]
+     [<SomeAttribute2>]
+     field3: string }

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Backspace - Record - Definition 05 - Empty line 02.fs.gold
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Backspace - Record - Definition 05 - Empty line 02.fs.gold
@@ -1,0 +1,9 @@
+﻿// ${CHAR:Backspace}
+module Module
+
+type SomeRecord =
+   { field1: string
+     field2: string
+     {caret}[<SomeAttribute1>]
+     [<SomeAttribute2>]
+     field3: string }

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Backspace - Record - Instance 01.fs
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Backspace - Record - Instance 01.fs
@@ -1,0 +1,7 @@
+﻿// ${CHAR:Backspace}
+module Module
+
+let someRecord =
+   { field1 = "Quick"
+     field2 = "Brown"
+     {caret}field3 = "Fox" }

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Backspace - Record - Instance 01.fs.gold
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Backspace - Record - Instance 01.fs.gold
@@ -1,0 +1,6 @@
+﻿// ${CHAR:Backspace}
+module Module
+
+let someRecord =
+   { field1 = "Quick"
+     field2 = "Brown"; {caret}field3 = "Fox" }

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Backspace - Record - Instance 02 - Comment.fs
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Backspace - Record - Instance 02 - Comment.fs
@@ -1,0 +1,8 @@
+﻿// ${CHAR:Backspace}
+module Module
+
+let someRecord =
+   { field1 = "Quick"
+     field2 = "Brown"
+     // Some cool comment
+     {caret}field3 = "Fox" }

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Backspace - Record - Instance 02 - Comment.fs.gold
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Backspace - Record - Instance 02 - Comment.fs.gold
@@ -1,0 +1,8 @@
+﻿// ${CHAR:Backspace}
+module Module
+
+let someRecord =
+   { field1 = "Quick"
+     field2 = "Brown"
+     // Some cool comment
+    {caret}field3 = "Fox" }

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Backspace - Record - Instance 03 - Empty line.fs
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Backspace - Record - Instance 03 - Empty line.fs
@@ -1,0 +1,8 @@
+﻿// ${CHAR:Backspace}
+module Module
+
+let someRecord =
+   { field1 = "Quick"
+     field2 = "Brown"
+
+     {caret}field3 = "Fox" }

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Backspace - Record - Instance 03 - Empty line.fs.gold
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Backspace - Record - Instance 03 - Empty line.fs.gold
@@ -1,0 +1,7 @@
+﻿// ${CHAR:Backspace}
+module Module
+
+let someRecord =
+   { field1 = "Quick"
+     field2 = "Brown"
+     {caret}field3 = "Fox" }

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Delete - Record - Anonymous 01.fs
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Delete - Record - Anonymous 01.fs
@@ -1,0 +1,7 @@
+﻿// ${CHAR:Delete}
+module Module
+
+let someRecord =
+   {| field1 = "Quick"
+      field2 = "Brown"  {caret}
+      field3 = "Fox" |}

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Delete - Record - Anonymous 01.fs.gold
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Delete - Record - Anonymous 01.fs.gold
@@ -1,0 +1,6 @@
+﻿// ${CHAR:Delete}
+module Module
+
+let someRecord =
+   {| field1 = "Quick"
+      field2 = "Brown"; {caret}field3 = "Fox" |}

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Delete - Record - Definition 01.fs
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Delete - Record - Definition 01.fs
@@ -1,0 +1,7 @@
+﻿// ${CHAR:Delete}
+module Module
+
+type SomeRecord =
+   { field1: string
+     field2: string{caret}
+     field3: string }

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Delete - Record - Definition 01.fs.gold
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Delete - Record - Definition 01.fs.gold
@@ -1,0 +1,6 @@
+﻿// ${CHAR:Delete}
+module Module
+
+type SomeRecord =
+   { field1: string
+     field2: string; {caret}field3: string }

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Delete - Record - Definition 02.fs
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Delete - Record - Definition 02.fs
@@ -1,0 +1,9 @@
+﻿// ${CHAR:Delete}
+module Module
+
+type SomeRecord =
+   { field1: string
+     field2: string {caret}
+     [<SomeAttribute1>]
+     [<SomeAttribute2>]
+     field3: string }

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Delete - Record - Definition 02.fs.gold
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Delete - Record - Definition 02.fs.gold
@@ -1,0 +1,6 @@
+﻿// ${CHAR:Delete}
+module Module
+
+type SomeRecord =
+   { field1: string
+     field2: string; {caret}[<SomeAttribute1>] [<SomeAttribute2>] field3: string }

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Delete - Record - Definition 03 - Comment.fs
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Delete - Record - Definition 03 - Comment.fs
@@ -1,0 +1,8 @@
+﻿// ${CHAR:Delete}
+module Module
+
+type SomeRecord =
+   { field1: string
+     field2: string{caret}
+     // Some cool comment
+     field3: string }

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Delete - Record - Definition 03 - Comment.fs.gold
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Delete - Record - Definition 03 - Comment.fs.gold
@@ -1,0 +1,7 @@
+﻿// ${CHAR:Delete}
+module Module
+
+type SomeRecord =
+   { field1: string
+     field2: string{caret}     // Some cool comment
+     field3: string }

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Delete - Record - Definition 04 - Empty line 01.fs
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Delete - Record - Definition 04 - Empty line 01.fs
@@ -1,0 +1,8 @@
+﻿// ${CHAR:Delete}
+module Module
+
+type SomeRecord =
+   { field1: string
+     field2: string{caret}
+
+     field3: string }

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Delete - Record - Definition 04 - Empty line 01.fs.gold
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Delete - Record - Definition 04 - Empty line 01.fs.gold
@@ -1,0 +1,7 @@
+﻿// ${CHAR:Delete}
+module Module
+
+type SomeRecord =
+   { field1: string
+     field2: string{caret}
+     field3: string }

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Delete - Record - Definition 05 - Empty line 02.fs
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Delete - Record - Definition 05 - Empty line 02.fs
@@ -1,0 +1,10 @@
+﻿// ${CHAR:Delete}
+module Module
+
+type SomeRecord =
+   { field1: string
+     field2: string{caret}
+
+     [<SomeAttribute1>]
+     [<SomeAttribute2>]
+     field3: string }

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Delete - Record - Definition 05 - Empty line 02.fs.gold
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Delete - Record - Definition 05 - Empty line 02.fs.gold
@@ -1,0 +1,9 @@
+﻿// ${CHAR:Delete}
+module Module
+
+type SomeRecord =
+   { field1: string
+     field2: string{caret}
+     [<SomeAttribute1>]
+     [<SomeAttribute2>]
+     field3: string }

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Delete - Record - Instance 01.fs
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Delete - Record - Instance 01.fs
@@ -1,0 +1,7 @@
+﻿// ${CHAR:Delete}
+module Module
+
+let someRecord =
+   { field1 = "Quick"
+     field2 = "Brown"    {caret}
+     field3 = "Fox" }

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Delete - Record - Instance 01.fs.gold
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Delete - Record - Instance 01.fs.gold
@@ -1,0 +1,6 @@
+﻿// ${CHAR:Delete}
+module Module
+
+let someRecord =
+   { field1 = "Quick"
+     field2 = "Brown"; {caret}field3 = "Fox" }

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Delete - Record - Instance 02 - Comment.fs
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Delete - Record - Instance 02 - Comment.fs
@@ -1,0 +1,8 @@
+﻿// ${CHAR:Delete}
+module Module
+
+let someRecord =
+   { field1 = "Quick"
+     field2 = "Brown"{caret}
+     // Some cool comment
+     field3 = "Fox" }

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Delete - Record - Instance 02 - Comment.fs.gold
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Delete - Record - Instance 02 - Comment.fs.gold
@@ -1,0 +1,7 @@
+﻿// ${CHAR:Delete}
+module Module
+
+let someRecord =
+   { field1 = "Quick"
+     field2 = "Brown"{caret}     // Some cool comment
+     field3 = "Fox" }

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Delete - Record - Instance 03 - Empty line.fs
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Delete - Record - Instance 03 - Empty line.fs
@@ -1,0 +1,8 @@
+﻿// ${CHAR:Delete}
+module Module
+
+let someRecord =
+   { field1 = "Quick"
+     field2 = "Brown"{caret}
+
+     field3 = "Fox" }

--- a/ReSharper.FSharp/test/data/features/service/typingAssist/Delete - Record - Instance 03 - Empty line.fs.gold
+++ b/ReSharper.FSharp/test/data/features/service/typingAssist/Delete - Record - Instance 03 - Empty line.fs.gold
@@ -1,0 +1,7 @@
+﻿// ${CHAR:Delete}
+module Module
+
+let someRecord =
+   { field1 = "Quick"
+     field2 = "Brown"{caret}
+     field3 = "Fox" }

--- a/ReSharper.FSharp/test/src/FSharp.Tests/Actions/TypingAssistTest.fs
+++ b/ReSharper.FSharp/test/src/FSharp.Tests/Actions/TypingAssistTest.fs
@@ -191,6 +191,15 @@ type FSharpTypingAssistTest() =
     [<Test>] member x.``Backspace - String - Triple quote 07``() = x.DoNamedTest()
     [<Test>] member x.``Backspace - String - Verbatim 01 - Empty``() = x.DoNamedTest()
 
+    [<Test>] member x.``Backspace - Record - Definition 01``() = x.DoNamedTest()
+    [<Test>] member x.``Backspace - Record - Definition 02``() = x.DoNamedTest()
+    [<Test>] member x.``Backspace - Record - Instance 01``() = x.DoNamedTest()
+    [<Test>] member x.``Backspace - Record - Anonymous 01``() = x.DoNamedTest()
+
+    [<Test>] member x.``Delete - Record - Definition 01``() = x.DoNamedTest()
+    [<Test>] member x.``Delete - Record - Definition 02``() = x.DoNamedTest()
+    [<Test>] member x.``Delete - Record - Instance 01``() = x.DoNamedTest()
+    [<Test>] member x.``Delete - Record - Anonymous 01``() = x.DoNamedTest()
 
     [<Test>] member x.``Space 01 - Inside empty list``() = x.DoNamedTest()
     [<Test>] member x.``Space 02 - Inside empty array``() = x.DoNamedTest()

--- a/ReSharper.FSharp/test/src/FSharp.Tests/Actions/TypingAssistTest.fs
+++ b/ReSharper.FSharp/test/src/FSharp.Tests/Actions/TypingAssistTest.fs
@@ -193,12 +193,22 @@ type FSharpTypingAssistTest() =
 
     [<Test>] member x.``Backspace - Record - Definition 01``() = x.DoNamedTest()
     [<Test>] member x.``Backspace - Record - Definition 02``() = x.DoNamedTest()
+    [<Test>] member x.``Backspace - Record - Definition 03 - Comment``() = x.DoNamedTest()
+    [<Test>] member x.``Backspace - Record - Definition 04 - Empty line 01``() = x.DoNamedTest()
+    [<Test>] member x.``Backspace - Record - Definition 05 - Empty line 02``() = x.DoNamedTest()
     [<Test>] member x.``Backspace - Record - Instance 01``() = x.DoNamedTest()
+    [<Test>] member x.``Backspace - Record - Instance 02 - Comment``() = x.DoNamedTest()
+    [<Test>] member x.``Backspace - Record - Instance 03 - Empty line``() = x.DoNamedTest()
     [<Test>] member x.``Backspace - Record - Anonymous 01``() = x.DoNamedTest()
 
     [<Test>] member x.``Delete - Record - Definition 01``() = x.DoNamedTest()
     [<Test>] member x.``Delete - Record - Definition 02``() = x.DoNamedTest()
+    [<Test>] member x.``Delete - Record - Definition 03 - Comment``() = x.DoNamedTest()
+    [<Test>] member x.``Delete - Record - Definition 04 - Empty line 01``() = x.DoNamedTest()
+    [<Test>] member x.``Delete - Record - Definition 05 - Empty line 02``() = x.DoNamedTest()
     [<Test>] member x.``Delete - Record - Instance 01``() = x.DoNamedTest()
+    [<Test>] member x.``Delete - Record - Instance 02 - Comment``() = x.DoNamedTest()
+    [<Test>] member x.``Delete - Record - Instance 03 - Empty line``() = x.DoNamedTest()
     [<Test>] member x.``Delete - Record - Anonymous 01``() = x.DoNamedTest()
 
     [<Test>] member x.``Space 01 - Inside empty list``() = x.DoNamedTest()


### PR DESCRIPTION
This PR implements delete/backspace assist for cases when the caret is inside record declaration/instance to help in deletion of redundant whitespace. The feature also works for anonymous records and records with attributes as well.

Examples:

Definition:
```fsharp
type SomeRecord =
   { field1: string
     field2: string
     {caret}field3: string }
```
<kbd>Backspace</kbd>:
```fsharp
type SomeRecord =
   { field1: string
     field2: string; field3: string }
```

Instance:
```fsharp
// Before
let someRecord =
   { field1 = "Quick"
     field2 = "Brown"{caret}
     field3 = "Fox" }
```
<kbd>Delete</kbd>:
```fsharp
let someRecord =
   { field1 = "Quick"
     field2 = "Brown"; field3 = "Fox" }
```