### PR TITLE
Type Providers: lazily throw exceptions when accessing attribute arguments

### DIFF
--- a/ReSharper.FSharp/src/FSharp.Psi.Daemon/src/Tooltips/FSharpIdentifierTooltipProvider.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Daemon/src/Tooltips/FSharpIdentifierTooltipProvider.fs
@@ -77,8 +77,8 @@ type FSharpIdentifierTooltipProvider(lifetime, solution, presenter, xmlDocServic
             let (ToolTipText layouts) = FSharpIdentifierTooltipProvider.GetFSharpToolTipText(results.CheckResults, token)
 
             layouts |> List.collect (function
-                | ToolTipElement.None
-                | ToolTipElement.CompositionError _ -> []
+                | ToolTipElement.None -> []
+                | ToolTipElement.CompositionError errorText -> [ RichText(errorText) ]
 
                 | ToolTipElement.Group(overloads) ->
                     overloads |> List.map (fun overload ->

--- a/ReSharper.FSharp/src/FSharp.TypeProviders.Host/src/ModelCreators/ProvidedCustomAttributeCreator.cs
+++ b/ReSharper.FSharp/src/FSharp.TypeProviders.Host/src/ModelCreators/ProvidedCustomAttributeCreator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Reflection;
+using JetBrains.ReSharper.Plugins.FSharp.TypeProviders.Host.Utils;
 using JetBrains.ReSharper.Plugins.FSharp.TypeProviders.Protocol.Utils;
 using JetBrains.Rider.FSharp.TypeProviders.Protocol.Server;
 
@@ -8,12 +9,26 @@ namespace JetBrains.ReSharper.Plugins.FSharp.TypeProviders.Host.ModelCreators
 {
   public class ProvidedCustomAttributeCreator : ProvidedRdModelsCreatorBase<CustomAttributeData, RdCustomAttributeData>
   {
+    private readonly TypeProvidersContext myTypeProvidersContext;
+
+    public ProvidedCustomAttributeCreator(TypeProvidersContext typeProvidersContext) =>
+      myTypeProvidersContext = typeProvidersContext;
+
     protected override RdCustomAttributeData CreateRdModelInternal(CustomAttributeData providedModel,
-      int typeProviderId) =>
-      new(
+      int typeProviderId)
+    {
+      var (namedArguments, exn1) =
+        myTypeProvidersContext.Logger.CatchWithException(() => providedModel.NamedArguments?.Select(Convert).ToArray());
+
+      var (constructorArguments, exn2) =
+        myTypeProvidersContext.Logger.CatchWithException(() =>
+          providedModel.ConstructorArguments.Select(Convert).ToArray());
+
+      return new RdCustomAttributeData(
         providedModel.Constructor.DeclaringType?.FullName ?? "",
-        providedModel.NamedArguments?.Select(Convert).ToArray() ?? Array.Empty<RdCustomAttributeNamedArgument>(),
-        providedModel.ConstructorArguments.Select(Convert).ToArray());
+        new(namedArguments ?? Array.Empty<RdCustomAttributeNamedArgument>(), exn1?.Message),
+        new(constructorArguments ?? Array.Empty<RdCustomAttributeTypedArgument>(), exn2?.Message));
+    }
 
     private static RdCustomAttributeNamedArgument Convert(CustomAttributeNamedArgument argument) =>
       new(argument.MemberName, Convert(argument.TypedValue));

--- a/ReSharper.FSharp/src/FSharp.TypeProviders.Host/src/TypeProvidersContext.cs
+++ b/ReSharper.FSharp/src/FSharp.TypeProviders.Host/src/TypeProvidersContext.cs
@@ -77,7 +77,7 @@ namespace JetBrains.ReSharper.Plugins.FSharp.TypeProviders.Host
       ProvidedFieldRdModelsCreator = new ProvidedFieldCreator(this);
       ProvidedEventRdModelsCreator = new ProvidedEventCreator(this);
       ProvidedConstructorRdModelsCreator = new ProvidedConstructorCreator(this);
-      ProvidedCustomAttributeRdModelsCreator = new ProvidedCustomAttributeCreator();
+      ProvidedCustomAttributeRdModelsCreator = new ProvidedCustomAttributeCreator(this);
     }
   }
 }

--- a/ReSharper.FSharp/src/FSharp.TypeProviders.Host/src/Utils/LoggerExtensions.cs
+++ b/ReSharper.FSharp/src/FSharp.TypeProviders.Host/src/Utils/LoggerExtensions.cs
@@ -1,0 +1,22 @@
+using System;
+using JetBrains.Diagnostics;
+using JetBrains.Util;
+
+namespace JetBrains.ReSharper.Plugins.FSharp.TypeProviders.Host.Utils
+{
+  public static class LoggerExtensions
+  {
+    public static (T result, Exception exception) CatchWithException<T>(this ILogger logger, Func<T> f)
+    {
+      try
+      {
+        return (f(), null);
+      }
+      catch (Exception ex)
+      {
+        logger.LogException(LoggingLevel.ERROR, ex, ExceptionOrigin.Algorithmic);
+        return (default, ex);
+      }
+    }
+  }
+}

--- a/rider-fsharp/protocol/src/kotlin/model/RdFSharpTypeProvidersModel.kt
+++ b/rider-fsharp/protocol/src/kotlin/model/RdFSharpTypeProvidersModel.kt
@@ -71,8 +71,14 @@ object RdFSharpTypeProvidersModel : Root() {
 
     private val RdCustomAttributeData = structdef {
         field("FullName", string)
-        field("NamedArguments", array(RdCustomAttributeNamedArgument))
-        field("ConstructorArguments", array(RdCustomAttributeTypedArgument))
+        field("NamedArguments", structdef("NamedArgumentsResult") {
+            field("Arguments", array(RdCustomAttributeNamedArgument))
+            field("Error", string.nullable)
+        })
+        field("ConstructorArguments", structdef("ConstructorArgumentsResult") {
+            field("Arguments", array(RdCustomAttributeTypedArgument))
+            field("Error", string.nullable)
+        })
     }
 
     private val RdTypeProviderProcessModel = aggregatedef("RdTypeProviderProcessModel") {


### PR DESCRIPTION
There are cases when a type provider may throw an exception when accessing attribute arguments for a provided type/member. Prior to this fix, exceptions were thrown during converting attributes from OOP TP to RD model, which could lead to phantom errors even in cases where FCS does not request attribute arguments. This PR allows exceptions to be thrown not when passing attributes between processes, but when accessing attribute arguments directly.