### PR TITLE
Code Cleanup: add F# to Code Cleanup options

### DIFF
--- a/ReSharper.FSharp/src/FSharp.Psi.Features/src/CodeCleanup/FSharpReformatCode.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Features/src/CodeCleanup/FSharpReformatCode.fs
@@ -1,7 +1,7 @@
 namespace JetBrains.ReSharper.Plugins.FSharp.Services.Formatter
 
-open System
 open JetBrains.Application.Infra
+open JetBrains.Diagnostics
 open JetBrains.DocumentModel
 open JetBrains.DocumentModel.Impl
 open JetBrains.ProjectModel
@@ -34,7 +34,7 @@ type FSharpReformatCode() =
             | CodeCleanupService.DefaultProfileType.CODE_STYLE ->
                 profile.SetSetting<bool>(REFORMAT_CODE_DESCRIPTOR, true)
             | _ -> 
-                raise(ArgumentException(nameof(profileType)))
+                Assertion.Fail($"Unexpected cleanup profile type: {nameof(profileType)}")
 
         member x.IsAvailable(sourceFile: IPsiSourceFile) =
             sourceFile.PrimaryPsiLanguage :? FSharpLanguage

--- a/ReSharper.FSharp/src/FSharp.Psi.Features/src/CodeCleanup/FSharpReformatCode.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Features/src/CodeCleanup/FSharpReformatCode.fs
@@ -6,7 +6,6 @@ open JetBrains.DocumentModel
 open JetBrains.DocumentModel.Impl
 open JetBrains.ProjectModel
 open JetBrains.ReSharper.Feature.Services.CodeCleanup
-open JetBrains.ReSharper.Feature.Services.Resources
 open JetBrains.ReSharper.Plugins.FSharp.Psi
 open JetBrains.ReSharper.Plugins.FSharp.Util
 open JetBrains.ReSharper.Psi
@@ -21,7 +20,6 @@ type FSharpReformatCode() =
         "FSReformatCode",
         CodeCleanupLanguage("F#", 2),
         CodeCleanupOptionDescriptor.ReformatGroup,
-        typedefof<Strings>,
         displayName = "Reformat code")
 
     interface IReformatCodeCleanupModule with


### PR DESCRIPTION
Fix for [RIDER-65997](https://youtrack.jetbrains.com/issue/RIDER-65997/Add-F-support-in-Code-Cleanup-options)

- [ ]  Add localization

![image](https://user-images.githubusercontent.com/26364714/183210806-b8812b4c-5a49-40e5-8d52-9e5b7bda59e8.png)
