### PR TITLE
LambdaAnalyzer: disable for invocations with optional args

### DIFF
--- a/ReSharper.FSharp/src/FSharp.Psi.Daemon/src/Analyzers/LambdaAnalyzer.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Daemon/src/Analyzers/LambdaAnalyzer.fs
@@ -190,7 +190,7 @@ type LambdaAnalyzer() =
             let memberParamGroups = x.CurriedParameterGroups
             let lambdaPatterns = lambda.Patterns
 
-            let hasOptionalArgsInMember =
+            let memberHasOptionalParams =
                 memberParamGroups.Count = 1 && lambdaPatterns.Count = 1 &&
 
                 let memberTupleParams = memberParamGroups[0]
@@ -202,7 +202,7 @@ type LambdaAnalyzer() =
                 memberTupleParams.Count >= lambdaTupleParamsCount &&
                 memberTupleParams[lambdaTupleParamsCount - 1].IsOptionalArg
 
-            if hasOptionalArgsInMember then null else ctor arg
+            if memberHasOptionalParams then null else ctor arg
         | _ -> ctor arg
 
     let rec containsForcedCalculations (expression: IFSharpExpression) =

--- a/ReSharper.FSharp/src/FSharp.Psi.Daemon/src/Analyzers/LambdaAnalyzer.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Daemon/src/Analyzers/LambdaAnalyzer.fs
@@ -167,6 +167,9 @@ type LambdaAnalyzer() =
 
                 match replacementExprSymbol with
                 | ValueSome (:? FSharpMemberOrFunctionOrValue as x) ->
+                    // If the lambda simplification does not convert it to a method group,
+                    // for example, if the body of the lambda does not consist of a method call,
+                    // then everything is OK
                     x.IsFunction || not x.IsMember ||
 
                     not parameterIsDelegate &&

--- a/ReSharper.FSharp/src/FSharp.Psi.Daemon/src/Analyzers/LambdaAnalyzer.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Daemon/src/Analyzers/LambdaAnalyzer.fs
@@ -139,13 +139,13 @@ type LambdaAnalyzer() =
         let appTuple = TupleExprNavigator.GetByExpression(argExpr)
         let app = getArgsOwner argExpr
 
-        let reference = getReference app
-        if not (app :? IPrefixAppExpr) || isNull reference then ctor arg else
-
-        if isNotNull binaryExpr &&
-           not (hasNamedArgStructure binaryExpr && isTopLevelArg binaryExpr) then ctor arg else
-
         let outerReferenceCheck =
+            let reference = getReference app
+            if not (app :? IPrefixAppExpr) || isNull reference then true else
+
+            if isNotNull binaryExpr &&
+               not (hasNamedArgStructure binaryExpr && isTopLevelArg binaryExpr) then true else
+
             match reference.GetFcsSymbol() with
             | :? FSharpMemberOrFunctionOrValue as m when m.IsMember ->
                 let lambdaPos = if isNotNull appTuple then appTuple.Expressions.IndexOf(argExpr) else 0

--- a/ReSharper.FSharp/src/FSharp.Psi.Daemon/src/Analyzers/LambdaAnalyzer.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Daemon/src/Analyzers/LambdaAnalyzer.fs
@@ -145,7 +145,7 @@ type LambdaAnalyzer() =
         if isNotNull binaryExpr &&
            not (hasNamedArgStructure binaryExpr && isTopLevelArg binaryExpr) then ctor arg else
 
-        let checkOuterReference =
+        let outerReferenceCheck =
             match reference.GetFcsSymbol() with
             | :? FSharpMemberOrFunctionOrValue as m when m.IsMember ->
                 let lambdaPos = if isNotNull appTuple then appTuple.Expressions.IndexOf(argExpr) else 0
@@ -183,7 +183,7 @@ type LambdaAnalyzer() =
                 | _ -> true
             | _ -> true
 
-        if not checkOuterReference then null else
+        if not outerReferenceCheck then null else
 
         match replacementExprSymbol with
         | ValueSome (:? FSharpMemberOrFunctionOrValue as x) when x.IsMember ->

--- a/ReSharper.FSharp/test/data/features/daemon/lambdaAnalyzer/Optional parameters.fs
+++ b/ReSharper.FSharp/test/data/features/daemon/lambdaAnalyzer/Optional parameters.fs
@@ -8,12 +8,22 @@ type C1(_a: int) = class end
 
 
 [(1, 1)] |> List.map (fun (a, b) -> A(a, b))
+let _ = fun (a, b) -> A(a, b)
+
 [(1, 1)] |> List.map (fun (a, b) -> A.M(a, b))
+let _ = fun (a, b) -> A.M(a, b)
+
 [(1, 1)] |> List.map (fun (a, b) -> A.M1(a, b))
+let _ = fun (a, b) -> A.M1(a, b)
+
 [(1, 1)] |> List.map (fun (a, b) (c, d) -> A.M1(c, d))
+let _ = fun (a, b) (c, d) -> A.M1(c, d)
 
 [(1, 1)] |> List.map (fun (a, b) -> A1(a, b))
+let _ = fun (a, b) -> A1(a, b)
 
 [1] |> List.map (fun a -> C(a))
+let _ = fun a -> C(a)
 
 [1] |> List.map (fun a -> C1(a))
+let _ = fun a -> C1(a)

--- a/ReSharper.FSharp/test/data/features/daemon/lambdaAnalyzer/Optional parameters.fs
+++ b/ReSharper.FSharp/test/data/features/daemon/lambdaAnalyzer/Optional parameters.fs
@@ -1,0 +1,18 @@
+type A(_a: int, ?_b: int) =
+    static member M(x, y) = ()
+    static member M1(x, ?y) = ()
+
+type A1(_a: int, _b: int) = class end
+type C(?_a: int) = class end
+type C1(_a: int) = class end
+
+
+[(1, 1)] |> List.map (fun (a, b) -> A(a, b))
+[(1, 1)] |> List.map (fun (a, b) -> A.M(a, b))
+[(1, 1)] |> List.map (fun (a, b) -> A.M1(a, b))
+
+[(1, 1)] |> List.map (fun (a, b) -> A1(a, b))
+
+[1] |> List.map (fun a -> C(a))
+
+[1] |> List.map (fun a -> C1(a))

--- a/ReSharper.FSharp/test/data/features/daemon/lambdaAnalyzer/Optional parameters.fs
+++ b/ReSharper.FSharp/test/data/features/daemon/lambdaAnalyzer/Optional parameters.fs
@@ -10,6 +10,7 @@ type C1(_a: int) = class end
 [(1, 1)] |> List.map (fun (a, b) -> A(a, b))
 [(1, 1)] |> List.map (fun (a, b) -> A.M(a, b))
 [(1, 1)] |> List.map (fun (a, b) -> A.M1(a, b))
+[(1, 1)] |> List.map (fun (a, b) (c, d) -> A.M1(c, d))
 
 [(1, 1)] |> List.map (fun (a, b) -> A1(a, b))
 

--- a/ReSharper.FSharp/test/data/features/daemon/lambdaAnalyzer/Optional parameters.fs.gold
+++ b/ReSharper.FSharp/test/data/features/daemon/lambdaAnalyzer/Optional parameters.fs.gold
@@ -10,6 +10,7 @@ type C1(_a: int) = class end
 [(1, 1)] |> List.map (fun (a, b) -> A(a, b))
 [(1, 1)] |> List.map (|fun (a, b) -> A.M(a, b)|(0))
 [(1, 1)] |> List.map (fun (a, b) -> A.M1(a, b))
+[(1, 1)] |> List.map (fun (a, b) (c, d) -> A.M1(c, d))
 
 [(1, 1)] |> List.map (|fun (a, b) -> A1(a, b)|(1))
 

--- a/ReSharper.FSharp/test/data/features/daemon/lambdaAnalyzer/Optional parameters.fs.gold
+++ b/ReSharper.FSharp/test/data/features/daemon/lambdaAnalyzer/Optional parameters.fs.gold
@@ -8,17 +8,30 @@ type C1(_a: int) = class end
 
 
 [(1, 1)] |> List.map (fun (a, b) -> A(a, b))
-[(1, 1)] |> List.map (|fun (a, b) -> A.M(a, b)|(0))
-[(1, 1)] |> List.map (fun (a, b) -> A.M1(a, b))
-[(1, 1)] |> List.map (fun (a, b) (c, d) -> A.M1(c, d))
+let _ = fun (a, b) -> A(a, b)
 
-[(1, 1)] |> List.map (|fun (a, b) -> A1(a, b)|(1))
+[(1, 1)] |> List.map (|fun (a, b) -> A.M(a, b)|(0))
+let _ = |fun (a, b) -> A.M(a, b)|(1)
+
+[(1, 1)] |> List.map (fun (a, b) -> A.M1(a, b))
+let _ = fun (a, b) -> A.M1(a, b)
+
+[(1, 1)] |> List.map (fun (a, b) (c, d) -> A.M1(c, d))
+let _ = fun (a, b) (c, d) -> A.M1(c, d)
+
+[(1, 1)] |> List.map (|fun (a, b) -> A1(a, b)|(2))
+let _ = |fun (a, b) -> A1(a, b)|(3)
 
 [1] |> List.map (fun a -> C(a))
+let _ = fun a -> C(a)
 
-[1] |> List.map (|fun a -> C1(a)|(2))
+[1] |> List.map (|fun a -> C1(a)|(4))
+let _ = |fun a -> C1(a)|(5)
 
 ---------------------------------------------------------
 (0): ReSharper Hint: Lambda can be replaced with 'A.M'
-(1): ReSharper Hint: Lambda can be replaced with 'A1'
-(2): ReSharper Hint: Lambda can be replaced with 'C1'
+(1): ReSharper Hint: Lambda can be replaced with 'A.M'
+(2): ReSharper Hint: Lambda can be replaced with 'A1'
+(3): ReSharper Hint: Lambda can be replaced with 'A1'
+(4): ReSharper Hint: Lambda can be replaced with 'C1'
+(5): ReSharper Hint: Lambda can be replaced with 'C1'

--- a/ReSharper.FSharp/test/data/features/daemon/lambdaAnalyzer/Optional parameters.fs.gold
+++ b/ReSharper.FSharp/test/data/features/daemon/lambdaAnalyzer/Optional parameters.fs.gold
@@ -1,0 +1,23 @@
+﻿type A(_a: int, ?_b: int) =
+    static member M(x, y) = ()
+    static member M1(x, ?y) = ()
+
+type A1(_a: int, _b: int) = class end
+type C(?_a: int) = class end
+type C1(_a: int) = class end
+
+
+[(1, 1)] |> List.map (fun (a, b) -> A(a, b))
+[(1, 1)] |> List.map (|fun (a, b) -> A.M(a, b)|(0))
+[(1, 1)] |> List.map (fun (a, b) -> A.M1(a, b))
+
+[(1, 1)] |> List.map (|fun (a, b) -> A1(a, b)|(1))
+
+[1] |> List.map (fun a -> C(a))
+
+[1] |> List.map (|fun a -> C1(a)|(2))
+
+---------------------------------------------------------
+(0): ReSharper Hint: Lambda can be replaced with 'A.M'
+(1): ReSharper Hint: Lambda can be replaced with 'A1'
+(2): ReSharper Hint: Lambda can be replaced with 'C1'

--- a/ReSharper.FSharp/test/src/FSharp.Intentions.Tests/src/Daemon/LambdaAnalyzerTest.fs
+++ b/ReSharper.FSharp/test/src/FSharp.Intentions.Tests/src/Daemon/LambdaAnalyzerTest.fs
@@ -36,3 +36,4 @@ type LambdaAnalyzerTest() =
     [<Test>] member x.``Overloads 01``() = x.DoNamedTest()
     [<Test>] member x.``Forced calculations``() = x.DoNamedTest()
     [<Test>] member x.``Used names - Nested scope``() = x.DoNamedTest()
+    [<Test>] member x.``Optional parameters``() = x.DoNamedTest()


### PR DESCRIPTION
Fix for [RIDER-87136](https://youtrack.jetbrains.com/issue/RIDER-87136/False-positive-simplify-lambda)