### PR TITLE
Frontend tests/Type Providers: remove 'withOutOfProcessTypeProviders'

### DIFF
--- a/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/Extensions.kt
+++ b/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/Extensions.kt
@@ -7,8 +7,8 @@ import com.jetbrains.rider.inTests.TestHost
 import com.jetbrains.rider.plugins.fsharp.rdFSharpModel
 import com.jetbrains.rider.projectView.solution
 import com.jetbrains.rider.test.base.BaseTestWithSolution
-import com.jetbrains.rider.test.framework.frameworkLogger
 import com.jetbrains.rider.test.scriptingApi.dumpSevereHighlighters
+import org.testng.Assert
 import java.io.PrintStream
 
 fun com.intellij.openapi.editor.Editor.dumpTypeProviders(stream: PrintStream) {
@@ -19,30 +19,23 @@ fun com.intellij.openapi.editor.Editor.dumpTypeProviders(stream: PrintStream) {
     }
 }
 
-fun withSetting(project: Project, setting: String, function: () -> Unit) {
-    TestHost.getInstance(project.protocolHost).setSetting(setting, "true")
+fun withSetting(project: Project, setting: String, enterValue: String, exitValue: String, function: () -> Unit) {
+    TestHost.getInstance(project.protocolHost).setSetting(setting, enterValue)
     try {
         function()
     } finally {
-        TestHost.getInstance(project.protocolHost).setSetting(setting, "false")
+        TestHost.getInstance(project.protocolHost).setSetting(setting, exitValue)
     }
 }
 
-fun BaseTestWithSolution.withOutOfProcessTypeProviders(function: () -> Unit) {
-    withSetting(project, "FSharp/FSharpOptions/FSharpExperimentalFeatures/OutOfProcessTypeProviders/@EntryValue") {
-        try {
-            function()
-        } finally {
-            val tpProcessCount = ProcessListUtil
-                    .getProcessList()
-                    .count { it.executableName.startsWith("JetBrains.ReSharper.Plugins.FSharp.TypeProviders.Host") }
-            if (tpProcessCount != 1) frameworkLogger.warn("Expected single type providers process, but was $tpProcessCount")
-        }
+fun BaseTestWithSolution.withDisabledOutOfProcessTypeProviders(function: () -> Unit) {
+    withSetting(project, "FSharp/FSharpOptions/FSharpExperimentalFeatures/OutOfProcessTypeProviders/@EntryValue", "false", "true") {
+        function()
     }
 }
 
 fun withEditorConfig(project: Project, function: () -> Unit) {
-    withSetting(project, "CodeStyle/EditorConfig/EnableEditorConfigSupport", function)
+    withSetting(project, "CodeStyle/EditorConfig/EnableEditorConfigSupport", "true", "false", function)
 }
 
 fun withCultureInfo(project: Project, culture: String, function: () -> Unit) {

--- a/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/Extensions.kt
+++ b/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/Extensions.kt
@@ -1,6 +1,5 @@
 package com.jetbrains.rider.plugins.fsharp.test
 
-import com.intellij.execution.process.impl.ProcessListUtil
 import com.intellij.openapi.project.Project
 import com.jetbrains.rdclient.protocol.protocolHost
 import com.jetbrains.rider.inTests.TestHost
@@ -8,7 +7,6 @@ import com.jetbrains.rider.plugins.fsharp.rdFSharpModel
 import com.jetbrains.rider.projectView.solution
 import com.jetbrains.rider.test.base.BaseTestWithSolution
 import com.jetbrains.rider.test.scriptingApi.dumpSevereHighlighters
-import org.testng.Assert
 import java.io.PrintStream
 
 fun com.intellij.openapi.editor.Editor.dumpTypeProviders(stream: PrintStream) {

--- a/rider-fsharp/src/test/kotlin/typeProviders/GenerativeTypeProvidersTest.kt
+++ b/rider-fsharp/src/test/kotlin/typeProviders/GenerativeTypeProvidersTest.kt
@@ -3,7 +3,6 @@ package typeProviders
 import com.jetbrains.rdclient.testFramework.waitForDaemon
 import com.jetbrains.rdclient.testFramework.waitForNextDaemon
 import com.jetbrains.rider.daemon.util.hasErrors
-import com.jetbrains.rider.plugins.fsharp.test.withOutOfProcessTypeProviders
 import com.jetbrains.rider.projectView.solutionDirectoryPath
 import com.jetbrains.rider.test.annotations.TestEnvironment
 import com.jetbrains.rider.test.asserts.shouldBeFalse
@@ -24,24 +23,22 @@ class GenerativeTypeProvidersTest : BaseTestWithSolution() {
     fun `generative type providers cross-project analysis`() {
         val generativeProviderProjectPath = "${project.solutionDirectoryPath}/GenerativeTypeProvider/GenerativeTypeProvider.fsproj"
 
-        withOutOfProcessTypeProviders {
-            withOpenedEditor(project, "GenerativeTypeLibrary/Library.fs") {
-                waitForDaemon()
-                markupAdapter.hasErrors.shouldBeTrue()
+        withOpenedEditor(project, "GenerativeTypeLibrary/Library.fs") {
+            waitForDaemon()
+            markupAdapter.hasErrors.shouldBeTrue()
 
-                buildSelectedProjectsWithConsoleBuild(listOf(generativeProviderProjectPath))
+            buildSelectedProjectsWithConsoleBuild(listOf(generativeProviderProjectPath))
 
-                waitForNextDaemon(Duration.ofSeconds(5))
-                markupAdapter.hasErrors.shouldBeFalse()
-            }
+            waitForNextDaemon(Duration.ofSeconds(5))
+            markupAdapter.hasErrors.shouldBeFalse()
+        }
 
-            unloadProject(arrayOf("TypeProviderLibrary", "GenerativeTypeProvider"))
-            reloadProject(arrayOf("TypeProviderLibrary", "GenerativeTypeProvider"))
+        unloadProject(arrayOf("TypeProviderLibrary", "GenerativeTypeProvider"))
+        reloadProject(arrayOf("TypeProviderLibrary", "GenerativeTypeProvider"))
 
-            withOpenedEditor(project, "GenerativeTypeLibrary/Library.fs") {
-                waitForDaemon()
-                markupAdapter.hasErrors.shouldBeFalse()
-            }
+        withOpenedEditor(project, "GenerativeTypeLibrary/Library.fs") {
+            waitForDaemon()
+            markupAdapter.hasErrors.shouldBeFalse()
         }
     }
 }

--- a/rider-fsharp/src/test/kotlin/typeProviders/TypeProvidersCacheTest.kt
+++ b/rider-fsharp/src/test/kotlin/typeProviders/TypeProvidersCacheTest.kt
@@ -2,16 +2,16 @@ package typeProviders
 
 import com.jetbrains.rdclient.testFramework.executeWithGold
 import com.jetbrains.rdclient.testFramework.waitForDaemon
-import com.jetbrains.rider.daemon.util.hasErrors
 import com.jetbrains.rider.plugins.fsharp.test.dumpTypeProviders
-import com.jetbrains.rider.plugins.fsharp.test.withOutOfProcessTypeProviders
 import com.jetbrains.rider.test.annotations.TestEnvironment
-import com.jetbrains.rider.test.asserts.shouldBeFalse
 import com.jetbrains.rider.test.asserts.shouldBeTrue
 import com.jetbrains.rider.test.base.BaseTestWithSolution
 import com.jetbrains.rider.test.enums.CoreVersion
 import com.jetbrains.rider.test.enums.ToolsetVersion
-import com.jetbrains.rider.test.scriptingApi.*
+import com.jetbrains.rider.test.scriptingApi.reloadAllProjects
+import com.jetbrains.rider.test.scriptingApi.typeWithLatency
+import com.jetbrains.rider.test.scriptingApi.unloadAllProjects
+import com.jetbrains.rider.test.scriptingApi.withOpenedEditor
 import org.testng.annotations.Test
 import java.io.File
 
@@ -33,76 +33,66 @@ class TypeProvidersCacheTest : BaseTestWithSolution() {
 
     @Test
     fun checkCachesWhenProjectReloading() {
-        withOutOfProcessTypeProviders {
-            checkTypeProviders(File(testGoldFile.path + "_before"), defaultSourceFile)
+        checkTypeProviders(File(testGoldFile.path + "_before"), defaultSourceFile)
 
-            unloadAllProjects()
-            reloadAllProjects(project)
+        unloadAllProjects()
+        reloadAllProjects(project)
 
-            checkTypeProviders(File(testGoldFile.path + "_after"), defaultSourceFile)
-        }
+        checkTypeProviders(File(testGoldFile.path + "_after"), defaultSourceFile)
     }
 
     @Test
     fun invalidation() {
         val testDirectory = File(project.basePath + "/TypeProviderLibrary/Test")
 
-        withOutOfProcessTypeProviders {
-            withOpenedEditor(project, defaultSourceFile) {
-                waitForDaemon()
+        withOpenedEditor(project, defaultSourceFile) {
+            waitForDaemon()
 
-                testDirectory.deleteRecursively().shouldBeTrue()
-                typeWithLatency("//")
-                waitForDaemon()
+            testDirectory.deleteRecursively().shouldBeTrue()
+            typeWithLatency("//")
+            waitForDaemon()
 
-                executeWithGold(File(testGoldFile.path + "_before")) {
-                    dumpTypeProviders(it)
-                }
+            executeWithGold(File(testGoldFile.path + "_before")) {
+                dumpTypeProviders(it)
+            }
 
-                testDirectory.mkdir().shouldBeTrue()
-                typeWithLatency(" ")
-                waitForDaemon()
+            testDirectory.mkdir().shouldBeTrue()
+            typeWithLatency(" ")
+            waitForDaemon()
 
-                executeWithGold(File(testGoldFile.path + "_after")) {
-                    dumpTypeProviders(it)
-                }
+            executeWithGold(File(testGoldFile.path + "_after")) {
+                dumpTypeProviders(it)
             }
         }
     }
 
     @Test
     fun typing() {
-        withOutOfProcessTypeProviders {
-            withOpenedEditor(project, defaultSourceFile) {
-                waitForDaemon()
-                typeWithLatency("//")
-                checkTypeProviders(testGoldFile, defaultSourceFile)
-            }
+        withOpenedEditor(project, defaultSourceFile) {
+            waitForDaemon()
+            typeWithLatency("//")
+            checkTypeProviders(testGoldFile, defaultSourceFile)
         }
     }
 
     @Test
     fun projectsWithEqualProviders() {
-        withOutOfProcessTypeProviders {
-            withOpenedEditor(project, "TypeProviderLibrary/Library.fs") {
-                waitForDaemon()
-            }
-            withOpenedEditor(project, "TypeProviderLibrary2/Library.fs") {
-                waitForDaemon()
-                checkTypeProviders(testGoldFile, defaultSourceFile)
-            }
+        withOpenedEditor(project, "TypeProviderLibrary/Library.fs") {
+            waitForDaemon()
+        }
+        withOpenedEditor(project, "TypeProviderLibrary2/Library.fs") {
+            waitForDaemon()
+            checkTypeProviders(testGoldFile, defaultSourceFile)
         }
     }
 
     @Test(description = "RIDER-73091", enabled = false)
     fun script() {
-        withOutOfProcessTypeProviders {
-            checkTypeProviders(File(testGoldFile.path + "_before"), "TypeProviderLibrary/Script.fsx")
+        checkTypeProviders(File(testGoldFile.path + "_before"), "TypeProviderLibrary/Script.fsx")
 
-            unloadAllProjects()
-            reloadAllProjects(project)
+        unloadAllProjects()
+        reloadAllProjects(project)
 
-            checkTypeProviders(File(testGoldFile.path + "_after"), "TypeProviderLibrary/Script.fsx")
-        }
+        checkTypeProviders(File(testGoldFile.path + "_after"), "TypeProviderLibrary/Script.fsx")
     }
 }

--- a/rider-fsharp/src/test/kotlin/typeProviders/TypeProvidersRuntimeTest.kt
+++ b/rider-fsharp/src/test/kotlin/typeProviders/TypeProvidersRuntimeTest.kt
@@ -3,7 +3,6 @@ package typeProviders
 import com.jetbrains.rdclient.testFramework.waitForDaemon
 import com.jetbrains.rider.daemon.util.hasErrors
 import com.jetbrains.rider.plugins.fsharp.test.fcsHost
-import com.jetbrains.rider.plugins.fsharp.test.withOutOfProcessTypeProviders
 import com.jetbrains.rider.test.annotations.TestEnvironment
 import com.jetbrains.rider.test.asserts.shouldBeFalse
 import com.jetbrains.rider.test.asserts.shouldBeTrue
@@ -22,9 +21,9 @@ class TypeProvidersRuntimeTest : BaseTestWithSolution() {
 
     @Test
     @TestEnvironment(
-        toolset = ToolsetVersion.TOOLSET_16,
-        coreVersion = CoreVersion.DOT_NET_CORE_3_1,
-        solution = "TypeProviderLibrary")
+            toolset = ToolsetVersion.TOOLSET_16,
+            coreVersion = CoreVersion.DOT_NET_CORE_3_1,
+            solution = "TypeProviderLibrary")
     fun framework461() = doTest(".NET Framework 4.8")
 
     @Test(enabled = false)
@@ -45,23 +44,21 @@ class TypeProvidersRuntimeTest : BaseTestWithSolution() {
 
     @Test(enabled = false)
     @TestEnvironment(
-        toolset = ToolsetVersion.TOOLSET_16_CORE,
-        coreVersion = CoreVersion.DOT_NET_CORE_3_1,
-        solution = "FscTypeProviderLibrary"
+            toolset = ToolsetVersion.TOOLSET_16_CORE,
+            coreVersion = CoreVersion.DOT_NET_CORE_3_1,
+            solution = "FscTypeProviderLibrary"
     )
     fun fsc() = doTest(".NET Framework 4.8")
 
     private fun doTest(expectedRuntime: String) {
-        withOutOfProcessTypeProviders {
-            withOpenedEditor(project, "TypeProviderLibrary/Library.fs") {
-                waitForDaemon()
-                this.project!!.fcsHost
+        withOpenedEditor(project, "TypeProviderLibrary/Library.fs") {
+            waitForDaemon()
+            this.project!!.fcsHost
                     .typeProvidersRuntimeVersion.sync(Unit)
                     .shouldNotBeNull()
                     .startsWith(expectedRuntime)
                     .shouldBeTrue()
-                markupAdapter.hasErrors.shouldBeFalse()
-            }
+            markupAdapter.hasErrors.shouldBeFalse()
         }
     }
 }

--- a/rider-fsharp/src/test/kotlin/typeProviders/TypeProvidersRuntimeTest.kt
+++ b/rider-fsharp/src/test/kotlin/typeProviders/TypeProvidersRuntimeTest.kt
@@ -21,9 +21,9 @@ class TypeProvidersRuntimeTest : BaseTestWithSolution() {
 
     @Test
     @TestEnvironment(
-            toolset = ToolsetVersion.TOOLSET_16,
-            coreVersion = CoreVersion.DOT_NET_CORE_3_1,
-            solution = "TypeProviderLibrary")
+        toolset = ToolsetVersion.TOOLSET_16,
+        coreVersion = CoreVersion.DOT_NET_CORE_3_1,
+        solution = "TypeProviderLibrary")
     fun framework461() = doTest(".NET Framework 4.8")
 
     @Test(enabled = false)
@@ -44,9 +44,9 @@ class TypeProvidersRuntimeTest : BaseTestWithSolution() {
 
     @Test(enabled = false)
     @TestEnvironment(
-            toolset = ToolsetVersion.TOOLSET_16_CORE,
-            coreVersion = CoreVersion.DOT_NET_CORE_3_1,
-            solution = "FscTypeProviderLibrary"
+        toolset = ToolsetVersion.TOOLSET_16_CORE,
+        coreVersion = CoreVersion.DOT_NET_CORE_3_1,
+        solution = "FscTypeProviderLibrary"
     )
     fun fsc() = doTest(".NET Framework 4.8")
 

--- a/rider-fsharp/src/test/kotlin/typeProviders/TypeProvidersSettingTest.kt
+++ b/rider-fsharp/src/test/kotlin/typeProviders/TypeProvidersSettingTest.kt
@@ -3,7 +3,7 @@ package typeProviders
 import com.jetbrains.rdclient.testFramework.waitForDaemon
 import com.jetbrains.rider.daemon.util.hasErrors
 import com.jetbrains.rider.plugins.fsharp.rdFSharpModel
-import com.jetbrains.rider.plugins.fsharp.test.withOutOfProcessTypeProviders
+import com.jetbrains.rider.plugins.fsharp.test.withDisabledOutOfProcessTypeProviders
 import com.jetbrains.rider.projectView.solution
 import com.jetbrains.rider.test.annotations.TestEnvironment
 import com.jetbrains.rider.test.asserts.shouldBeFalse
@@ -12,7 +12,10 @@ import com.jetbrains.rider.test.asserts.shouldNotBeNull
 import com.jetbrains.rider.test.base.BaseTestWithSolution
 import com.jetbrains.rider.test.enums.CoreVersion
 import com.jetbrains.rider.test.enums.ToolsetVersion
-import com.jetbrains.rider.test.scriptingApi.*
+import com.jetbrains.rider.test.scriptingApi.markupAdapter
+import com.jetbrains.rider.test.scriptingApi.reloadAllProjects
+import com.jetbrains.rider.test.scriptingApi.unloadAllProjects
+import com.jetbrains.rider.test.scriptingApi.withOpenedEditor
 import org.testng.annotations.Test
 
 @Test
@@ -26,10 +29,19 @@ class TypeProvidersSettingTest : BaseTestWithSolution() {
     fun enableTypeProvidersSetting() {
         val sourceFile = "TypeProviderLibrary2/Library.fs"
 
-        withOutOfProcessTypeProviders {
+        withOpenedEditor(project, sourceFile) {
+            waitForDaemon()
+            rdFcsHost.typeProvidersRuntimeVersion.sync(Unit).shouldNotBeNull()
+            markupAdapter.hasErrors.shouldBeFalse()
+        }
+
+        withDisabledOutOfProcessTypeProviders {
+            unloadAllProjects()
+            reloadAllProjects(project)
+
             withOpenedEditor(project, sourceFile) {
                 waitForDaemon()
-                rdFcsHost.typeProvidersRuntimeVersion.sync(Unit).shouldNotBeNull()
+                rdFcsHost.typeProvidersRuntimeVersion.sync(Unit).shouldBeNull()
                 markupAdapter.hasErrors.shouldBeFalse()
             }
         }
@@ -39,19 +51,8 @@ class TypeProvidersSettingTest : BaseTestWithSolution() {
 
         withOpenedEditor(project, sourceFile) {
             waitForDaemon()
-            rdFcsHost.typeProvidersRuntimeVersion.sync(Unit).shouldBeNull()
+            rdFcsHost.typeProvidersRuntimeVersion.sync(Unit).shouldNotBeNull()
             markupAdapter.hasErrors.shouldBeFalse()
-        }
-
-        unloadAllProjects()
-        reloadAllProjects(project)
-
-        withOutOfProcessTypeProviders {
-            withOpenedEditor(project, sourceFile) {
-                waitForDaemon()
-                rdFcsHost.typeProvidersRuntimeVersion.sync(Unit).shouldNotBeNull()
-                markupAdapter.hasErrors.shouldBeFalse()
-            }
         }
     }
 }

--- a/rider-fsharp/src/test/kotlin/typeProviders/TypeProvidersTest.kt
+++ b/rider-fsharp/src/test/kotlin/typeProviders/TypeProvidersTest.kt
@@ -2,7 +2,6 @@ package typeProviders
 
 import com.jetbrains.rdclient.testFramework.executeWithGold
 import com.jetbrains.rdclient.testFramework.waitForDaemon
-import com.jetbrains.rider.plugins.fsharp.test.withOutOfProcessTypeProviders
 import com.jetbrains.rider.test.annotations.TestEnvironment
 import com.jetbrains.rider.test.base.BaseTestWithSolution
 import com.jetbrains.rider.test.enums.CoreVersion
@@ -34,12 +33,10 @@ class TypeProvidersTest : BaseTestWithSolution() {
     fun legacyTypeProviders() = doTest("LegacyTypeProviders")
 
     private fun doTest(fileName: String) {
-        withOutOfProcessTypeProviders {
-            withOpenedEditor(project, "TypeProviderLibrary/$fileName.fs") {
-                waitForDaemon()
-                executeWithGold(testGoldFile) {
-                    dumpSevereHighlighters(it)
-                }
+        withOpenedEditor(project, "TypeProviderLibrary/$fileName.fs") {
+            waitForDaemon()
+            executeWithGold(testGoldFile) {
+                dumpSevereHighlighters(it)
             }
         }
     }


### PR DESCRIPTION
Since we host type providers out-of-process by default