### PR TITLE
Psi/MemberSignature: fix typeUsage -> returnTypeInfo

### DIFF
--- a/ReSharper.FSharp/src/FSharp.Psi/src/FSharp.psi
+++ b/ReSharper.FSharp/src/FSharp.Psi/src/FSharp.psi
@@ -1310,8 +1310,7 @@ memberSignature  options { stubBase="FSharpProperTypeMemberDeclarationBase"; } e
   accessModifier{ACCESS_MODIFIER, AccessModifier}?
   identOrOpName{IDENTIFIER, Identifier}
   postfixTypeParameterDeclarationList<TYPE_PARAMETER_LIST, TypeParameterList>?
-  COLON
-  typeUsage<TYPE, TypeUsage>
+  returnTypeInfo<RETURN_INFO, ReturnTypeInfo>
   accessorDecls?;
 
 private accessorDecls:

--- a/ReSharper.FSharp/src/FSharp.Psi/src/Impl/Tree/MemberSignature.cs
+++ b/ReSharper.FSharp/src/FSharp.Psi/src/Impl/Tree/MemberSignature.cs
@@ -15,7 +15,7 @@ namespace JetBrains.ReSharper.Plugins.FSharp.Psi.Impl.Tree
       if (Parent is IMemberConstraint)
         return null;
 
-      if (TypeUsage is IFunctionTypeUsage)
+      if (ReturnTypeInfo is { ReturnType: IFunctionTypeUsage })
         return this.CreateMethod();
 
       return GetFcsSymbol() is { } fcsSymbol


### PR DESCRIPTION
Similar to https://github.com/JetBrains/resharper-fsharp/pull/392
https://github.com/JetBrains/resharper-fsharp/blob/215b0b4febea04974f01d28555119fa679ad3adc/ReSharper.FSharp/src/FSharp.Psi.Features/src/Parsing/FSharpTreeBuilderBase.fs#L842-L853

https://github.com/JetBrains/resharper-fsharp/blob/215b0b4febea04974f01d28555119fa679ad3adc/ReSharper.FSharp/test/data/parsing/signatures/Type%20member%20-%20Member%2001.fsi.gold#L31-L49