### PR TITLE
LambdaAnalyzer: check for implicit conversions

### DIFF
--- a/ReSharper.FSharp/src/FSharp.Psi.Daemon/src/Analyzers/LambdaAnalyzer.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Daemon/src/Analyzers/LambdaAnalyzer.fs
@@ -112,7 +112,7 @@ type LambdaAnalyzer() =
                 | _ -> expr.TryGetFcsType()
             | _ -> expr.TryGetFcsType()
 
-        isNotNull exprType &&
+        isNotNull exprType && not exprType.IsUnresolved &&
         not exprType.IsGenericParameter && not lambdaReturnType.IsGenericParameter &&
 
         // TODO: find a better way to compare types, since regular comparison doesn't work in tests

--- a/ReSharper.FSharp/src/FSharp.Psi.Daemon/src/Analyzers/LambdaAnalyzer.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Daemon/src/Analyzers/LambdaAnalyzer.fs
@@ -102,10 +102,10 @@ type LambdaAnalyzer() =
 
         let exprType =
             match expr with
-            | :? IPrefixAppExpr as prefixApp ->
-                match prefixApp.FunctionExpression with
-                | :? IReferenceExpr as reference ->
-                    match reference.Reference.GetFcsSymbol() with
+            | :? IPrefixAppExpr as prefixAppExpr ->
+                match prefixAppExpr.FunctionExpression with
+                | :? IReferenceExpr as referenceExpr ->
+                    match referenceExpr.Reference.GetFcsSymbol() with
                     | :? FSharpMemberOrFunctionOrValue as mfv when mfv.IsMember ->
                         mfv.ReturnParameter.Type
                     | _ -> expr.TryGetFcsType()

--- a/ReSharper.FSharp/src/FSharp.Psi.Daemon/src/Analyzers/LambdaAnalyzer.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Daemon/src/Analyzers/LambdaAnalyzer.fs
@@ -101,7 +101,7 @@ type LambdaAnalyzer() =
             i <- i - 1
 
         let exprType =
-            match expr.IgnoreInnerParens() with
+            match expr with
             | :? IPrefixAppExpr as prefixApp ->
                 match prefixApp.FunctionExpression with
                 | :? IReferenceExpr as reference ->

--- a/ReSharper.FSharp/src/FSharp.Psi.Daemon/src/Analyzers/LambdaAnalyzer.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Daemon/src/Analyzers/LambdaAnalyzer.fs
@@ -120,6 +120,7 @@ type LambdaAnalyzer() =
 
     let tryCreateWarning (ctor: ILambdaExpr * 'a -> #IHighlighting) (lambda: ILambdaExpr, replacementExpr: 'a as arg) isFSharp6Supported =
         if isFSharp6Supported && hasExplicitConversion(lambda) then null else
+
         let lambda = lambda.IgnoreParentParens()
 
         let replacementRefExpr = replacementExpr.As<IFSharpExpression>().IgnoreInnerParens().As<IReferenceExpr>()

--- a/ReSharper.FSharp/src/FSharp.Psi.Daemon/src/Analyzers/LambdaAnalyzer.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Daemon/src/Analyzers/LambdaAnalyzer.fs
@@ -14,6 +14,7 @@ open JetBrains.ReSharper.Plugins.FSharp.Util.FSharpSymbolUtil
 open JetBrains.ReSharper.Psi.ExtensionsAPI
 open JetBrains.ReSharper.Psi.Tree
 open JetBrains.Util
+open JetBrains.ReSharper.Plugins.FSharp.Psi.Util
 
 [<ElementProblemAnalyzer(typeof<ILambdaExpr>,
                          HighlightingTypes = [| typeof<LambdaCanBeReplacedWithBuiltinFunctionWarning>
@@ -85,7 +86,40 @@ type LambdaAnalyzer() =
 
         compareArgsRec expr 0 null
 
+    let hasExplicitConversion (lambda: ILambdaExpr) =
+        let expr = lambda.Expression.IgnoreInnerParens()
+
+        let lambdaType = lambda.TryGetFcsType()
+        if isNull lambdaType then false else
+
+        let lambdaParamsCount = lambda.Patterns.Count
+        let mutable lambdaReturnType = lambdaType
+        let mutable i = lambdaParamsCount
+
+        while i > 0 && lambdaReturnType.IsFunctionType do
+            lambdaReturnType <- lambdaReturnType.GenericArguments[1]
+            i <- i - 1
+
+        let exprType =
+            match expr.IgnoreInnerParens() with
+            | :? IPrefixAppExpr as prefixApp ->
+                match prefixApp.FunctionExpression with
+                | :? IReferenceExpr as reference ->
+                    match reference.Reference.GetFcsSymbol() with
+                    | :? FSharpMemberOrFunctionOrValue as mfv when mfv.IsMember ->
+                        mfv.ReturnParameter.Type
+                    | _ -> expr.TryGetFcsType()
+                | _ -> expr.TryGetFcsType()
+            | _ -> expr.TryGetFcsType()
+
+        isNotNull exprType && not exprType.IsUnresolved &&
+        not exprType.IsGenericParameter && not lambdaReturnType.IsGenericParameter &&
+
+        // TODO: find a better way to compare types, since regular comparison doesn't work in tests
+        exprType.Format(FSharpDisplayContext.Empty) <> lambdaReturnType.Format(FSharpDisplayContext.Empty)
+
     let tryCreateWarning (ctor: ILambdaExpr * 'a -> #IHighlighting) (lambda: ILambdaExpr, replacementExpr: 'a as arg) isFSharp6Supported =
+        if isFSharp6Supported && hasExplicitConversion(lambda) then null else
         let lambda = lambda.IgnoreParentParens()
 
         let replacementRefExpr = replacementExpr.As<IFSharpExpression>().IgnoreInnerParens().As<IReferenceExpr>()

--- a/ReSharper.FSharp/src/FSharp.Psi.Daemon/src/Analyzers/LambdaAnalyzer.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Daemon/src/Analyzers/LambdaAnalyzer.fs
@@ -112,7 +112,7 @@ type LambdaAnalyzer() =
                 | _ -> expr.TryGetFcsType()
             | _ -> expr.TryGetFcsType()
 
-        isNotNull exprType && not exprType.IsUnresolved &&
+        isNotNull exprType &&
         not exprType.IsGenericParameter && not lambdaReturnType.IsGenericParameter &&
 
         // TODO: find a better way to compare types, since regular comparison doesn't work in tests

--- a/ReSharper.FSharp/test/data/features/daemon/lambdaAnalyzer/Implicit conversions.fs
+++ b/ReSharper.FSharp/test/data/features/daemon/lambdaAnalyzer/Implicit conversions.fs
@@ -36,3 +36,4 @@ let _: string = fun x -> x
 
 let f1 x y = 5
 let _: int -> FSharpFunc<int, int> = fun x -> f1 x
+let _: int -> 'a = fun x -> f1 1 x

--- a/ReSharper.FSharp/test/data/features/daemon/lambdaAnalyzer/Implicit conversions.fs
+++ b/ReSharper.FSharp/test/data/features/daemon/lambdaAnalyzer/Implicit conversions.fs
@@ -1,0 +1,38 @@
+module Test
+
+type I =
+    interface
+    end
+
+type T(x) =
+    interface I
+    static member F(x) = T(x)
+    static member F1(x) = T(x) :> I
+    static member Id(x) = x
+
+let f x = T(x)
+let g x : I = T(x)
+
+let _: _ -> I = fun x -> f x
+let _: _ -> I = fun x -> g x
+let _: _ -> I = fun x -> id x
+let _: _ -> I = fun x -> T x
+let _: _ -> I = fun x -> T.F(x)
+let _: _ -> I = fun x -> T.F1(x)
+let _: _ -> I = fun x -> T.Id(x)
+let _: I[] = [||] |> Array.map (fun x -> T(x))
+let _: T[] = [||] |> Array.map (fun x -> T(x))
+let _ = if true then (id: _ -> I) else fun x -> T(x)
+let _ = if true then (id: _ -> I) else fun x -> T.Id(x)
+
+let h x y : I = T(x)
+
+let _: _ -> _ -> I = fun x y -> h x y
+
+
+let _: int -> float = fun x -> x
+let _: string = fun x -> x
+
+
+let f1 x y = 5
+let _: int -> FSharpFunc<int, int> = fun x -> f1 x

--- a/ReSharper.FSharp/test/data/features/daemon/lambdaAnalyzer/Implicit conversions.fs.gold
+++ b/ReSharper.FSharp/test/data/features/daemon/lambdaAnalyzer/Implicit conversions.fs.gold
@@ -36,6 +36,7 @@ let _: string = |fun x -> x|(8)
 
 let f1 x y = 5
 let _: int -> FSharpFunc<int, int> = |fun x -> f1 x|(9)
+let _: int -> 'a = |fun x -> f1 1 x|(10)
 
 ---------------------------------------------------------
 (0): ReSharper Hint: Lambda can be replaced with 'g'
@@ -48,3 +49,4 @@ let _: int -> FSharpFunc<int, int> = |fun x -> f1 x|(9)
 (7): ReSharper Hint: Lambda can be replaced with 'h'
 (8): ReSharper Hint: Lambda can be replaced with 'id'
 (9): ReSharper Hint: Lambda can be replaced with 'f1'
+(10): ReSharper Hint: Lambda can be simplified

--- a/ReSharper.FSharp/test/data/features/daemon/lambdaAnalyzer/Implicit conversions.fs.gold
+++ b/ReSharper.FSharp/test/data/features/daemon/lambdaAnalyzer/Implicit conversions.fs.gold
@@ -1,0 +1,50 @@
+﻿module Test
+
+type I =
+    interface
+    end
+
+type T(x) =
+    interface I
+    static member F(x) = T(x)
+    static member F1(x) = T(x) :> I
+    static member Id(x) = x
+
+let f x = T(x)
+let g x : I = T(x)
+
+let _: _ -> I = fun x -> f x
+let _: _ -> I = |fun x -> g x|(0)
+let _: _ -> I = |fun x -> |id|(2) x|(1)
+let _: _ -> I = fun x -> T x
+let _: _ -> I = fun x -> T.F(x)
+let _: _ -> I = |fun x -> T.F1(x)|(3)
+let _: _ -> I = |fun x -> T.Id(x)|(4)
+let _: I[] = [||] |> Array.map (fun x -> T(x))
+let _: T[] = [||] |> Array.map (|fun x -> T(x)|(5))
+let _ = if true then (id: _ -> I) else fun x -> T(x)
+let _ = if true then (id: _ -> I) else |fun x -> T.Id(x)|(6)
+
+let h x y : I = T(x)
+
+let _: _ -> _ -> I = |fun x y -> h x y|(7)
+
+
+let _: int -> float = fun x -> x
+let _: string = |fun x -> x|(8)
+
+
+let f1 x y = 5
+let _: int -> FSharpFunc<int, int> = |fun x -> f1 x|(9)
+
+---------------------------------------------------------
+(0): ReSharper Hint: Lambda can be replaced with 'g'
+(1): ReSharper Hint: Lambda can be replaced with 'id'
+(2): ReSharper Dead Code: Redundant application
+(3): ReSharper Hint: Lambda can be replaced with 'T.F1'
+(4): ReSharper Hint: Lambda can be replaced with 'T.Id'
+(5): ReSharper Hint: Lambda can be replaced with 'T'
+(6): ReSharper Hint: Lambda can be replaced with 'T.Id'
+(7): ReSharper Hint: Lambda can be replaced with 'h'
+(8): ReSharper Hint: Lambda can be replaced with 'id'
+(9): ReSharper Hint: Lambda can be replaced with 'f1'

--- a/ReSharper.FSharp/test/src/FSharp.Intentions.Tests/src/Daemon/LambdaAnalyzerTest.fs
+++ b/ReSharper.FSharp/test/src/FSharp.Intentions.Tests/src/Daemon/LambdaAnalyzerTest.fs
@@ -31,6 +31,7 @@ type LambdaAnalyzerTest() =
     [<Test>] member x.``Delegates - Not available``() = x.DoNamedTest()
     [<FSharpLanguageLevel(FSharpLanguageLevel.FSharp60)>]
     [<Test>] member x.``Delegates - F# 6``() = x.DoNamedTest()
+    [<Test; Description("RIDER-78171")>] member x.``Implicit conversions``() = x.DoNamedTest()
     [<Test>] member x.``Not available``() = x.DoNamedTest()
     [<Test>] member x.``Overloads 01``() = x.DoNamedTest()
     [<Test>] member x.``Used names - Nested scope``() = x.DoNamedTest()


### PR DESCRIPTION
Fix for [RIDER-78171](https://youtrack.jetbrains.com/issue/RIDER-78171/Lambda-can-be-simplified-lead-to-errors)