### PR TITLE
Psi/FSharpMethodParameter: fix [<ParamArray>] check

### DIFF
--- a/ReSharper.FSharp/src/FSharp.Psi/src/Impl/DeclaredElement/FSharpMethodParameter.cs
+++ b/ReSharper.FSharp/src/FSharp.Psi/src/Impl/DeclaredElement/FSharpMethodParameter.cs
@@ -55,7 +55,7 @@ namespace JetBrains.ReSharper.Plugins.FSharp.Psi.Impl.DeclaredElement
     }
 
     public override ParameterKind Kind => FSharpSymbol.MapParameterKind();
-    public override bool IsParameterArray => Owner is IFSharpMethod && FSharpSymbol.IsParamArrayArg;
+    public override bool IsParameterArray => Owner is IFSharpFunction && FSharpSymbol.IsParamArrayArg;
 
     // todo: implement IsCliOptional in FCS
     public override bool IsOptional =>

--- a/ReSharper.FSharp/test/data/cache/csharpResolve/Parameters 01.cs
+++ b/ReSharper.FSharp/test/data/cache/csharpResolve/Parameters 01.cs
@@ -7,5 +7,7 @@ public class Class1
     var a = new A("argOne", "argTwo", "argThree");
     var b = new A(1, "argTwo", "argThree");
     f("argOne", "argTwo", "argThree");
+
+    var c = new B("argOne", "argTwo");
   }
 }

--- a/ReSharper.FSharp/test/data/cache/csharpResolve/Parameters 01.cs
+++ b/ReSharper.FSharp/test/data/cache/csharpResolve/Parameters 01.cs
@@ -1,0 +1,11 @@
+﻿using static Module;
+
+public class Class1
+{
+  public Class1()
+  {
+    var a = new A("argOne", "argTwo", "argThree");
+    var b = new A(1, "argTwo", "argThree");
+    f("argOne", "argTwo", "argThree");
+  }
+}

--- a/ReSharper.FSharp/test/data/cache/csharpResolve/Parameters 01.fs
+++ b/ReSharper.FSharp/test/data/cache/csharpResolve/Parameters 01.fs
@@ -4,3 +4,5 @@ let f (x: string, [<System.ParamArray>] y: obj array) = ()
   
 type A(x: string, [<System.ParamArray>] y: obj array) =
   new(x1: int, [<System.ParamArray>] y2: obj array) = ResourceString("", 1)
+
+type B(x: obj array) = class end

--- a/ReSharper.FSharp/test/data/cache/csharpResolve/Parameters 01.fs
+++ b/ReSharper.FSharp/test/data/cache/csharpResolve/Parameters 01.fs
@@ -1,0 +1,6 @@
+module Module
+
+let f (x: string, [<System.ParamArray>] y: obj array) = ()
+  
+type A(x: string, [<System.ParamArray>] y: obj array) =
+  new(x1: int, [<System.ParamArray>] y2: obj array) = ResourceString("", 1)

--- a/ReSharper.FSharp/test/data/cache/csharpResolve/Parameters 01.gold
+++ b/ReSharper.FSharp/test/data/cache/csharpResolve/Parameters 01.gold
@@ -7,11 +7,15 @@ public class Class1
     var a = new A("argOne", "argTwo", "argThree");
     var b = new A(1, "argTwo", "argThree");
     f("argOne", "argTwo", "argThree");
+
+    var c = new B(|"argOne", "argTwo"|(0));
   }
 }
 
 ---------------------------------------------------------
+(0): ReSharper Underlined Error Highlighting: Constructor 'B' has 1 parameter(s) but is invoked with 2 argument(s)
 M:Module.A.#ctor(System.String,System.Object[])
 M:Module.A.#ctor(System.Int32,System.Object[])
 M:Module.f(System.String,System.Object[])
 M:Module.f(System.String,System.Object[])
+M:Module.B.#ctor(System.Object[])

--- a/ReSharper.FSharp/test/data/cache/csharpResolve/Parameters 01.gold
+++ b/ReSharper.FSharp/test/data/cache/csharpResolve/Parameters 01.gold
@@ -1,0 +1,17 @@
+﻿using static Module;
+
+public class Class1
+{
+  public Class1()
+  {
+    var a = new A("argOne", "argTwo", "argThree");
+    var b = new A(1, "argTwo", "argThree");
+    f("argOne", "argTwo", "argThree");
+  }
+}
+
+---------------------------------------------------------
+M:Module.A.#ctor(System.String,System.Object[])
+M:Module.A.#ctor(System.Int32,System.Object[])
+M:Module.f(System.String,System.Object[])
+M:Module.f(System.String,System.Object[])

--- a/ReSharper.FSharp/test/data/features/parameterInfo/App - Curried - Tuple 17.fs.gold
+++ b/ReSharper.FSharp/test/data/features/parameterInfo/App - Curried - Tuple 17.fs.gold
@@ -1,7 +1,7 @@
 ﻿ParameterInfo is available
 --- All invocables: ----
-(a: int[]) : unit
-Parameter: 0 'a: int[]'
+(params a: int[]) : unit
+Parameter: 0 'params a: int[]'
 
 --- Accepted invocables: ---
-(a: int[]) : unit
+(params a: int[]) : unit

--- a/ReSharper.FSharp/test/data/features/parameterInfo/App - Curried - Tuple 18.fs.gold
+++ b/ReSharper.FSharp/test/data/features/parameterInfo/App - Curried - Tuple 18.fs.gold
@@ -1,6 +1,7 @@
 ﻿ParameterInfo is available
 --- All invocables: ----
-(a: 'a, b: int[]) : unit
-Parameter: 3
+(a: 'a, params b: int[]) : unit
+Parameter: 1 'params b: int[]'
+
 --- Accepted invocables: ---
-(a: 'a, b: int[]) : unit
+(a: 'a, params b: int[]) : unit

--- a/ReSharper.FSharp/test/src/FSharp.Tests/Cache/CSharpResolveTest.fs
+++ b/ReSharper.FSharp/test/src/FSharp.Tests/Cache/CSharpResolveTest.fs
@@ -180,6 +180,8 @@ type CSharpResolveTest() =
     [<Test>] member x.``AttributeUsage 01 - AllowMultiple``() = x.DoNamedTest()
     [<Test>] member x.``AttributeUsage 02 - AttributeTargets``() = x.DoNamedTest()
 
+    [<Test>] member x.``Parameters 01``() = x.DoNamedTest()
+
     override x.RelativeTestDataPath = "cache/csharpResolve"
 
     override x.DoTest(project: IProject, _: IProject) =


### PR DESCRIPTION
Fix for [RIDER-80565](https://youtrack.jetbrains.com/issue/RIDER-80565/SystemParamArray-is-not-handled-correctly-when-referencing-from-C-code)

Before:
![image](https://user-images.githubusercontent.com/26364714/183217630-49c69a95-5a06-4bee-82df-6f876fc0c6b2.png)

After:
![image](https://user-images.githubusercontent.com/26364714/183217639-1cdc3b91-293d-443b-a08e-3ffcb6b4c345.png)
