### PR TITLE
Obsolete Coreversion.DEFAULT in the tests

### DIFF
--- a/rider-fsharp/src/test/kotlin/FSharpCompletionTest.kt
+++ b/rider-fsharp/src/test/kotlin/FSharpCompletionTest.kt
@@ -8,7 +8,7 @@ import com.jetbrains.rider.test.scriptingApi.*
 import org.testng.annotations.Test
 
 @Test
-@TestEnvironment(toolset = ToolsetVersion.TOOLSET_16_CORE, coreVersion = CoreVersion.DEFAULT)
+@TestEnvironment(toolset = ToolsetVersion.TOOLSET_16_CORE, coreVersion = CoreVersion.DOT_NET_CORE_3_1)
 class FSharpCompletionTest : CompletionTestBase() {
     override fun getSolutionDirectoryName() = "CoreConsoleApp"
     override val restoreNuGetPackages = true

--- a/rider-fsharp/src/test/kotlin/FileSystemShimTest.kt
+++ b/rider-fsharp/src/test/kotlin/FileSystemShimTest.kt
@@ -12,7 +12,7 @@ import java.io.File
 import java.time.Duration
 
 @Test
-@TestEnvironment(coreVersion = CoreVersion.DEFAULT)
+@TestEnvironment(coreVersion = CoreVersion.DOT_NET_CORE_3_1)
 class FileSystemShimTest : BaseTestWithSolution() {
     override fun getSolutionDirectoryName() = "CoreConsoleApp"
 

--- a/rider-fsharp/src/test/kotlin/debugger/AsyncDebuggerTest.kt
+++ b/rider-fsharp/src/test/kotlin/debugger/AsyncDebuggerTest.kt
@@ -9,7 +9,7 @@ import com.jetbrains.rider.test.scriptingApi.waitForPause
 import org.testng.annotations.Test
 
 @Test
-@TestEnvironment(toolset = ToolsetVersion.TOOLSET_16_CORE, coreVersion = CoreVersion.DEFAULT)
+@TestEnvironment(toolset = ToolsetVersion.TOOLSET_16_CORE, coreVersion = CoreVersion.DOT_NET_CORE_3_1)
 class AsyncDebuggerTest : DebuggerTestBase() {
     override val projectName = "AsyncProgram"
     override fun getSolutionDirectoryName() = projectName

--- a/rider-fsharp/src/test/kotlin/projectModel/FcsModuleReaderTest.kt
+++ b/rider-fsharp/src/test/kotlin/projectModel/FcsModuleReaderTest.kt
@@ -30,7 +30,7 @@ import java.time.Duration
 
 @Suppress("UnstableApiUsage")
 @Test
-@TestEnvironment(coreVersion = CoreVersion.DEFAULT)
+@TestEnvironment(coreVersion = CoreVersion.DOT_NET_CORE_3_1)
 class FcsModuleReaderTest : ProjectModelBaseTest() {
     companion object {
         private var launchCounter = 0

--- a/rider-fsharp/src/test/kotlin/projectModel/FcsProjectProviderTest.kt
+++ b/rider-fsharp/src/test/kotlin/projectModel/FcsProjectProviderTest.kt
@@ -22,7 +22,7 @@ import org.testng.annotations.Test
 
 @Suppress("UnstableApiUsage")
 @Test
-@TestEnvironment(coreVersion = CoreVersion.DEFAULT)
+@TestEnvironment(coreVersion = CoreVersion.DOT_NET_CORE_3_1)
 class FcsProjectProviderTest : BaseTestWithSolution() {
     override fun getSolutionDirectoryName() = throw Exception("Solutions are set in tests below")
 

--- a/rider-fsharp/src/test/kotlin/projectModel/ReferencesOrderTest.kt
+++ b/rider-fsharp/src/test/kotlin/projectModel/ReferencesOrderTest.kt
@@ -8,7 +8,7 @@ import com.jetbrains.rider.test.enums.CoreVersion
 import org.testng.annotations.Test
 
 @Test
-@TestEnvironment(toolset = ToolsetVersion.TOOLSET_16_CORE, coreVersion = CoreVersion.DEFAULT)
+@TestEnvironment(toolset = ToolsetVersion.TOOLSET_16_CORE, coreVersion = CoreVersion.DOT_NET_CORE_3_1)
 class ReferencesOrder : BaseTestWithSolution() {
     override fun getSolutionDirectoryName() = "ReferencesOrder"
 

--- a/rider-fsharp/src/test/kotlin/typingAssist/FSharpTypingAssistTest.kt
+++ b/rider-fsharp/src/test/kotlin/typingAssist/FSharpTypingAssistTest.kt
@@ -7,7 +7,7 @@ import com.jetbrains.rider.test.scriptingApi.typeOrCallAction
 import org.testng.annotations.DataProvider
 import org.testng.annotations.Test
 
-@TestEnvironment(coreVersion = CoreVersion.DEFAULT)
+@TestEnvironment(coreVersion = CoreVersion.DOT_NET_CORE_3_1)
 class FSharpTypingAssistTest: TypingAssistTestBase() {
 
     override fun getSolutionDirectoryName(): String = "CoreConsoleApp"


### PR DESCRIPTION
We replace DEFAULT with the LATEST_STABLE, which currently refers to the dotnet 6.0. It should be used in case test is not dependent on the particular SDK version. In all other cases, dotnet version should be specified explicitly, which makes coverage for the given framework visible.

See [RIDER-76457](https://youtrack.jetbrains.com/issue/RIDER-76457).