### PR TITLE
Psi/AbstractMemberDeclaration: fix typeUsage -> returnTypeInfo

### DIFF
--- a/ReSharper.FSharp/src/FSharp.Psi/src/FSharp.psi
+++ b/ReSharper.FSharp/src/FSharp.Psi/src/FSharp.psi
@@ -1336,8 +1336,7 @@ abstractMemberDeclaration options { stubBase="FSharpProperTypeMemberDeclarationB
   MEMBER<MEMBER, MemberKeyword>?
   identOrOpName{IDENTIFIER, Identifier}
   postfixTypeParameterDeclarationList<TYPE_PARAMETER_LIST, TypeParameterList>?
-  COLON
-  typeUsage<TYPE, TypeUsage>;
+  returnTypeInfo<RETURN_INFO, ReturnTypeInfo>;
 
 valFieldDeclaration options { stubBase="FSharpProperTypeMemberDeclarationBase"; } extras {
   get { methodName="Attributes" path=<valFieldDeclaration:ATTRIBUTE_LIST/attributeList:ATTRIBUTE> };


### PR DESCRIPTION
Since we process it as return type info
https://github.com/JetBrains/resharper-fsharp/blob/215b0b4febea04974f01d28555119fa679ad3adc/ReSharper.FSharp/src/FSharp.Psi.Features/src/Parsing/FSharpTreeBuilderBase.fs#L844-L849

https://github.com/JetBrains/resharper-fsharp/blob/215b0b4febea04974f01d28555119fa679ad3adc/ReSharper.FSharp/test/data/parsing/Type%20member%20-%20Abstract%2002%20-%20Function.fs.gold#L18-L36