### PR TITLE
ConvertTupleToArrayOrListElementsFix: improvement for 'a * 'b

### DIFF
--- a/ReSharper.FSharp/src/FSharp.Psi.Intentions/src/QuickFixes/ConvertTupleToArrayOrListElementsFix.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Intentions/src/QuickFixes/ConvertTupleToArrayOrListElementsFix.fs
@@ -17,7 +17,7 @@ open JetBrains.Util
 type ConvertTupleToArrayOrListElementsFix(warning: TypeEquationError) =
     inherit FSharpQuickFixBase()
 
-    let regex = Regex("[\w\d]*( \* [\w\d]*)+")
+    let regex = Regex("['?\w\d]*( \* ['?\w\d]*)+")
     let expr = warning.Expr
     let actualType = warning.ActualType
     let arrayOrListExpr = ArrayOrListExprNavigator.GetByExpression(expr.IgnoreParentParens())

--- a/ReSharper.FSharp/test/data/features/quickFixes/convertTupleToArrayOrListElements/Array 02.fs
+++ b/ReSharper.FSharp/test/data/features/quickFixes/convertTupleToArrayOrListElements/Array 02.fs
@@ -1,0 +1,2 @@
+let _: int list = [ a, b{caret} ]
+

--- a/ReSharper.FSharp/test/data/features/quickFixes/convertTupleToArrayOrListElements/Array 02.fs.gold
+++ b/ReSharper.FSharp/test/data/features/quickFixes/convertTupleToArrayOrListElements/Array 02.fs.gold
@@ -1,0 +1,2 @@
+﻿let _: int list = [ a; b{caret} ]
+

--- a/ReSharper.FSharp/test/src/FSharp.Intentions.Tests/src/QuickFixes/ConvertTupleToArrayOrListElementsFixTest.fs
+++ b/ReSharper.FSharp/test/src/FSharp.Intentions.Tests/src/QuickFixes/ConvertTupleToArrayOrListElementsFixTest.fs
@@ -11,6 +11,7 @@ type ConvertTupleToArrayOrListElementsFixTest() =
     override x.RelativeTestDataPath = "features/quickFixes/convertTupleToArrayOrListElements"
 
     [<Test>] member x.``Array 01``() = x.DoNamedTest()
+    [<Test>] member x.``Array 02``() = x.DoNamedTest()
 
     [<Test>] member x.``In parens``() = x.DoNamedTest()
     [<Test>] member x.``Large tuple``() = x.DoNamedTest()


### PR DESCRIPTION
Improvement for
https://youtrack.jetbrains.com/issue/RIDER-70854/Improve-Use-separators-quickfix

![image](https://user-images.githubusercontent.com/26364714/206060262-6bf40832-924a-4a66-bc4b-85387e4afd25.png)
