### PR TITLE
Bump Microsoft.NETCore.Platform

### DIFF
--- a/ReSharper.FSharp/src/FSharp.Fantomas.Host/FSharp.Fantomas.Host.csproj
+++ b/ReSharper.FSharp/src/FSharp.Fantomas.Host/FSharp.Fantomas.Host.csproj
@@ -18,7 +18,7 @@
       <PackageReference Include="FSharp.Core" Version="$(FSharpCoreVersion)" />
       <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
       <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
-      <PackageReference Include="Microsoft.NETCore.Platforms" Version="5.0.0" />
+      <PackageReference Include="Microsoft.NETCore.Platforms" Version="6.0.7" />
       <PackageReference Include="Microsoft.NETCore.Targets" Version="1.1.3" />
     </ItemGroup>
 

--- a/ReSharper.FSharp/src/FSharp.TypeProviders.Host.NetCore/FSharp.TypeProviders.Host.NetCore.csproj
+++ b/ReSharper.FSharp/src/FSharp.TypeProviders.Host.NetCore/FSharp.TypeProviders.Host.NetCore.csproj
@@ -17,7 +17,7 @@
         <PackageReference Include="System.Collections" Version="4.3.0"/>
         <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0"/>
         <PackageReference Include="System.IO.FileSystem" Version="4.3.0"/>
-        <PackageReference Include="Microsoft.NETCore.Platforms" Version="5.0.0"/>
+        <PackageReference Include="Microsoft.NETCore.Platforms" Version="6.0.7"/>
         <PackageReference Include="Microsoft.NETCore.Targets" Version="1.1.0"/>
     </ItemGroup>
 


### PR DESCRIPTION
Since v5.x.x has [vulnerability](https://devhub.checkmarx.com/cve-details/CVE-2021-31957/?utm_source=jetbrains&utm_medium=referral&utm_campaign=rider&utm_term=nuget)
