### PR TITLE
Add missing member SplitDeclarationAndInitializer.

### DIFF
--- a/ReSharper.FSharp/src/FSharp.Psi.Services/src/Refactorings/FSharpInlineVariable.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Services/src/Refactorings/FSharpInlineVariable.fs
@@ -34,6 +34,7 @@ type FSharpInlineHelper(driver) =
     override x.RemoveCastFromElement _ = raise (NotImplementedException())
     override x.GetArgumentOwner(_, _) = raise (NotImplementedException())
     override x.AllNotQualifiableReferences _ = raise (NotImplementedException())
+    override x.SplitDeclarationAndInitializer _ = raise (NotImplementedException())
 
 type FSharpInlineVariable(workflow, solution, driver) =
     inherit InlineVarBase(workflow, solution, driver)


### PR DESCRIPTION
I wasn't able to build the `ReSharper.FSharp.sln` without this.