### PR TITLE
Reformat Kotlin code

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+; Topmost EditorConfig file
+root = true
+
+[*.{java,kt,kts}]
+indent_style = space
+indent_size = 2
+tab_width = 2

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,14 @@
+# List of revisions that are hidden from git blame annotations.
+# This concerns massive code re-formatting, renaming, large changes
+# that were later reverted, etc.
+#
+# Configure your git so that it always ignores the revisions listed
+# in this file:
+#
+#     git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# When adding a new revision to the list, please put its commit message
+# in a comment above it.
+
+# Kotlin: reformat with 2-space indent
+438504eb85f3d1d5e650dbaf22047a45715f22a2

--- a/rider-fsharp/build.gradle.kts
+++ b/rider-fsharp/build.gradle.kts
@@ -9,21 +9,21 @@ import org.jetbrains.kotlin.daemon.common.toHexString
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    id ("com.jetbrains.rdgen") version "2022.3.1"
-    id("org.jetbrains.intellij") version "1.11.0" // https://github.com/JetBrains/gradle-intellij-plugin/releases
-    id("org.jetbrains.grammarkit") version "2021.2.2"
-    id("me.filippov.gradle.jvm.wrapper") version "0.14.0"
-    kotlin("jvm") version "1.7.0"
+  id("com.jetbrains.rdgen") version "2022.3.1"
+  id("org.jetbrains.intellij") version "1.11.0" // https://github.com/JetBrains/gradle-intellij-plugin/releases
+  id("org.jetbrains.grammarkit") version "2021.2.2"
+  id("me.filippov.gradle.jvm.wrapper") version "0.14.0"
+  kotlin("jvm") version "1.7.0"
 }
 
 apply {
-    plugin("kotlin")
+  plugin("kotlin")
 }
 
 repositories {
-    mavenCentral()
-    maven("https://cache-redirector.jetbrains.com/repo1.maven.org/maven2")
-    maven("https://cache-redirector.jetbrains.com/intellij-dependencies")
+  mavenCentral()
+  maven("https://cache-redirector.jetbrains.com/repo1.maven.org/maven2")
+  maven("https://cache-redirector.jetbrains.com/intellij-dependencies")
 }
 
 val baseVersion = "2023.1"
@@ -31,38 +31,38 @@ val buildCounter = ext.properties["build.number"] ?: "9999"
 version = "$baseVersion.$buildCounter"
 
 intellij {
-    type.set("RD")
+  type.set("RD")
 
-    // Download a version of Rider to compile and run with. Either set `version` to
-    // 'LATEST-TRUNK-SNAPSHOT' or 'LATEST-EAP-SNAPSHOT' or a known version.
-    // This will download from www.jetbrains.com/intellij-repository/snapshots or
-    // www.jetbrains.com/intellij-repository/releases, respectively.
-    // Note that there's no guarantee that these are kept up-to-date
-    // version = 'LATEST-TRUNK-SNAPSHOT'
-    // If the build isn't available in intellij-repository, use an installed version via `localPath`
-    // localPath = '/Users/matt/Library/Application Support/JetBrains/Toolbox/apps/Rider/ch-1/171.4089.265/Rider EAP.app/Contents'
-    // localPath = "C:\\Users\\Ivan.Shakhov\\AppData\\Local\\JetBrains\\Toolbox\\apps\\Rider\\ch-0\\171.4456.459"
-    // localPath = "C:\\Users\\ivan.pashchenko\\AppData\\Local\\JetBrains\\Toolbox\\apps\\Rider\\ch-0\\dev"
-    // localPath 'build/riderRD-173-SNAPSHOT'
+  // Download a version of Rider to compile and run with. Either set `version` to
+  // 'LATEST-TRUNK-SNAPSHOT' or 'LATEST-EAP-SNAPSHOT' or a known version.
+  // This will download from www.jetbrains.com/intellij-repository/snapshots or
+  // www.jetbrains.com/intellij-repository/releases, respectively.
+  // Note that there's no guarantee that these are kept up-to-date
+  // version = 'LATEST-TRUNK-SNAPSHOT'
+  // If the build isn't available in intellij-repository, use an installed version via `localPath`
+  // localPath = '/Users/matt/Library/Application Support/JetBrains/Toolbox/apps/Rider/ch-1/171.4089.265/Rider EAP.app/Contents'
+  // localPath = "C:\\Users\\Ivan.Shakhov\\AppData\\Local\\JetBrains\\Toolbox\\apps\\Rider\\ch-0\\171.4456.459"
+  // localPath = "C:\\Users\\ivan.pashchenko\\AppData\\Local\\JetBrains\\Toolbox\\apps\\Rider\\ch-0\\dev"
+  // localPath 'build/riderRD-173-SNAPSHOT'
 
-    val dir = file("build/rider")
-    if (dir.exists()) {
-        logger.lifecycle("*** Using Rider SDK from local path " + dir.absolutePath)
-        localPath.set(dir.absolutePath)
-    } else {
-        logger.lifecycle("*** Using Rider SDK from intellij-snapshots repository")
-        version.set("$baseVersion-SNAPSHOT")
-    }
+  val dir = file("build/rider")
+  if (dir.exists()) {
+    logger.lifecycle("*** Using Rider SDK from local path " + dir.absolutePath)
+    localPath.set(dir.absolutePath)
+  } else {
+    logger.lifecycle("*** Using Rider SDK from intellij-snapshots repository")
+    version.set("$baseVersion-SNAPSHOT")
+  }
 
-    instrumentCode.set(false)
-    downloadSources.set(false)
+  instrumentCode.set(false)
+  downloadSources.set(false)
 
-    // Uncomment when need to install plugin into a different IDE build.
-    // updateSinceUntilBuild = false
+  // Uncomment when need to install plugin into a different IDE build.
+  // updateSinceUntilBuild = false
 
-    // rider-plugins-appender: workaround for https://youtrack.jetbrains.com/issue/IDEA-179607
-    // org.intellij.intelliLang needed for tests with language injection marks
-    plugins.set(listOf("rider-plugins-appender", "org.intellij.intelliLang"))
+  // rider-plugins-appender: workaround for https://youtrack.jetbrains.com/issue/IDEA-179607
+  // org.intellij.intelliLang needed for tests with language injection marks
+  plugins.set(listOf("rider-plugins-appender", "org.intellij.intelliLang"))
 }
 
 val repoRoot = projectDir.parentFile!!
@@ -76,39 +76,43 @@ val primaryTargetFramework = "net472"
 val outputRelativePath = "bin/$buildConfiguration/$primaryTargetFramework"
 
 val libFiles = listOf(
-        "FSharp.Common/$outputRelativePath/FSharp.Core.dll",
-        "FSharp.Common/$outputRelativePath/FSharp.Core.xml",
-        "FSharp.Common/$outputRelativePath/FSharp.Compiler.Service.dll", // todo: add pdb after next repack
-        "FSharp.Common/$outputRelativePath/FSharp.DependencyManager.Nuget.dll",
-        "FSharp.Common/$outputRelativePath/FSharp.Compiler.Interactive.Settings.dll")
+  "FSharp.Common/$outputRelativePath/FSharp.Core.dll",
+  "FSharp.Common/$outputRelativePath/FSharp.Core.xml",
+  "FSharp.Common/$outputRelativePath/FSharp.Compiler.Service.dll", // todo: add pdb after next repack
+  "FSharp.Common/$outputRelativePath/FSharp.DependencyManager.Nuget.dll",
+  "FSharp.Common/$outputRelativePath/FSharp.Compiler.Interactive.Settings.dll"
+)
 
 val pluginFiles = listOf(
-        "FSharp.ProjectModelBase/$outputRelativePath/JetBrains.ReSharper.Plugins.FSharp.ProjectModelBase",
-        "FSharp.Common/$outputRelativePath/JetBrains.ReSharper.Plugins.FSharp.Common",
-        "FSharp.Psi/$outputRelativePath/JetBrains.ReSharper.Plugins.FSharp.Psi",
-        "FSharp.Psi.Services/$outputRelativePath/JetBrains.ReSharper.Plugins.FSharp.Psi.Services",
-        "FSharp.Psi.Daemon/$outputRelativePath/JetBrains.ReSharper.Plugins.FSharp.Psi.Daemon",
-        "FSharp.Psi.Intentions/$outputRelativePath/JetBrains.ReSharper.Plugins.FSharp.Psi.Intentions",
-        "FSharp.Psi.Features/$outputRelativePath/JetBrains.ReSharper.Plugins.FSharp.Psi.Features",
-        "FSharp.Fantomas.Protocol/$outputRelativePath/JetBrains.ReSharper.Plugins.FSharp.Fantomas.Protocol",
-        "FSharp.TypeProviders.Protocol/$outputRelativePath/JetBrains.ReSharper.Plugins.FSharp.TypeProviders.Protocol")
+  "FSharp.ProjectModelBase/$outputRelativePath/JetBrains.ReSharper.Plugins.FSharp.ProjectModelBase",
+  "FSharp.Common/$outputRelativePath/JetBrains.ReSharper.Plugins.FSharp.Common",
+  "FSharp.Psi/$outputRelativePath/JetBrains.ReSharper.Plugins.FSharp.Psi",
+  "FSharp.Psi.Services/$outputRelativePath/JetBrains.ReSharper.Plugins.FSharp.Psi.Services",
+  "FSharp.Psi.Daemon/$outputRelativePath/JetBrains.ReSharper.Plugins.FSharp.Psi.Daemon",
+  "FSharp.Psi.Intentions/$outputRelativePath/JetBrains.ReSharper.Plugins.FSharp.Psi.Intentions",
+  "FSharp.Psi.Features/$outputRelativePath/JetBrains.ReSharper.Plugins.FSharp.Psi.Features",
+  "FSharp.Fantomas.Protocol/$outputRelativePath/JetBrains.ReSharper.Plugins.FSharp.Fantomas.Protocol",
+  "FSharp.TypeProviders.Protocol/$outputRelativePath/JetBrains.ReSharper.Plugins.FSharp.TypeProviders.Protocol"
+)
 
 val typeProvidersFiles = listOf(
-        "FSharp.TypeProviders.Host/$outputRelativePath/JetBrains.ReSharper.Plugins.FSharp.TypeProviders.Host.exe",
-        "FSharp.TypeProviders.Host/$outputRelativePath/JetBrains.ReSharper.Plugins.FSharp.TypeProviders.Host.pdb",
-        "FSharp.TypeProviders.Host/$outputRelativePath/JetBrains.ReSharper.Plugins.FSharp.TypeProviders.Host.exe.config",
-        "FSharp.TypeProviders.Host.NetCore/bin/$buildConfiguration/netcoreapp3.1/JetBrains.ReSharper.Plugins.FSharp.TypeProviders.Host.NetCore.dll",
-        "FSharp.TypeProviders.Host.NetCore/bin/$buildConfiguration/netcoreapp3.1/JetBrains.ReSharper.Plugins.FSharp.TypeProviders.Host.NetCore.pdb",
-        "FSharp.TypeProviders.Host.NetCore/bin/$buildConfiguration/netcoreapp3.1/tploader.win.runtimeconfig.json",
-        "FSharp.TypeProviders.Host.NetCore/bin/$buildConfiguration/netcoreapp3.1/tploader.unix.runtimeconfig.json")
+  "FSharp.TypeProviders.Host/$outputRelativePath/JetBrains.ReSharper.Plugins.FSharp.TypeProviders.Host.exe",
+  "FSharp.TypeProviders.Host/$outputRelativePath/JetBrains.ReSharper.Plugins.FSharp.TypeProviders.Host.pdb",
+  "FSharp.TypeProviders.Host/$outputRelativePath/JetBrains.ReSharper.Plugins.FSharp.TypeProviders.Host.exe.config",
+  "FSharp.TypeProviders.Host.NetCore/bin/$buildConfiguration/netcoreapp3.1/JetBrains.ReSharper.Plugins.FSharp.TypeProviders.Host.NetCore.dll",
+  "FSharp.TypeProviders.Host.NetCore/bin/$buildConfiguration/netcoreapp3.1/JetBrains.ReSharper.Plugins.FSharp.TypeProviders.Host.NetCore.pdb",
+  "FSharp.TypeProviders.Host.NetCore/bin/$buildConfiguration/netcoreapp3.1/tploader.win.runtimeconfig.json",
+  "FSharp.TypeProviders.Host.NetCore/bin/$buildConfiguration/netcoreapp3.1/tploader.unix.runtimeconfig.json"
+)
 
 val fantomasFiles = listOf(
-        "FSharp.Fantomas.Host/bin/$buildConfiguration/net6.0/Fantomas.FCS.dll",
-        "FSharp.Fantomas.Host/bin/$buildConfiguration/net6.0/Fantomas.Core.dll",
-        "FSharp.Fantomas.Host/bin/$buildConfiguration/net6.0/JetBrains.ReSharper.Plugins.FSharp.Fantomas.Host.dll",
-        "FSharp.Fantomas.Host/bin/$buildConfiguration/net6.0/JetBrains.ReSharper.Plugins.FSharp.Fantomas.Host.pdb",
-        "FSharp.Fantomas.Host/bin/$buildConfiguration/net6.0/Fantomas.Host.win.runtimeconfig.json",
-        "FSharp.Fantomas.Host/bin/$buildConfiguration/net6.0/Fantomas.Host.unix.runtimeconfig.json")
+  "FSharp.Fantomas.Host/bin/$buildConfiguration/net6.0/Fantomas.FCS.dll",
+  "FSharp.Fantomas.Host/bin/$buildConfiguration/net6.0/Fantomas.Core.dll",
+  "FSharp.Fantomas.Host/bin/$buildConfiguration/net6.0/JetBrains.ReSharper.Plugins.FSharp.Fantomas.Host.dll",
+  "FSharp.Fantomas.Host/bin/$buildConfiguration/net6.0/JetBrains.ReSharper.Plugins.FSharp.Fantomas.Host.pdb",
+  "FSharp.Fantomas.Host/bin/$buildConfiguration/net6.0/Fantomas.Host.win.runtimeconfig.json",
+  "FSharp.Fantomas.Host/bin/$buildConfiguration/net6.0/Fantomas.Host.unix.runtimeconfig.json"
+)
 
 val nugetConfigPath = File(repoRoot, "NuGet.Config")
 val dotNetSdkPathPropsPath = File("build", "DotNetSdkPath.generated.props")
@@ -117,256 +121,256 @@ val backendLexerSources = "$repoRoot/rider-fsharp/build/backend-lexer-sources/"
 val riderFSharpTargetsGroup = "rider-fsharp"
 
 fun File.writeTextIfChanged(content: String) {
-    val bytes = content.toByteArray()
+  val bytes = content.toByteArray()
 
-    if (!exists() || readBytes().toHexString() != bytes.toHexString()) {
-        println("Writing $path")
-        writeBytes(bytes)
-    }
+  if (!exists() || readBytes().toHexString() != bytes.toHexString()) {
+    println("Writing $path")
+    writeBytes(bytes)
+  }
 }
 
 tasks {
-    val dotNetSdkPath by lazy {
-        val sdkPath = setupDependencies.get().idea.get().classes.resolve("lib").resolve("DotNetSdkForRdPlugins")
-        if (sdkPath.isDirectory.not()) error("$sdkPath does not exist or not a directory")
+  val dotNetSdkPath by lazy {
+    val sdkPath = setupDependencies.get().idea.get().classes.resolve("lib").resolve("DotNetSdkForRdPlugins")
+    if (sdkPath.isDirectory.not()) error("$sdkPath does not exist or not a directory")
 
-        println("SDK path: $sdkPath")
-        return@lazy sdkPath
+    println("SDK path: $sdkPath")
+    return@lazy sdkPath
+  }
+
+  configure<RdGenExtension> {
+    val csOutput = File(repoRoot, "ReSharper.FSharp/src/FSharp.ProjectModelBase/src/Protocol")
+    val ktOutput = File(repoRoot, "rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/protocol")
+
+    val typeProviderClientOutput = File(repoRoot, "ReSharper.FSharp/src/FSharp.TypeProviders.Protocol/src/Client")
+    val typeProviderServerOutput = File(repoRoot, "ReSharper.FSharp/src/FSharp.TypeProviders.Protocol/src/Server")
+
+    val fantomasServerOutput = File(repoRoot, "ReSharper.FSharp/src/FSharp.Fantomas.Protocol/src/Server")
+    val fantomasClientOutput = File(repoRoot, "ReSharper.FSharp/src/FSharp.Fantomas.Protocol/src/Client")
+
+    verbose = true
+    hashFolder = "build/rdgen"
+    logger.info("Configuring rdgen params")
+    classpath({
+      logger.info("Calculating classpath for rdgen, intellij.ideaDependency is ${rdLibDirectory().canonicalPath}")
+      rdLibDirectory().resolve("rider-model.jar").canonicalPath
+    })
+    sources(File(repoRoot, "rider-fsharp/protocol/src/kotlin/model"))
+    packages = "model"
+
+    generator {
+      language = "kotlin"
+      transform = "asis"
+      root = "com.jetbrains.rider.model.nova.ide.IdeRoot"
+      namespace = "com.jetbrains.rider.model"
+      directory = "$ktOutput"
     }
 
-    configure<RdGenExtension> {
-        val csOutput = File(repoRoot, "ReSharper.FSharp/src/FSharp.ProjectModelBase/src/Protocol")
-        val ktOutput = File(repoRoot, "rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/protocol")
-
-        val typeProviderClientOutput = File(repoRoot, "ReSharper.FSharp/src/FSharp.TypeProviders.Protocol/src/Client")
-        val typeProviderServerOutput = File(repoRoot, "ReSharper.FSharp/src/FSharp.TypeProviders.Protocol/src/Server")
-
-        val fantomasServerOutput = File(repoRoot, "ReSharper.FSharp/src/FSharp.Fantomas.Protocol/src/Server")
-        val fantomasClientOutput = File(repoRoot, "ReSharper.FSharp/src/FSharp.Fantomas.Protocol/src/Client")
-
-        verbose = true
-        hashFolder = "build/rdgen"
-        logger.info("Configuring rdgen params")
-        classpath({
-            logger.info("Calculating classpath for rdgen, intellij.ideaDependency is ${rdLibDirectory().canonicalPath}")
-            rdLibDirectory().resolve("rider-model.jar").canonicalPath
-        })
-        sources(File(repoRoot, "rider-fsharp/protocol/src/kotlin/model"))
-        packages = "model"
-
-        generator {
-            language = "kotlin"
-            transform = "asis"
-            root = "com.jetbrains.rider.model.nova.ide.IdeRoot"
-            namespace = "com.jetbrains.rider.model"
-            directory = "$ktOutput"
-        }
-
-        generator {
-            language = "csharp"
-            transform = "reversed"
-            root = "com.jetbrains.rider.model.nova.ide.IdeRoot"
-            namespace = "JetBrains.Rider.Model"
-            directory = "$csOutput"
-        }
-
-        generator {
-            language = "csharp"
-            transform = "asis"
-            root = "model.RdFSharpTypeProvidersModel"
-            namespace = "JetBrains.Rider.FSharp.TypeProviders.Protocol.Client"
-            directory = "$typeProviderClientOutput"
-        }
-        generator {
-            language = "csharp"
-            transform = "reversed"
-            root = "model.RdFSharpTypeProvidersModel"
-            namespace = "JetBrains.Rider.FSharp.TypeProviders.Protocol.Server"
-            directory = "$typeProviderServerOutput"
-        }
-
-        generator {
-            language = "csharp"
-            transform = "asis"
-            root = "model.RdFantomasModel"
-            namespace = "JetBrains.ReSharper.Plugins.FSharp.Fantomas.Client"
-            directory = "$fantomasClientOutput"
-        }
-        generator {
-            language = "csharp"
-            transform = "reversed"
-            root = "model.RdFantomasModel"
-            namespace = "JetBrains.ReSharper.Plugins.FSharp.Fantomas.Server"
-            directory = "$fantomasServerOutput"
-        }
+    generator {
+      language = "csharp"
+      transform = "reversed"
+      root = "com.jetbrains.rider.model.nova.ide.IdeRoot"
+      namespace = "JetBrains.Rider.Model"
+      directory = "$csOutput"
     }
 
-    withType<IntelliJInstrumentCodeTask> {
-        val bundledMavenArtifacts = file("build/maven-artifacts")
-        if (bundledMavenArtifacts.exists()) {
-            logger.lifecycle("Use ant compiler artifacts from local folder: $bundledMavenArtifacts")
-            compilerClassPathFromMaven.set(
-                bundledMavenArtifacts.walkTopDown()
-                    .filter { it.extension == "jar" && !it.name.endsWith("-sources.jar") }
-                    .toList() + File("${ideaDependency.get().classes}/lib/util.jar")
-            )
-        } else {
-            logger.lifecycle("Use ant compiler artifacts from maven")
-        }
+    generator {
+      language = "csharp"
+      transform = "asis"
+      root = "model.RdFSharpTypeProvidersModel"
+      namespace = "JetBrains.Rider.FSharp.TypeProviders.Protocol.Client"
+      directory = "$typeProviderClientOutput"
+    }
+    generator {
+      language = "csharp"
+      transform = "reversed"
+      root = "model.RdFSharpTypeProvidersModel"
+      namespace = "JetBrains.Rider.FSharp.TypeProviders.Protocol.Server"
+      directory = "$typeProviderServerOutput"
     }
 
-    withType<PrepareSandboxTask> {
-        var files = libFiles + pluginFiles.map { "$it.dll" } + pluginFiles.map { "$it.pdb" }
-        files = files.map { "$resharperPluginPath/src/$it" }
-        val fantomasFiles = fantomasFiles.map { "$resharperPluginPath/src/$it" }
-        val typeProvidersFiles = typeProvidersFiles.map { "$resharperPluginPath/src/$it" }
+    generator {
+      language = "csharp"
+      transform = "asis"
+      root = "model.RdFantomasModel"
+      namespace = "JetBrains.ReSharper.Plugins.FSharp.Fantomas.Client"
+      directory = "$fantomasClientOutput"
+    }
+    generator {
+      language = "csharp"
+      transform = "reversed"
+      root = "model.RdFantomasModel"
+      namespace = "JetBrains.ReSharper.Plugins.FSharp.Fantomas.Server"
+      directory = "$fantomasServerOutput"
+    }
+  }
 
-        if (name == IntelliJPluginConstants.PREPARE_TESTING_SANDBOX_TASK_NAME) {
-            val testHostPath = "$resharperPluginPath/test/src/FSharp.Tests.Host/$outputRelativePath"
-            val testHostName = "$testHostPath/JetBrains.ReSharper.Plugins.FSharp.Tests.Host"
-            files = files + listOf("$testHostName.dll", "$testHostName.pdb")
-        }
+  withType<IntelliJInstrumentCodeTask> {
+    val bundledMavenArtifacts = file("build/maven-artifacts")
+    if (bundledMavenArtifacts.exists()) {
+      logger.lifecycle("Use ant compiler artifacts from local folder: $bundledMavenArtifacts")
+      compilerClassPathFromMaven.set(
+        bundledMavenArtifacts.walkTopDown()
+          .filter { it.extension == "jar" && !it.name.endsWith("-sources.jar") }
+          .toList() + File("${ideaDependency.get().classes}/lib/util.jar")
+      )
+    } else {
+      logger.lifecycle("Use ant compiler artifacts from maven")
+    }
+  }
 
-        fun moveToPlugin(files: List<String>, destinationFolder: String) {
-            files.forEach {
-                from(it) { into("${intellij.pluginName.get()}/$destinationFolder") }
-            }
-        }
+  withType<PrepareSandboxTask> {
+    var files = libFiles + pluginFiles.map { "$it.dll" } + pluginFiles.map { "$it.pdb" }
+    files = files.map { "$resharperPluginPath/src/$it" }
+    val fantomasFiles = fantomasFiles.map { "$resharperPluginPath/src/$it" }
+    val typeProvidersFiles = typeProvidersFiles.map { "$resharperPluginPath/src/$it" }
 
-        moveToPlugin(files, "dotnet")
-        moveToPlugin(fantomasFiles, "fantomas")
-        moveToPlugin(typeProvidersFiles, "typeProviders")
-        moveToPlugin(listOf("projectTemplates"), "projectTemplates")
-
-        doLast {
-            fun validateFiles(files: List<String>, destinationFolder: String) {
-                files.forEach {
-                    val file = file(it)
-                    if (!file.exists()) throw RuntimeException("File $file does not exist")
-                    logger.warn("$name: ${file.name} -> $destinationDir/${intellij.pluginName.get()}/$destinationFolder")
-                }
-            }
-            validateFiles(files, "dotnet")
-            validateFiles(fantomasFiles, "fantomas")
-            validateFiles(typeProvidersFiles, "typeProviders")
-        }
+    if (name == IntelliJPluginConstants.PREPARE_TESTING_SANDBOX_TASK_NAME) {
+      val testHostPath = "$resharperPluginPath/test/src/FSharp.Tests.Host/$outputRelativePath"
+      val testHostName = "$testHostPath/JetBrains.ReSharper.Plugins.FSharp.Tests.Host"
+      files = files + listOf("$testHostName.dll", "$testHostName.pdb")
     }
 
-    // Initially introduced in:
-    // https://github.com/JetBrains/ForTea/blob/master/Frontend/build.gradle.kts
-    withType<RunIdeTask> {
-        // Match Rider's default heap size of 1.5Gb (default for runIde is 512Mb)
-        maxHeapSize = "1500m"
+    fun moveToPlugin(files: List<String>, destinationFolder: String) {
+      files.forEach {
+        from(it) { into("${intellij.pluginName.get()}/$destinationFolder") }
+      }
     }
 
-    val resetLexerDirectory = create("resetLexerDirectory") {
-        doFirst {
-            File(backendLexerSources).deleteRecursively()
-            File(backendLexerSources).mkdirs()
+    moveToPlugin(files, "dotnet")
+    moveToPlugin(fantomasFiles, "fantomas")
+    moveToPlugin(typeProvidersFiles, "typeProviders")
+    moveToPlugin(listOf("projectTemplates"), "projectTemplates")
+
+    doLast {
+      fun validateFiles(files: List<String>, destinationFolder: String) {
+        files.forEach {
+          val file = file(it)
+          if (!file.exists()) throw RuntimeException("File $file does not exist")
+          logger.warn("$name: ${file.name} -> $destinationDir/${intellij.pluginName.get()}/$destinationFolder")
         }
+      }
+      validateFiles(files, "dotnet")
+      validateFiles(fantomasFiles, "fantomas")
+      validateFiles(typeProvidersFiles, "typeProviders")
+    }
+  }
+
+  // Initially introduced in:
+  // https://github.com/JetBrains/ForTea/blob/master/Frontend/build.gradle.kts
+  withType<RunIdeTask> {
+    // Match Rider's default heap size of 1.5Gb (default for runIde is 512Mb)
+    maxHeapSize = "1500m"
+  }
+
+  val resetLexerDirectory = create("resetLexerDirectory") {
+    doFirst {
+      File(backendLexerSources).deleteRecursively()
+      File(backendLexerSources).mkdirs()
+    }
+  }
+
+  // Cannot use ordinary copy here, because it requires eager evaluation of locations
+  val copyUnicodeLex = create("copyUnicodeLex") {
+    dependsOn(resetLexerDirectory)
+    doFirst {
+      val libPath = File("$dotNetSdkPath").parent
+      File(libPath, "ReSharperHost/PsiTasks").listFiles { it -> it.extension == "lex" }!!.forEach {
+        println(it)
+        it.copyTo(File(backendLexerSources, it.name))
+      }
+    }
+  }
+
+  val copyBackendLexerSources = create<Copy>("copyBackendLexerSources") {
+    dependsOn(resetLexerDirectory)
+    from("$resharperPluginPath/src/FSharp.Psi/src/Parsing/Lexing") {
+      include("*.lex")
+    }
+    into(backendLexerSources)
+  }
+
+  val generateFSharpLexer = task<GenerateLexerTask>("generateFSharpLexer") {
+    dependsOn(copyBackendLexerSources, copyUnicodeLex)
+    source.set("src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/lexer/_FSharpLexer.flex")
+    targetDir.set("src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/lexer")
+    targetClass.set("_FSharpLexer")
+    purgeOldFiles.set(true)
+  }
+
+  withType<KotlinCompile> {
+    kotlinOptions.jvmTarget = "17"
+    dependsOn(generateFSharpLexer, rdgen)
+  }
+
+  withType<Test> {
+    useTestNG {
+      groupByInstances = true
     }
 
-    // Cannot use ordinary copy here, because it requires eager evaluation of locations
-    val copyUnicodeLex = create("copyUnicodeLex") {
-        dependsOn(resetLexerDirectory)
-        doFirst {
-            val libPath = File("$dotNetSdkPath").parent
-            File(libPath, "ReSharperHost/PsiTasks").listFiles { it -> it.extension == "lex" }!!.forEach {
-                println(it)
-                it.copyTo(File(backendLexerSources, it.name))
-            }
-        }
+    testLogging {
+      showStandardStreams = true
+      exceptionFormat = TestExceptionFormat.FULL
     }
+    val rerunSuccessfulTests = false
+    outputs.upToDateWhen { !rerunSuccessfulTests }
+    ignoreFailures = true
+  }
 
-    val copyBackendLexerSources = create<Copy>("copyBackendLexerSources") {
-        dependsOn(resetLexerDirectory)
-        from("$resharperPluginPath/src/FSharp.Psi/src/Parsing/Lexing") {
-            include("*.lex")
-        }
-        into(backendLexerSources)
-    }
-
-    val generateFSharpLexer = task<GenerateLexerTask>("generateFSharpLexer") {
-        dependsOn(copyBackendLexerSources, copyUnicodeLex)
-        source.set("src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/lexer/_FSharpLexer.flex")
-        targetDir.set("src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/lexer")
-        targetClass.set("_FSharpLexer")
-        purgeOldFiles.set(true)
-    }
-
-    withType<KotlinCompile> {
-        kotlinOptions.jvmTarget = "17"
-        dependsOn(generateFSharpLexer, rdgen)
-    }
-
-    withType<Test> {
-        useTestNG {
-            groupByInstances = true
-        }
-
-        testLogging {
-            showStandardStreams = true
-            exceptionFormat = TestExceptionFormat.FULL
-        }
-        val rerunSuccessfulTests = false
-        outputs.upToDateWhen { !rerunSuccessfulTests }
-        ignoreFailures = true
-    }
-
-    val writeDotNetSdkPathProps = create("writeDotNetSdkPathProps") {
-        group = riderFSharpTargetsGroup
-        doLast {
-            dotNetSdkPathPropsPath.writeTextIfChanged(
-                """<Project>
+  val writeDotNetSdkPathProps = create("writeDotNetSdkPathProps") {
+    group = riderFSharpTargetsGroup
+    doLast {
+      dotNetSdkPathPropsPath.writeTextIfChanged(
+        """<Project>
   <PropertyGroup>
     <DotNetSdkPath>$dotNetSdkPath</DotNetSdkPath>
   </PropertyGroup>
 </Project>
 """
-            )
-        }
-
-        getByName("buildSearchableOptions") {
-            enabled = buildConfiguration == "Release"
-        }
+      )
     }
 
-    val writeNuGetConfig = create("writeNuGetConfig") {
-        group = riderFSharpTargetsGroup
-        doLast {
-            nugetConfigPath.writeTextIfChanged(
-                """<?xml version="1.0" encoding="utf-8"?>
+    getByName("buildSearchableOptions") {
+      enabled = buildConfiguration == "Release"
+    }
+  }
+
+  val writeNuGetConfig = create("writeNuGetConfig") {
+    group = riderFSharpTargetsGroup
+    doLast {
+      nugetConfigPath.writeTextIfChanged(
+        """<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
     <add key="resharper-sdk" value="$dotNetSdkPath" />
   </packageSources>
 </configuration>
 """
-            )
-        }
+      )
     }
+  }
 
-    named("assemble") {
-        doLast {
-            logger.lifecycle("Plugin version: $version")
-            logger.lifecycle("##teamcity[buildNumber '$version']")
-        }
+  named("assemble") {
+    doLast {
+      logger.lifecycle("Plugin version: $version")
+      logger.lifecycle("##teamcity[buildNumber '$version']")
     }
+  }
 
-    val prepare = create("prepare") {
-        group = riderFSharpTargetsGroup
-        dependsOn(rdgen, writeNuGetConfig, writeDotNetSdkPathProps)
-    }
+  val prepare = create("prepare") {
+    group = riderFSharpTargetsGroup
+    dependsOn(rdgen, writeNuGetConfig, writeDotNetSdkPathProps)
+  }
 
-    create("buildReSharperPlugin") {
-        group = riderFSharpTargetsGroup
-        dependsOn(prepare)
-        doLast {
-            exec {
-                executable = "msbuild"
-                args = listOf("$resharperPluginPath/ReSharper.FSharp.sln")
-            }
-        }
+  create("buildReSharperPlugin") {
+    group = riderFSharpTargetsGroup
+    dependsOn(prepare)
+    doLast {
+      exec {
+        executable = "msbuild"
+        args = listOf("$resharperPluginPath/ReSharper.FSharp.sln")
+      }
     }
-    defaultTasks(prepare)
+  }
+  defaultTasks(prepare)
 }

--- a/rider-fsharp/protocol/build.gradle.kts
+++ b/rider-fsharp/protocol/build.gradle.kts
@@ -1,31 +1,31 @@
 plugins {
-    id("org.jetbrains.kotlin.jvm")
+  id("org.jetbrains.kotlin.jvm")
 }
 
 val rdLibDirectory: () -> File by rootProject.extra
 
 repositories {
-    mavenCentral()
-    maven { setUrl("https://cache-redirector.jetbrains.com/maven-central") }
-    flatDir {
-        dir(rdLibDirectory())
-    }
+  mavenCentral()
+  maven { setUrl("https://cache-redirector.jetbrains.com/maven-central") }
+  flatDir {
+    dir(rdLibDirectory())
+  }
 }
 
 tasks {
-    withType<JavaCompile> {
-        sourceSets {
-            main {
-                java {
-                    srcDir("src/kotlin/model")
-                }
-            }
+  withType<JavaCompile> {
+    sourceSets {
+      main {
+        java {
+          srcDir("src/kotlin/model")
         }
+      }
     }
+  }
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlin:kotlin-stdlib")
-    implementation(group = "", name = "rd-gen")
-    implementation(group = "", name = "rider-model")
+  implementation("org.jetbrains.kotlin:kotlin-stdlib")
+  implementation(group = "", name = "rd-gen")
+  implementation(group = "", name = "rider-model")
 }

--- a/rider-fsharp/protocol/src/kotlin/model/RdFSharpModel.kt
+++ b/rider-fsharp/protocol/src/kotlin/model/RdFSharpModel.kt
@@ -9,64 +9,64 @@ import com.jetbrains.rd.generator.nova.kotlin.Kotlin11Generator
 @Suppress("unused")
 object RdFSharpModel : Ext(SolutionModel.Solution) {
 
-    private val fsiRuntime = enum("RdFsiRuntime") {
-        +"NetFramework"
-        +"Mono"
-        +"Core"
-    }
+  private val fsiRuntime = enum("RdFsiRuntime") {
+    +"NetFramework"
+    +"Mono"
+    +"Core"
+  }
 
-    private val RdFSharpInteractiveHost = aggregatedef("RdFSharpInteractiveHost") {
-        call("requestNewFsiSessionInfo", void, structdef("RdFsiSessionInfo") {
-            field("fsiPath", string)
-            field("runtime", fsiRuntime)
-            field("isCustomTool", bool)
-            field("args", immutableList(string))
-            field("fixArgsForAttach", bool)
-        })
-        call("getProjectReferences", int, immutableList(string))
-        field("fsiTools", aggregatedef("RdFSharpInteractiveTools") {
-            call("prepareCommands", structdef("RdFsiPrepareCommandsArgs") {
-                field("firstCommandIndex", int)
-                field("commands", immutableList(string))
-            }, immutableList(string))
-        })
-        property("moveCaretOnSendLine", bool).readonly
-        property("moveCaretOnSendSelection", bool).readonly
-        property("copyRecentToEditor", bool).readonly
-    }
+  private val RdFSharpInteractiveHost = aggregatedef("RdFSharpInteractiveHost") {
+    call("requestNewFsiSessionInfo", void, structdef("RdFsiSessionInfo") {
+      field("fsiPath", string)
+      field("runtime", fsiRuntime)
+      field("isCustomTool", bool)
+      field("args", immutableList(string))
+      field("fixArgsForAttach", bool)
+    })
+    call("getProjectReferences", int, immutableList(string))
+    field("fsiTools", aggregatedef("RdFSharpInteractiveTools") {
+      call("prepareCommands", structdef("RdFsiPrepareCommandsArgs") {
+        field("firstCommandIndex", int)
+        field("commands", immutableList(string))
+      }, immutableList(string))
+    })
+    property("moveCaretOnSendLine", bool).readonly
+    property("moveCaretOnSendSelection", bool).readonly
+    property("copyRecentToEditor", bool).readonly
+  }
 
-    private val RdFSharpTestHost = aggregatedef("RdFSharpTestHost") {
-        sink("fileChecked", string).async
-        sink("dotnetToolInvalidated", void).async
-        sink("fantomasNotificationFired", string).async
-        sink("fcsProjectInvalidated", structdef("RdFcsProject") {
-            field("projectName", string)
-            field("targetFramework", string)
-        })
-        call("getLastModificationStamp", string, dateTime)
-        call("getCultureInfoAndSetNew", string, string)
-        call("getSourceCache", string, structdef("RdFSharpSource") {
-            field("source", string)
-            field("timestamp", dateTime)
-        }.nullable)
-        call("dumpSingleProjectMapping", void, string)
-        call("dumpSingleProjectLocalReferences", void, immutableList(string))
-        call("fantomasVersion", void, string)
-        call("dumpFantomasRunOptions", void, string)
-        call("terminateFantomasHost", void, void)
-        call("TypeProvidersRuntimeVersion", void, string.nullable)
-        call("DumpTypeProvidersProcess", void, string)
-        call("dumpFcsRefrencedProjects", int, immutableList(string))
-        call("dumpFcsModuleReader", void, string)
-    }
+  private val RdFSharpTestHost = aggregatedef("RdFSharpTestHost") {
+    sink("fileChecked", string).async
+    sink("dotnetToolInvalidated", void).async
+    sink("fantomasNotificationFired", string).async
+    sink("fcsProjectInvalidated", structdef("RdFcsProject") {
+      field("projectName", string)
+      field("targetFramework", string)
+    })
+    call("getLastModificationStamp", string, dateTime)
+    call("getCultureInfoAndSetNew", string, string)
+    call("getSourceCache", string, structdef("RdFSharpSource") {
+      field("source", string)
+      field("timestamp", dateTime)
+    }.nullable)
+    call("dumpSingleProjectMapping", void, string)
+    call("dumpSingleProjectLocalReferences", void, immutableList(string))
+    call("fantomasVersion", void, string)
+    call("dumpFantomasRunOptions", void, string)
+    call("terminateFantomasHost", void, void)
+    call("TypeProvidersRuntimeVersion", void, string.nullable)
+    call("DumpTypeProvidersProcess", void, string)
+    call("dumpFcsRefrencedProjects", int, immutableList(string))
+    call("dumpFcsModuleReader", void, string)
+  }
 
-    init {
+  init {
 
-        setting(Kotlin11Generator.Namespace, "com.jetbrains.rider.plugins.fsharp")
-        setting(CSharp50Generator.Namespace, "JetBrains.ReSharper.Plugins.FSharp")
+    setting(Kotlin11Generator.Namespace, "com.jetbrains.rider.plugins.fsharp")
+    setting(CSharp50Generator.Namespace, "JetBrains.ReSharper.Plugins.FSharp")
 
-        field("fSharpInteractiveHost", RdFSharpInteractiveHost)
-        field("fsharpTestHost", RdFSharpTestHost)
-        property("fcsBusyDelayMs", int)
-    }
+    field("fSharpInteractiveHost", RdFSharpInteractiveHost)
+    field("fsharpTestHost", RdFSharpTestHost)
+    property("fcsBusyDelayMs", int)
+  }
 }

--- a/rider-fsharp/protocol/src/kotlin/model/RdFSharpTypeProvidersModel.kt
+++ b/rider-fsharp/protocol/src/kotlin/model/RdFSharpTypeProvidersModel.kt
@@ -9,378 +9,378 @@ import java.io.File
 @Suppress("unused")
 object RdFSharpTypeProvidersModel : Root() {
 
-    lateinit var RdProvidedPropertyInfo: Struct.Concrete
-    lateinit var RdProvidedMethodInfo: Struct.Concrete
-    lateinit var RdProvidedParameterInfo: Struct.Concrete
+  lateinit var RdProvidedPropertyInfo: Struct.Concrete
+  lateinit var RdProvidedMethodInfo: Struct.Concrete
+  lateinit var RdProvidedParameterInfo: Struct.Concrete
 
-    private val RdProvidedMemberProcessModel = baseclass {
-        call("DeclaringType", int, int)
-    }
+  private val RdProvidedMemberProcessModel = baseclass {
+    call("DeclaringType", int, int)
+  }
 
-    private val RdProvidedMethodBaseProcessModel = baseclass extends RdProvidedMemberProcessModel {
-        call("GetParameters", int, array(RdProvidedParameterInfo))
-        call("GetGenericArguments", int, array(int))
-    }
+  private val RdProvidedMethodBaseProcessModel = baseclass extends RdProvidedMemberProcessModel {
+    call("GetParameters", int, array(RdProvidedParameterInfo))
+    call("GetGenericArguments", int, array(int))
+  }
 
-    private val RdProvidedEntity = basestruct {
-        field("EntityId", int)
-    }
+  private val RdProvidedEntity = basestruct {
+    field("EntityId", int)
+  }
 
-    private val RdProvidedMemberInfo = basestruct extends RdProvidedEntity {
-        field("Name", string.nullable)
-    }
+  private val RdProvidedMemberInfo = basestruct extends RdProvidedEntity {
+    field("Name", string.nullable)
+  }
 
-    private var RdOutOfProcessProvidedType = structdef extends RdProvidedMemberInfo {
-        field("BaseType", int)
-        field("DeclaringType", int)
-        field("FullName", string.nullable)
-        field("Namespace", string.nullable)
-        field("Flags", RdProvidedTypeFlags)
-        field("GenericArguments", array(int).nullable)
-        field("Assembly", int)
-    }
+  private var RdOutOfProcessProvidedType = structdef extends RdProvidedMemberInfo {
+    field("BaseType", int)
+    field("DeclaringType", int)
+    field("FullName", string.nullable)
+    field("Namespace", string.nullable)
+    field("Flags", RdProvidedTypeFlags)
+    field("GenericArguments", array(int).nullable)
+    field("Assembly", int)
+  }
 
-    private val RdProvidedMethodBase = basestruct extends RdProvidedMemberInfo {
-        field("DeclaringType", int)
-        field("Flags", RdProvidedMethodFlags)
-        field("GenericArguments", array(int).nullable)
-    }
+  private val RdProvidedMethodBase = basestruct extends RdProvidedMemberInfo {
+    field("DeclaringType", int)
+    field("Flags", RdProvidedMethodFlags)
+    field("GenericArguments", array(int).nullable)
+  }
 
-    private val RdResolutionEnvironment = structdef {
-        field("ResolutionFolder", string)
-        field("OutputFile", string.nullable)
-        field("ShowResolutionMessages", bool)
-        field("ReferencedAssemblies", array(string))
-        field("TemporaryFolder", string)
-    }
+  private val RdResolutionEnvironment = structdef {
+    field("ResolutionFolder", string)
+    field("OutputFile", string.nullable)
+    field("ShowResolutionMessages", bool)
+    field("ReferencedAssemblies", array(string))
+    field("TemporaryFolder", string)
+  }
 
-    private val RdProvidedNamespace = structdef {
-        field("Name", string.nullable) // if null then global namespace
-        field("NestedNamespaces", array(this))
-        field("Types", array(int))
-    }
+  private val RdProvidedNamespace = structdef {
+    field("Name", string.nullable) // if null then global namespace
+    field("NestedNamespaces", array(this))
+    field("Types", array(int))
+  }
 
-    private val RdCustomAttributeNamedArgument = structdef {
-        field("MemberName", string)
-        field("TypedValue", RdAttributeArg)
-    }
+  private val RdCustomAttributeNamedArgument = structdef {
+    field("MemberName", string)
+    field("TypedValue", RdAttributeArg)
+  }
 
-    private val RdCustomAttributeData = structdef {
-        field("FullName", string)
-        field("NamedArguments", structdef("NamedArgumentsResult") {
-            field("Arguments", array(RdCustomAttributeNamedArgument))
-            field("Error", string.nullable)
-        })
-        field("ConstructorArguments", structdef("ConstructorArgumentsResult") {
-            field("Arguments", array(RdAttributeArg))
-            field("Error", string.nullable)
-        })
-    }
+  private val RdCustomAttributeData = structdef {
+    field("FullName", string)
+    field("NamedArguments", structdef("NamedArgumentsResult") {
+      field("Arguments", array(RdCustomAttributeNamedArgument))
+      field("Error", string.nullable)
+    })
+    field("ConstructorArguments", structdef("ConstructorArgumentsResult") {
+      field("Arguments", array(RdAttributeArg))
+      field("Error", string.nullable)
+    })
+  }
 
-    private val RdTypeProviderProcessModel = aggregatedef("RdTypeProviderProcessModel") {
-        signal("Invalidate", int)
-        call("InvalidateExternalTP", int, void)
-        call("GetProvidedNamespaces", int, array(RdProvidedNamespace))
-        call("Dispose", array(int), void)
-        call("GetCustomAttributes", structdef("GetCustomAttributesArgs") {
-            field("EntityId", int)
-            field("ProvidedEntityType", RdProvidedEntityType)
-        }, array(RdCustomAttributeData))
-        call(
-            "InstantiateTypeProvidersOfAssembly",
-            InstantiateTypeProvidersOfAssemblyParameters,
-            structdef("InstantiationResult") {
-                field("TypeProviders", array(RdTypeProvider))
-                field("CachedIds", array(int))
-            })
-        call("Kill", void, void)
-    }
+  private val RdTypeProviderProcessModel = aggregatedef("RdTypeProviderProcessModel") {
+    signal("Invalidate", int)
+    call("InvalidateExternalTP", int, void)
+    call("GetProvidedNamespaces", int, array(RdProvidedNamespace))
+    call("Dispose", array(int), void)
+    call("GetCustomAttributes", structdef("GetCustomAttributesArgs") {
+      field("EntityId", int)
+      field("ProvidedEntityType", RdProvidedEntityType)
+    }, array(RdCustomAttributeData))
+    call(
+      "InstantiateTypeProvidersOfAssembly",
+      InstantiateTypeProvidersOfAssemblyParameters,
+      structdef("InstantiationResult") {
+        field("TypeProviders", array(RdTypeProvider))
+        field("CachedIds", array(int))
+      })
+    call("Kill", void, void)
+  }
 
-    private val RdStaticArg = structdef {
-        field("TypeName", RdTypeName)
-        field("Value", string)
-    }
+  private val RdStaticArg = structdef {
+    field("TypeName", RdTypeName)
+    field("Value", string)
+  }
 
-    private val RdAttributeArgElement = structdef {
-        field("TypeName", string)
-        field("Value", string.nullable)
-    }
+  private val RdAttributeArgElement = structdef {
+    field("TypeName", string)
+    field("Value", string.nullable)
+  }
 
-    private val RdAttributeArg = structdef {
-        field("TypeName", string)
-        field("IsArray", bool)
-        field("Values", array(RdAttributeArgElement))
-    }
+  private val RdAttributeArg = structdef {
+    field("TypeName", string)
+    field("IsArray", bool)
+    field("Values", array(RdAttributeArgElement))
+  }
 
-    private val ApplyStaticArgumentsParameters = structdef {
-        field("Id", int)
-        field("TypePathWithArguments", array(string))
-        field("StaticArguments", array(RdStaticArg))
-    }
+  private val ApplyStaticArgumentsParameters = structdef {
+    field("Id", int)
+    field("TypePathWithArguments", array(string))
+    field("StaticArguments", array(RdStaticArg))
+  }
 
-    private val GetStaticArgumentsParameters = structdef {
-        field("TypeWithoutArguments", string)
-    }
+  private val GetStaticArgumentsParameters = structdef {
+    field("TypeWithoutArguments", string)
+  }
 
-    private val GetGeneratedAssemblyContentsParameters = structdef {
-        field("TypeProviderId", int)
-        field("SyntheticMethodBase", string)
-        field("Parameters", string)
-    }
+  private val GetGeneratedAssemblyContentsParameters = structdef {
+    field("TypeProviderId", int)
+    field("SyntheticMethodBase", string)
+    field("Parameters", string)
+  }
 
-    private val RdPublicKey = structdef {
-        field("IsKey", bool)
-        field("Data", array(byte))
-    }
+  private val RdPublicKey = structdef {
+    field("IsKey", bool)
+    field("Data", array(byte))
+  }
 
-    private val RdVersion = structdef {
-        field("Major", int)
-        field("Minor", int)
-        field("Build", int)
-        field("Revision", int)
-    }
+  private val RdVersion = structdef {
+    field("Major", int)
+    field("Minor", int)
+    field("Build", int)
+    field("Revision", int)
+  }
 
-    private val RdSystemRuntimeContainsType = structdef {
-        field("SystemRuntimeContainsTypeRef", structdef {
-            field("Value", structdef {
-                field("FakeTcImports", RdFakeTcImports)
-            })
-        })
-    }
-
-    private val InstantiateTypeProvidersOfAssemblyParameters = structdef {
-        field("RunTimeAssemblyFileName", string)
-        field("DesignTimeAssemblyNameString", string)
-        field("RdResolutionEnvironment", RdResolutionEnvironment)
-        field("IsInvalidationSupported", bool)
-        field("IsInteractive", bool)
-        field("SystemRuntimeAssemblyVersion", string)
-        field("CompilerToolsPath", array(string))
+  private val RdSystemRuntimeContainsType = structdef {
+    field("SystemRuntimeContainsTypeRef", structdef {
+      field("Value", structdef {
         field("FakeTcImports", RdFakeTcImports)
-        field("EnvironmentPath", string)
+      })
+    })
+  }
+
+  private val InstantiateTypeProvidersOfAssemblyParameters = structdef {
+    field("RunTimeAssemblyFileName", string)
+    field("DesignTimeAssemblyNameString", string)
+    field("RdResolutionEnvironment", RdResolutionEnvironment)
+    field("IsInvalidationSupported", bool)
+    field("IsInteractive", bool)
+    field("SystemRuntimeAssemblyVersion", string)
+    field("CompilerToolsPath", array(string))
+    field("FakeTcImports", RdFakeTcImports)
+    field("EnvironmentPath", string)
+  }
+
+  private val RdFakeDllInfo = structdef {
+    field("FileName", string)
+  }
+
+  private val RdFakeTcImports = structdef {
+    field("Base", this.nullable)
+    field("DllInfos", array(RdFakeDllInfo))
+  }
+
+  private val RdProvidedTypeProcessModel = aggregatedef("RdProvidedTypeProcessModel") {
+    call("GetProvidedType", int, RdOutOfProcessProvidedType)
+    call("GetProvidedTypes", array(int), array(RdOutOfProcessProvidedType))
+    call("GetGenericTypeDefinition", int, int)
+    call("GetElementType", int, int)
+    call("GetArrayRank", int, int)
+    call("GetEnumUnderlyingType", int, int)
+    call("GenericParameterPosition", int, int)
+    call("GetStaticParameters", int, array(RdProvidedParameterInfo))
+    call("ApplyStaticArguments", ApplyStaticArgumentsParameters, int)
+    call("MakePointerType", int, int)
+    call("MakeByRefType", int, int)
+    call("MakeArrayType", structdef("MakeArrayTypeArgs") {
+      field("Id", int)
+      field("Rank", int)
+    }, int)
+    call("MakeGenericType", structdef("MakeGenericTypeArgs") {
+      field("EntityId", int)
+      field("ArgIds", array(int))
+    }, int)
+    call("GetContent", int, RdProvidedTypeContent)
+    call("GetAllNestedTypes", int, array(int))
+  }
+
+  private val ApplyStaticArgumentsForMethodArgs = structdef("ApplyStaticArgumentsForMethodArgs") {
+    field("EntityId", int)
+    field("FullNameAfterArguments", string)
+    field("StaticArgs", array(RdStaticArg))
+  }
+
+  private val RdProvidedMethodInfoProcessModel = aggregatedef("RdProvidedMethodInfoProcessModel") {
+    call("GetProvidedMethodInfo", int, RdProvidedMethodInfo)
+    call("GetProvidedMethodInfos", array(int), array(RdProvidedMethodInfo))
+    call("GetStaticParametersForMethod", int, array(RdProvidedParameterInfo))
+    call("ApplyStaticArgumentsForMethod", ApplyStaticArgumentsForMethodArgs, RdProvidedMethodInfo)
+    call("GetParameters", int, array(RdProvidedParameterInfo))
+  }
+
+  private val RdProvidedConstructorInfoProcessModel = aggregatedef("RdProvidedConstructorInfoProcessModel") {
+    call("GetStaticParametersForMethod", int, array(RdProvidedParameterInfo))
+    call("ApplyStaticArgumentsForMethod", ApplyStaticArgumentsForMethodArgs, RdProvidedConstructorInfo)
+    call("GetParameters", int, array(RdProvidedParameterInfo))
+  }
+
+  private val RdTypeProvider = structdef {
+    field("EntityId", int)
+    field("Name", string.nullable)
+    field("FullName", string)
+  }
+
+  private val RdAssemblyName = structdef {
+    field("Name", string)
+    field("PublicKey", RdPublicKey.nullable)
+    field("Version", string.nullable)
+    field("Flags", int)
+  }
+
+  private val RdProvidedAssembly = structdef extends RdProvidedEntity {
+    field("FullName", string)
+    field("AssemblyName", RdAssemblyName)
+  }
+
+  private val RdProvidedAssemblyProcessModel = aggregatedef("RdProvidedAssemblyProcessModel") {
+    call("GetProvidedAssembly", int, RdProvidedAssembly)
+    call("GetManifestModuleContents", int, array(byte))
+  }
+
+  private val RdProvidedFieldInfo = structdef {
+    field("Name", string.nullable)
+    field("FieldType", int)
+    field("DeclaringType", int)
+    field("RawConstantValue", RdStaticArg.nullable)
+    field("Flags", RdProvidedFieldFlags)
+    field("CustomAttributes", array(RdCustomAttributeData))
+  }
+
+  private val RdProvidedEventInfo = structdef {
+    field("Name", string.nullable)
+    field("DeclaringType", int)
+    field("EventHandlerType", int)
+    field("AddMethod", int)
+    field("RemoveMethod", int)
+    field("CustomAttributes", array(RdCustomAttributeData))
+  }
+
+  private val RdProvidedTypeContent = structdef {
+    field("Interfaces", array(int))
+    field("Constructors", array(RdProvidedConstructorInfo))
+    field("Methods", array(RdProvidedMethodInfo))
+    field("Properties", array(RdProvidedPropertyInfo))
+    field("Fields", array(RdProvidedFieldInfo))
+    field("Events", array(RdProvidedEventInfo))
+  }
+
+  private val RdProvidedConstructorInfo = structdef extends RdProvidedMethodBase {
+  }
+
+  private val RdProvidedTypeFlags = flags {
+    +"None"
+    +"IsVoid"
+    +"IsGenericParameter"
+    +"IsValueType"
+    +"IsByRef"
+    +"IsPointer"
+    +"IsEnum"
+    +"IsArray"
+    +"IsInterface"
+    +"IsClass"
+    +"IsSealed"
+    +"IsAbstract"
+    +"IsPublic"
+    +"IsNestedPublic"
+    +"IsSuppressRelocate"
+    +"IsErased"
+    +"IsGenericType"
+    +"IsMeasure"
+    +"IsCreatedByProvider"
+  }
+
+  private val RdProvidedFieldFlags = flags {
+    +"None"
+    +"IsInitOnly"
+    +"IsStatic"
+    +"IsSpecialName"
+    +"IsLiteral"
+    +"IsPublic"
+    +"IsFamily"
+    +"IsFamilyAndAssembly"
+    +"IsFamilyOrAssembly"
+    +"IsPrivate"
+  }
+
+  private val RdProvidedMethodFlags = flags {
+    +"None"
+    +"IsGenericMethod"
+    +"IsStatic"
+    +"IsFamily"
+    +"IsFamilyAndAssembly"
+    +"IsFamilyOrAssembly"
+    +"IsVirtual"
+    +"IsFinal"
+    +"IsPublic"
+    +"IsAbstract"
+    +"IsHideBySig"
+    +"IsConstructor"
+  }
+
+  private val RdTypeName = enum {
+    +"sbyte"
+    +"short"
+    +"int"
+    +"long"
+    +"byte"
+    +"ushort"
+    +"uint"
+    +"ulong"
+    +"decimal"
+    +"float"
+    +"double"
+    +"char"
+    +"bool"
+    +"string"
+    +"dbnull"
+  }
+
+  private val RdProvidedEntityType = flags {
+    +"TypeProvider"
+    +"TypeInfo"
+    +"MethodInfo"
+    +"ConstructorInfo"
+    +"FieldInfo"
+    +"PropertyInfo"
+    +"EventInfo"
+  }
+
+  private val RdTestHost = aggregatedef("RdTestHost") {
+    call("RuntimeVersion", void, string.nullable)
+    call("Dump", void, string)
+  }
+
+  init {
+    RdProvidedPropertyInfo = structdef extends RdProvidedMemberInfo {
+      field("DeclaringType", int)
+      field("PropertyType", int)
+      field("GetMethod", int)
+      field("SetMethod", int)
+      field("CanRead", bool)
+      field("CanWrite", bool)
+      field("IndexParameters", array(RdProvidedParameterInfo))
     }
 
-    private val RdFakeDllInfo = structdef {
-        field("FileName", string)
+    RdProvidedParameterInfo = structdef {
+      field("Name", string.nullable)
+      field("IsIn", bool)
+      field("IsOut", bool)
+      field("IsOptional", bool)
+      field("ParameterType", int)
+      field("RawDefaultValue", RdStaticArg.nullable)
+      field("HasDefaultValue", bool)
+      field("CustomAttributes", array(RdCustomAttributeData).nullable)
     }
 
-    private val RdFakeTcImports = structdef {
-        field("Base", this.nullable)
-        field("DllInfos", array(RdFakeDllInfo))
+    RdProvidedMethodInfo = structdef extends RdProvidedMethodBase {
+      field("ReturnType", int)
+      field("MetadataToken", int)
     }
 
-    private val RdProvidedTypeProcessModel = aggregatedef("RdProvidedTypeProcessModel") {
-        call("GetProvidedType", int, RdOutOfProcessProvidedType)
-        call("GetProvidedTypes", array(int), array(RdOutOfProcessProvidedType))
-        call("GetGenericTypeDefinition", int, int)
-        call("GetElementType", int, int)
-        call("GetArrayRank", int, int)
-        call("GetEnumUnderlyingType", int, int)
-        call("GenericParameterPosition", int, int)
-        call("GetStaticParameters", int, array(RdProvidedParameterInfo))
-        call("ApplyStaticArguments", ApplyStaticArgumentsParameters, int)
-        call("MakePointerType", int, int)
-        call("MakeByRefType", int, int)
-        call("MakeArrayType", structdef("MakeArrayTypeArgs") {
-            field("Id", int)
-            field("Rank", int)
-        }, int)
-        call("MakeGenericType", structdef("MakeGenericTypeArgs") {
-            field("EntityId", int)
-            field("ArgIds", array(int))
-        }, int)
-        call("GetContent", int, RdProvidedTypeContent)
-        call("GetAllNestedTypes", int, array(int))
-    }
-
-    private val ApplyStaticArgumentsForMethodArgs = structdef("ApplyStaticArgumentsForMethodArgs") {
-        field("EntityId", int)
-        field("FullNameAfterArguments", string)
-        field("StaticArgs", array(RdStaticArg))
-    }
-
-    private val RdProvidedMethodInfoProcessModel = aggregatedef("RdProvidedMethodInfoProcessModel") {
-        call("GetProvidedMethodInfo", int, RdProvidedMethodInfo)
-        call("GetProvidedMethodInfos", array(int), array(RdProvidedMethodInfo))
-        call("GetStaticParametersForMethod", int, array(RdProvidedParameterInfo))
-        call("ApplyStaticArgumentsForMethod", ApplyStaticArgumentsForMethodArgs, RdProvidedMethodInfo)
-        call("GetParameters", int, array(RdProvidedParameterInfo))
-    }
-
-    private val RdProvidedConstructorInfoProcessModel = aggregatedef("RdProvidedConstructorInfoProcessModel") {
-        call("GetStaticParametersForMethod", int, array(RdProvidedParameterInfo))
-        call("ApplyStaticArgumentsForMethod", ApplyStaticArgumentsForMethodArgs, RdProvidedConstructorInfo)
-        call("GetParameters", int, array(RdProvidedParameterInfo))
-    }
-
-    private val RdTypeProvider = structdef {
-        field("EntityId", int)
-        field("Name", string.nullable)
-        field("FullName", string)
-    }
-
-    private val RdAssemblyName = structdef {
-        field("Name", string)
-        field("PublicKey", RdPublicKey.nullable)
-        field("Version", string.nullable)
-        field("Flags", int)
-    }
-
-    private val RdProvidedAssembly = structdef extends RdProvidedEntity {
-        field("FullName", string)
-        field("AssemblyName", RdAssemblyName)
-    }
-
-    private val RdProvidedAssemblyProcessModel = aggregatedef("RdProvidedAssemblyProcessModel") {
-        call("GetProvidedAssembly", int, RdProvidedAssembly)
-        call("GetManifestModuleContents", int, array(byte))
-    }
-
-    private val RdProvidedFieldInfo = structdef {
-        field("Name", string.nullable)
-        field("FieldType", int)
-        field("DeclaringType", int)
-        field("RawConstantValue", RdStaticArg.nullable)
-        field("Flags", RdProvidedFieldFlags)
-        field("CustomAttributes", array(RdCustomAttributeData))
-    }
-
-    private val RdProvidedEventInfo = structdef {
-        field("Name", string.nullable)
-        field("DeclaringType", int)
-        field("EventHandlerType", int)
-        field("AddMethod", int)
-        field("RemoveMethod", int)
-        field("CustomAttributes", array(RdCustomAttributeData))
-    }
-
-    private val RdProvidedTypeContent = structdef {
-        field("Interfaces", array(int))
-        field("Constructors", array(RdProvidedConstructorInfo))
-        field("Methods", array(RdProvidedMethodInfo))
-        field("Properties", array(RdProvidedPropertyInfo))
-        field("Fields", array(RdProvidedFieldInfo))
-        field("Events", array(RdProvidedEventInfo))
-    }
-
-    private val RdProvidedConstructorInfo = structdef extends RdProvidedMethodBase {
-    }
-
-    private val RdProvidedTypeFlags = flags {
-        +"None"
-        +"IsVoid"
-        +"IsGenericParameter"
-        +"IsValueType"
-        +"IsByRef"
-        +"IsPointer"
-        +"IsEnum"
-        +"IsArray"
-        +"IsInterface"
-        +"IsClass"
-        +"IsSealed"
-        +"IsAbstract"
-        +"IsPublic"
-        +"IsNestedPublic"
-        +"IsSuppressRelocate"
-        +"IsErased"
-        +"IsGenericType"
-        +"IsMeasure"
-        +"IsCreatedByProvider"
-    }
-
-    private val RdProvidedFieldFlags = flags {
-        +"None"
-        +"IsInitOnly"
-        +"IsStatic"
-        +"IsSpecialName"
-        +"IsLiteral"
-        +"IsPublic"
-        +"IsFamily"
-        +"IsFamilyAndAssembly"
-        +"IsFamilyOrAssembly"
-        +"IsPrivate"
-    }
-
-    private val RdProvidedMethodFlags = flags {
-        +"None"
-        +"IsGenericMethod"
-        +"IsStatic"
-        +"IsFamily"
-        +"IsFamilyAndAssembly"
-        +"IsFamilyOrAssembly"
-        +"IsVirtual"
-        +"IsFinal"
-        +"IsPublic"
-        +"IsAbstract"
-        +"IsHideBySig"
-        +"IsConstructor"
-    }
-
-    private val RdTypeName = enum {
-        +"sbyte"
-        +"short"
-        +"int"
-        +"long"
-        +"byte"
-        +"ushort"
-        +"uint"
-        +"ulong"
-        +"decimal"
-        +"float"
-        +"double"
-        +"char"
-        +"bool"
-        +"string"
-        +"dbnull"
-    }
-
-    private val RdProvidedEntityType = flags {
-        +"TypeProvider"
-        +"TypeInfo"
-        +"MethodInfo"
-        +"ConstructorInfo"
-        +"FieldInfo"
-        +"PropertyInfo"
-        +"EventInfo"
-    }
-
-    private val RdTestHost = aggregatedef("RdTestHost") {
-        call("RuntimeVersion", void, string.nullable)
-        call("Dump", void, string)
-    }
-
-    init {
-        RdProvidedPropertyInfo = structdef extends RdProvidedMemberInfo {
-            field("DeclaringType", int)
-            field("PropertyType", int)
-            field("GetMethod", int)
-            field("SetMethod", int)
-            field("CanRead", bool)
-            field("CanWrite", bool)
-            field("IndexParameters", array(RdProvidedParameterInfo))
-        }
-
-        RdProvidedParameterInfo = structdef {
-            field("Name", string.nullable)
-            field("IsIn", bool)
-            field("IsOut", bool)
-            field("IsOptional", bool)
-            field("ParameterType", int)
-            field("RawDefaultValue", RdStaticArg.nullable)
-            field("HasDefaultValue", bool)
-            field("CustomAttributes", array(RdCustomAttributeData).nullable)
-        }
-
-        RdProvidedMethodInfo = structdef extends RdProvidedMethodBase {
-            field("ReturnType", int)
-            field("MetadataToken", int)
-        }
-
-        field("RdTypeProviderProcessModel", RdTypeProviderProcessModel)
-        field("RdProvidedTypeProcessModel", RdProvidedTypeProcessModel)
-        field("RdProvidedMethodInfoProcessModel", RdProvidedMethodInfoProcessModel)
-        field("RdProvidedConstructorInfoProcessModel", RdProvidedConstructorInfoProcessModel)
-        field("RdProvidedAssemblyProcessModel", RdProvidedAssemblyProcessModel)
-        field("RdTestHost", RdTestHost)
-    }
+    field("RdTypeProviderProcessModel", RdTypeProviderProcessModel)
+    field("RdProvidedTypeProcessModel", RdProvidedTypeProcessModel)
+    field("RdProvidedMethodInfoProcessModel", RdProvidedMethodInfoProcessModel)
+    field("RdProvidedConstructorInfoProcessModel", RdProvidedConstructorInfoProcessModel)
+    field("RdProvidedAssemblyProcessModel", RdProvidedAssemblyProcessModel)
+    field("RdTestHost", RdTestHost)
+  }
 }

--- a/rider-fsharp/protocol/src/kotlin/model/RdFantomasModel.kt
+++ b/rider-fsharp/protocol/src/kotlin/model/RdFantomasModel.kt
@@ -9,38 +9,38 @@ import java.io.File
 @Suppress("unused")
 object RdFantomasModel : Root() {
 
-    private val rdFcsParsingOptions = structdef {
-        field("lastSourceFile", string)
-        field("lightSyntax", bool.nullable)
-        field("conditionalCompilationDefines", array(string))
-        field("isExe", bool)
-        field("langVersion", string)
-    }
+  private val rdFcsParsingOptions = structdef {
+    field("lastSourceFile", string)
+    field("lightSyntax", bool.nullable)
+    field("conditionalCompilationDefines", array(string))
+    field("isExe", bool)
+    field("langVersion", string)
+  }
 
-    private val rdFcsRange = structdef {
-        field("fileName", string)
-        field("startLine", int)
-        field("startCol", int)
-        field("endLine", int)
-        field("endCol", int)
-    }
+  private val rdFcsRange = structdef {
+    field("fileName", string)
+    field("startLine", int)
+    field("startCol", int)
+    field("endLine", int)
+    field("endCol", int)
+  }
 
-    private val rdFantomasFormatArgs = basestruct {
-        field("fileName", string)
-        field("source", string)
-        field("formatConfig", array(string))
-        field("parsingOptions", rdFcsParsingOptions)
-        field("newLineText", string)
-    }
+  private val rdFantomasFormatArgs = basestruct {
+    field("fileName", string)
+    field("source", string)
+    field("formatConfig", array(string))
+    field("parsingOptions", rdFcsParsingOptions)
+    field("newLineText", string)
+  }
 
-    init {
-        call("getFormatConfigFields", void, array(string))
-        call("formatDocument", structdef("rdFantomasFormatDocumentArgs") extends rdFantomasFormatArgs {}, string)
-        call("formatSelection", structdef("rdFantomasFormatSelectionArgs") extends rdFantomasFormatArgs {
-            field("range", rdFcsRange)
-        }, string)
+  init {
+    call("getFormatConfigFields", void, array(string))
+    call("formatDocument", structdef("rdFantomasFormatDocumentArgs") extends rdFantomasFormatArgs {}, string)
+    call("formatSelection", structdef("rdFantomasFormatSelectionArgs") extends rdFantomasFormatArgs {
+      field("range", rdFcsRange)
+    }, string)
 
-        call("getVersion", void, string)
-        signal("exit", void)
-    }
+    call("getVersion", void, string)
+    signal("exit", void)
+  }
 }

--- a/rider-fsharp/settings.gradle.kts
+++ b/rider-fsharp/settings.gradle.kts
@@ -1,20 +1,20 @@
 pluginManagement {
-    repositories {
-        maven { setUrl("https://cache-redirector.jetbrains.com/plugins.gradle.org") }
-        gradlePluginPortal()
-        // This is for snapshot version of 'org.jetbrains.intellij' plugin
-        maven { setUrl("https://oss.sonatype.org/content/repositories/snapshots/") }
-    }
-    resolutionStrategy {
-        eachPlugin {
-            when(requested.id.name) {
-                // This required to correctly rd-gen plugin resolution. May be we should switch our naming to match Gradle plugin naming convention.
-                "rdgen" -> {
-                    useModule("com.jetbrains.rd:rd-gen:${requested.version}")
-                }
-            }
+  repositories {
+    maven { setUrl("https://cache-redirector.jetbrains.com/plugins.gradle.org") }
+    gradlePluginPortal()
+    // This is for snapshot version of 'org.jetbrains.intellij' plugin
+    maven { setUrl("https://oss.sonatype.org/content/repositories/snapshots/") }
+  }
+  resolutionStrategy {
+    eachPlugin {
+      when (requested.id.name) {
+        // This required to correctly rd-gen plugin resolution. May be we should switch our naming to match Gradle plugin naming convention.
+        "rdgen" -> {
+          useModule("com.jetbrains.rd:rd-gen:${requested.version}")
         }
+      }
     }
+  }
 }
 
 rootProject.name = "rider-fsharp"

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/FSharpFileType.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/FSharpFileType.kt
@@ -4,15 +4,15 @@ import com.intellij.openapi.fileTypes.LanguageFileType
 import com.jetbrains.rider.plugins.fsharp.FSharpIcons
 
 object FSharpFileType : LanguageFileType(FSharpLanguage) {
-    override fun getName() = FSharpLanguage.displayName
-    override fun getDefaultExtension() = "fs"
-    override fun getDescription() = "F# file"
-    override fun getIcon() = FSharpIcons.FSharp
+  override fun getName() = FSharpLanguage.displayName
+  override fun getDefaultExtension() = "fs"
+  override fun getDescription() = "F# file"
+  override fun getIcon() = FSharpIcons.FSharp
 }
 
 object FSharpScriptFileType : LanguageFileType(FSharpScriptLanguage) {
-    override fun getName() = FSharpScriptLanguage.displayName
-    override fun getDefaultExtension() = "fsx"
-    override fun getDescription() = "F# script file"
-    override fun getIcon() = FSharpIcons.FSharpScript
+  override fun getName() = FSharpScriptLanguage.displayName
+  override fun getDefaultExtension() = "fsx"
+  override fun getDescription() = "F# script file"
+  override fun getIcon() = FSharpIcons.FSharpScript
 }

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/FSharpLanguage.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/FSharpLanguage.kt
@@ -3,7 +3,7 @@ package com.jetbrains.rider.ideaInterop.fileTypes.fsharp
 import com.jetbrains.rider.ideaInterop.fileTypes.RiderLanguageBase
 
 abstract class FSharpLanguageBase(name: String) : RiderLanguageBase(name, name) {
-    override fun isCaseSensitive() = true
+  override fun isCaseSensitive() = true
 }
 
 object FSharpLanguage : FSharpLanguageBase("F#")

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/FSharpParserDefinition.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/FSharpParserDefinition.kt
@@ -10,22 +10,23 @@ import com.intellij.psi.tree.IFileElementType
 import com.jetbrains.rider.ideaInterop.fileTypes.fsharp.lexer.FSharpLexer
 
 class FSharpParserDefinition : RiderParserDefinitionBase(FSharpFileElementType, FSharpFileType) {
-    companion object {
-        val FSharpElementType = IElementType("RIDER_FSHARP", FSharpLanguage)
-        val FSharpFileElementType = RiderFileElementType("RIDER_FSHARP_FILE", FSharpLanguage, FSharpElementType)
-    }
+  companion object {
+    val FSharpElementType = IElementType("RIDER_FSHARP", FSharpLanguage)
+    val FSharpFileElementType = RiderFileElementType("RIDER_FSHARP_FILE", FSharpLanguage, FSharpElementType)
+  }
 
-    override fun createLexer(project: Project?): Lexer = FSharpLexer()
-    override fun getFileNodeType(): IFileElementType = FSharpFileElementType
+  override fun createLexer(project: Project?): Lexer = FSharpLexer()
+  override fun getFileNodeType(): IFileElementType = FSharpFileElementType
 }
 
 class FSharpScriptParserDefinition : RiderParserDefinitionBase(FSharpScriptFileElementType, FSharpScriptFileType) {
-    companion object {
-        val FSharpScriptElementType = IElementType("RIDER_FSHARP_SCRIPT", FSharpScriptLanguage)
-        val FSharpScriptFileElementType = RiderFileElementType("RIDER_FSHARP_SCRIPT_FILE", FSharpScriptLanguage, FSharpScriptElementType)
-    }
+  companion object {
+    val FSharpScriptElementType = IElementType("RIDER_FSHARP_SCRIPT", FSharpScriptLanguage)
+    val FSharpScriptFileElementType =
+      RiderFileElementType("RIDER_FSHARP_SCRIPT_FILE", FSharpScriptLanguage, FSharpScriptElementType)
+  }
 
-    override fun createLexer(project: Project?): Lexer = FSharpLexer()
-    override fun getFileNodeType(): IFileElementType = FSharpParserDefinition.FSharpFileElementType
+  override fun createLexer(project: Project?): Lexer = FSharpLexer()
+  override fun getFileNodeType(): IFileElementType = FSharpParserDefinition.FSharpFileElementType
 
 }

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/highlighting/FSharpSyntaxHighlighterFactory.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/highlighting/FSharpSyntaxHighlighterFactory.kt
@@ -9,22 +9,22 @@ import com.jetbrains.rider.ideaInterop.fileTypes.fsharp.lexer.FSharpLexer
 import com.jetbrains.rider.ideaInterop.fileTypes.fsharp.lexer.FSharpTokenType.*
 
 class FSharpSyntaxHighlighter : SyntaxHighlighterBase() {
-    companion object {
-        private val keywords = IDENT_KEYWORDS.types.map { it to FSharpTextAttributeKeys.KEYWORD }
-        private val pp_keywords = PP_KEYWORDS.types.map { it to FSharpTextAttributeKeys.PREPROCESSOR_KEYWORD }
-        private val strings = STRINGS.types.map { it to FSharpTextAttributeKeys.STRING }
-        private val interpolated_strings = INTERPOLATED_STRINGS.types.map { it to FSharpTextAttributeKeys.STRING }
-        private val comments = COMMENTS.types.map { it to FSharpTextAttributeKeys.BLOCK_COMMENT }
-        private val numbers = NUMBERS.types.map { it to FSharpTextAttributeKeys.NUMBER }
+  companion object {
+    private val keywords = IDENT_KEYWORDS.types.map { it to FSharpTextAttributeKeys.KEYWORD }
+    private val pp_keywords = PP_KEYWORDS.types.map { it to FSharpTextAttributeKeys.PREPROCESSOR_KEYWORD }
+    private val strings = STRINGS.types.map { it to FSharpTextAttributeKeys.STRING }
+    private val interpolated_strings = INTERPOLATED_STRINGS.types.map { it to FSharpTextAttributeKeys.STRING }
+    private val comments = COMMENTS.types.map { it to FSharpTextAttributeKeys.BLOCK_COMMENT }
+    private val numbers = NUMBERS.types.map { it to FSharpTextAttributeKeys.NUMBER }
 
-        private val ourKeys = mapOf(
-                CHARACTER_LITERAL to FSharpTextAttributeKeys.STRING,
-                BYTECHAR to FSharpTextAttributeKeys.STRING,
-                LINE_COMMENT to FSharpTextAttributeKeys.COMMENT,
-                TokenType.BAD_CHARACTER to HighlighterColors.BAD_CHARACTER
-        ) + keywords + pp_keywords + comments + strings + interpolated_strings + numbers
-    }
+    private val ourKeys = mapOf(
+      CHARACTER_LITERAL to FSharpTextAttributeKeys.STRING,
+      BYTECHAR to FSharpTextAttributeKeys.STRING,
+      LINE_COMMENT to FSharpTextAttributeKeys.COMMENT,
+      TokenType.BAD_CHARACTER to HighlighterColors.BAD_CHARACTER
+    ) + keywords + pp_keywords + comments + strings + interpolated_strings + numbers
+  }
 
-    override fun getHighlightingLexer() = FSharpLexer()
-    override fun getTokenHighlights(tokenType: IElementType): Array<TextAttributesKey> = pack(ourKeys[tokenType])
+  override fun getHighlightingLexer() = FSharpLexer()
+  override fun getTokenHighlights(tokenType: IElementType): Array<TextAttributesKey> = pack(ourKeys[tokenType])
 }

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/highlighting/FSharpTextAttributeKeys.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/highlighting/FSharpTextAttributeKeys.kt
@@ -4,11 +4,16 @@ import com.jetbrains.rider.colors.IRiderTextAttributeKeys
 import com.jetbrains.rider.colors.RiderLanguageTextAttributeKeys
 
 object FSharpTextAttributeKeys : IRiderTextAttributeKeys {
-    val KEYWORD = FSharpTextAttributeKeys.key("ReSharper.FSHARP_KEYWORD", RiderLanguageTextAttributeKeys.KEYWORD)
-    val PREPROCESSOR_KEYWORD = FSharpTextAttributeKeys.key("ReSharper.FSHARP_PREPROCESSOR_KEYWORD", RiderLanguageTextAttributeKeys.PREPROCESSOR_KEYWORD)
+  val KEYWORD = FSharpTextAttributeKeys.key("ReSharper.FSHARP_KEYWORD", RiderLanguageTextAttributeKeys.KEYWORD)
+  val PREPROCESSOR_KEYWORD = FSharpTextAttributeKeys.key(
+    "ReSharper.FSHARP_PREPROCESSOR_KEYWORD",
+    RiderLanguageTextAttributeKeys.PREPROCESSOR_KEYWORD
+  )
 
-    val STRING = FSharpTextAttributeKeys.key("ReSharper.FSHARP_STRING", RiderLanguageTextAttributeKeys.STRING)
-    val NUMBER = FSharpTextAttributeKeys.key("ReSharper.FSHARP_NUMBER", RiderLanguageTextAttributeKeys.NUMBER)
-    val COMMENT = FSharpTextAttributeKeys.key("ReSharper.FSHARP_LINE_COMMENT", RiderLanguageTextAttributeKeys.LINE_COMMENT)
-    val BLOCK_COMMENT = FSharpTextAttributeKeys.key("ReSharper.FSHARP_BLOCK_COMMENT", RiderLanguageTextAttributeKeys.BLOCK_COMMENT)
+  val STRING = FSharpTextAttributeKeys.key("ReSharper.FSHARP_STRING", RiderLanguageTextAttributeKeys.STRING)
+  val NUMBER = FSharpTextAttributeKeys.key("ReSharper.FSHARP_NUMBER", RiderLanguageTextAttributeKeys.NUMBER)
+  val COMMENT =
+    FSharpTextAttributeKeys.key("ReSharper.FSHARP_LINE_COMMENT", RiderLanguageTextAttributeKeys.LINE_COMMENT)
+  val BLOCK_COMMENT =
+    FSharpTextAttributeKeys.key("ReSharper.FSHARP_BLOCK_COMMENT", RiderLanguageTextAttributeKeys.BLOCK_COMMENT)
 }

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/lexer/FSharpInterpolatedStringKind.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/lexer/FSharpInterpolatedStringKind.kt
@@ -1,7 +1,7 @@
 package com.jetbrains.rider.ideaInterop.fileTypes.fsharp.lexer
 
 enum class FSharpInterpolatedStringKind {
-    Regular,
-    Verbatim,
-    TripleQuote
+  Regular,
+  Verbatim,
+  TripleQuote
 }

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/lexer/FSharpKeywordTokenNodeType.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/lexer/FSharpKeywordTokenNodeType.kt
@@ -1,3 +1,4 @@
 package com.jetbrains.rider.ideaInterop.fileTypes.fsharp.lexer
 
-class FSharpKeywordTokenNodeType(value: String, representation: String, val isContextual: Boolean) : FSharpTokenNodeType(value, representation)
+class FSharpKeywordTokenNodeType(value: String, representation: String, val isContextual: Boolean) :
+  FSharpTokenNodeType(value, representation)

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/lexer/FSharpKeywordsMap.java
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/lexer/FSharpKeywordsMap.java
@@ -7,35 +7,35 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 class FSharpKeywordsMap {
-    private static THashMap<CharSequence, IElementType> ourKeywordMap = new THashMap<>(CharSequenceHashingStrategy.CASE_SENSITIVE);
+  private static THashMap<CharSequence, IElementType> ourKeywordMap = new THashMap<>(CharSequenceHashingStrategy.CASE_SENSITIVE);
 
-    static {
-        for (IElementType type: FSharpTokenType.IDENT_KEYWORDS.getTypes()) {
-            if (!(type instanceof FSharpKeywordTokenNodeType)) continue;
-            ourKeywordMap.put(((FSharpKeywordTokenNodeType) type).getRepresentation(), type);
-        }
+  static {
+    for (IElementType type : FSharpTokenType.IDENT_KEYWORDS.getTypes()) {
+      if (!(type instanceof FSharpKeywordTokenNodeType)) continue;
+      ourKeywordMap.put(((FSharpKeywordTokenNodeType) type).getRepresentation(), type);
     }
+  }
 
-    @Nullable
-    static IElementType findKeyword(@NotNull CharSequence buffer, int start, int end) {
-        CharSequence sequence = buffer.subSequence(start, end);
-        return ourKeywordMap.get(sequence);
-    }
+  @Nullable
+  static IElementType findKeyword(@NotNull CharSequence buffer, int start, int end) {
+    CharSequence sequence = buffer.subSequence(start, end);
+    return ourKeywordMap.get(sequence);
+  }
 }
 
 class FSharpReservedKeywordsMap {
-    private static THashMap<CharSequence, IElementType> ourKeywordMap = new THashMap<>(CharSequenceHashingStrategy.CASE_SENSITIVE);
+  private static THashMap<CharSequence, IElementType> ourKeywordMap = new THashMap<>(CharSequenceHashingStrategy.CASE_SENSITIVE);
 
-    static {
-        for (IElementType type: FSharpTokenType.RESERVED_IDENT_KEYWORDS.getTypes()) {
-            if (!(type instanceof FSharpKeywordTokenNodeType)) continue;
-            ourKeywordMap.put(((FSharpKeywordTokenNodeType) type).getRepresentation(), type);
-        }
+  static {
+    for (IElementType type : FSharpTokenType.RESERVED_IDENT_KEYWORDS.getTypes()) {
+      if (!(type instanceof FSharpKeywordTokenNodeType)) continue;
+      ourKeywordMap.put(((FSharpKeywordTokenNodeType) type).getRepresentation(), type);
     }
+  }
 
-    @Nullable
-    static IElementType findKeyword(@NotNull CharSequence buffer, int start, int end) {
-        CharSequence sequence = buffer.subSequence(start, end);
-        return ourKeywordMap.get(sequence);
-    }
+  @Nullable
+  static IElementType findKeyword(@NotNull CharSequence buffer, int start, int end) {
+    CharSequence sequence = buffer.subSequence(start, end);
+    return ourKeywordMap.get(sequence);
+  }
 }

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/lexer/FSharpLexer.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/lexer/FSharpLexer.kt
@@ -8,29 +8,30 @@ import com.jetbrains.rider.ideaInterop.fileTypes.fsharp.lexer._FSharpLexer.YYINI
 
 @Suppress("UnstableApiUsage")
 class FSharpLexer : FlexAdapter(_FSharpLexer()), RestartableLexer {
-    override fun getStartState() = YYINITIAL
+  override fun getStartState() = YYINITIAL
 
-    override fun isRestartableState(state: Int) =
-        state == YYINITIAL || state == LINE
+  override fun isRestartableState(state: Int) =
+    state == YYINITIAL || state == LINE
 
-    override fun getState(): Int {
-        val flex = flex
-        return if (flex is _FSharpLexer && !flex.isRestartableState ||
-            FSharpTokenType.INTERPOLATED_STRING_ENDS.contains(tokenType)) -1 else super.getState()
+  override fun getState(): Int {
+    val flex = flex
+    return if (flex is _FSharpLexer && !flex.isRestartableState ||
+      FSharpTokenType.INTERPOLATED_STRING_ENDS.contains(tokenType)
+    ) -1 else super.getState()
+  }
+
+  override fun start(
+    buffer: CharSequence, startOffset: Int, endOffset: Int, initialState: Int, tokenIterator: TokenIterator?
+  ) {
+    val flex = flex
+    if (flex is _FSharpLexer) {
+      flex.myInterpolatedStringStates.clear()
+      flex.myNestedCommentLevel = 0
+      flex.myParenLevel = 0
+      flex.myTokenLength = 0
+      flex.myBrackLevel = 0
+      flex.myIsAfterUnfinishedIdent = false
     }
-
-    override fun start(
-        buffer: CharSequence, startOffset: Int, endOffset: Int, initialState: Int, tokenIterator: TokenIterator?
-    ) {
-        val flex = flex
-        if (flex is _FSharpLexer) {
-            flex.myInterpolatedStringStates.clear()
-            flex.myNestedCommentLevel = 0
-            flex.myParenLevel = 0
-            flex.myTokenLength = 0
-            flex.myBrackLevel = 0
-            flex.myIsAfterUnfinishedIdent = false
-        }
-        super.start(buffer, startOffset, endOffset, initialState)
-    }
+    super.start(buffer, startOffset, endOffset, initialState)
+  }
 }

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/lexer/FSharpLexerContext.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/lexer/FSharpLexerContext.kt
@@ -1,8 +1,8 @@
 package com.jetbrains.rider.ideaInterop.fileTypes.fsharp.lexer
 
 data class FSharpLexerContext(
-    val LexerState: Int,
-    val ParenLevel: Int,
-    val BrackLevel: Int,
-    val NestedCommentLevel: Int,
+  val LexerState: Int,
+  val ParenLevel: Int,
+  val BrackLevel: Int,
+  val NestedCommentLevel: Int,
 )

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/lexer/FSharpLexerInterpolatedStringState.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/lexer/FSharpLexerInterpolatedStringState.kt
@@ -3,7 +3,7 @@ package com.jetbrains.rider.ideaInterop.fileTypes.fsharp.lexer
 import java.util.*
 
 data class FSharpLexerInterpolatedStringState(
-    val Kind: FSharpInterpolatedStringKind,
-    val PreviousLexerContext: FSharpLexerContext,
-    val InterpolatedStringStack: Stack<InterpolatedStringStackItem>
+  val Kind: FSharpInterpolatedStringKind,
+  val PreviousLexerContext: FSharpLexerContext,
+  val InterpolatedStringStack: Stack<InterpolatedStringStackItem>
 )

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/lexer/FSharpTokenNodeType.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/lexer/FSharpTokenNodeType.kt
@@ -3,5 +3,7 @@ package com.jetbrains.rider.ideaInterop.fileTypes.fsharp.lexer
 import com.jetbrains.rider.ideaInterop.fileTypes.fsharp.FSharpLanguage
 
 open class FSharpTokenNodeType @JvmOverloads constructor(
-        value: String, representation: String = value) : RiderElementType(value, representation, FSharpLanguage
+  value: String, representation: String = value
+) : RiderElementType(
+  value, representation, FSharpLanguage
 )

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/lexer/FSharpTokenType.java
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/lexer/FSharpTokenType.java
@@ -6,428 +6,428 @@ import org.jetbrains.annotations.NotNull;
 
 public interface FSharpTokenType {
 
-    IElementType BIGNUM = createToken("BIGNUM");
-    IElementType BLOCK_COMMENT = createToken("BLOCK_COMMENT");
-    IElementType BYTE = createToken("BYTE");
-    IElementType BYTEARRAY = createToken("BYTEARRAY");
-    IElementType BYTECHAR = createToken("BYTECHAR");
-    IElementType CHARACTER_LITERAL = createToken("CHARACTER_LITERAL");
-    IElementType DECIMAL = createToken("DECIMAL");
-    IElementType LINE_COMMENT = createToken("LINE_COMMENT");
-    IElementType SHEBANG = createToken("SHEBANG");
-    IElementType IDENT = createToken("IDENT");
-    IElementType IEEE32 = createToken("IEEE32");
-    IElementType IEEE64 = createToken("IEEE64");
-    IElementType INT16 = createToken("INT16");
-    IElementType INT32 = createToken("INT32");
-    IElementType INT64 = createToken("INT64");
-    IElementType NATIVEINT = createToken("NATIVEINT");
-    IElementType LQUOTE_TYPED = createToken("LQUOTE_TYPED");
-    IElementType RQUOTE_TYPED = createToken("RQUOTE_TYPED");
-    IElementType LQUOTE_UNTYPED = createToken("LQUOTE_UNTYPED");
-    IElementType RQUOTE_UNTYPED = createToken("RQUOTE_UNTYPED");
-    IElementType RESERVED_IDENT_FORMATS = createToken("RESERVED_IDENT_FORMATS");
-    IElementType RESERVED_IDENT_KEYWORD = createToken("RESERVED_IDENT_KEYWORD");
-    IElementType RESERVED_LITERAL_FORMATS = createToken("RESERVED_LITERAL_FORMATS");
-    IElementType RESERVED_SYMBOLIC_SEQUENCE = createToken("RESERVED_SYMBOLIC_SEQUENCE");
-    IElementType SBYTE = createToken("SBYTE");
-    IElementType STRING = createToken("STRING");
-    IElementType REGULAR_INTERPOLATED_STRING = createToken("REGULAR_INTERPOLATED_STRING");
-    IElementType REGULAR_INTERPOLATED_STRING_START = createToken("REGULAR_INTERPOLATED_STRING_START");
-    IElementType REGULAR_INTERPOLATED_STRING_MIDDLE = createToken("REGULAR_INTERPOLATED_STRING_MIDDLE");
-    IElementType REGULAR_INTERPOLATED_STRING_END = createToken("REGULAR_INTERPOLATED_STRING_END");
-    IElementType LET_BANG = createToken("LET_BANG");
-    IElementType USE_BANG = createToken("USE_BANG");
-    IElementType DO_BANG = createToken("DO_BANG");
-    IElementType YIELD_BANG = createToken("YIELD_BANG");
-    IElementType RETURN_BANG = createToken("RETURN_BANG");
-    IElementType MATCH_BANG = createToken("MATCH_BANG");
-    IElementType AND_BANG = createToken("AND_BANG");
-    IElementType BAR = createToken("BAR");
-    IElementType RARROW = createToken("RARROW");
-    IElementType LARROW = createToken("LARROW");
-    IElementType DOT = createToken("DOT");
-    IElementType COLON = createToken("COLON");
-    IElementType LPAREN = createToken("LPAREN");
-    IElementType RPAREN = createToken("RPAREN");
-    IElementType STAR = createToken("STAR");
-    IElementType LBRACK = createToken("LBRACK");
-    IElementType RBRACK = createToken("RBRACK");
-    IElementType LBRACK_LESS = createToken("LBRACK_LESS");
-    IElementType GREATER_RBRACK = createToken("GREATER_RBRACK");
-    IElementType LBRACK_BAR = createToken("LBRACK_BAR");
-    IElementType LBRACE_BAR = createToken("LBRACE_BAR");
-    IElementType LESS = createToken("LESS");
-    IElementType GREATER = createToken("GREATER");
-    IElementType GREATER_BAR_RBRACK = createToken("GREATER_BAR_RBRACK");
-    IElementType BAR_RBRACK = createToken("BAR_RBRACK");
-    IElementType BAR_RBRACE = createToken("BAR_RBRACE");
-    IElementType LBRACE = createToken("LBRACE");
-    IElementType RBRACE = createToken("RBRACE");
-    IElementType QUOTE = createToken("QUOTE");
-    IElementType HASH = createToken("HASH");
-    IElementType COLON_QMARK_GREATER = createToken("COLON_QMARK_GREATER");
-    IElementType COLON_QMARK = createToken("COLON_QMARK");
-    IElementType COLON_GREATER = createToken("COLON_GREATER");
-    IElementType DOT_DOT = createToken("DOT_DOT");
-    IElementType COLON_COLON = createToken("COLON_COLON");
-    IElementType COLON_EQUALS = createToken("COLON_EQUALS");
-    IElementType SEMICOLON_SEMICOLON = createToken("SEMICOLON_SEMICOLON");
-    IElementType SEMICOLON = createToken("SEMICOLON");
-    IElementType EQUALS = createToken("EQUALS");
-    IElementType UNDERSCORE = createToken("UNDERSCORE");
-    IElementType QMARK = createToken("QMARK");
-    IElementType QMARK_QMARK = createToken("QMARK_QMARK");
-    IElementType LPAREN_STAR_RPAREN = createToken("LPAREN_STAR_RPAREN");
-    IElementType MINUS = createToken("MINUS");
-    IElementType PLUS = createToken("PLUS");
-    IElementType SYMBOLIC_OP = createToken("SYMBOLIC_OP");
-    IElementType BAD_SYMBOLIC_OP = createToken("BAD_SYMBOLIC_OP");
-    IElementType TRIPLE_QUOTED_STRING = createToken("TRIPLE_QUOTED_STRING");
-    IElementType TRIPLE_QUOTE_INTERPOLATED_STRING = createToken("TRIPLE_QUOTED_STRING");
-    IElementType TRIPLE_QUOTE_INTERPOLATED_STRING_START = createToken("TRIPLE_QUOTE_INTERPOLATED_STRING_START");
-    IElementType TRIPLE_QUOTE_INTERPOLATED_STRING_MIDDLE = createToken("TRIPLE_QUOTED_STRING_MIDDLE");
-    IElementType TRIPLE_QUOTE_INTERPOLATED_STRING_END = createToken("TRIPLE_QUOTED_STRING_END");
-    IElementType UINT16 = createToken("UINT16");
-    IElementType UINT32 = createToken("UINT32");
-    IElementType UINT64 = createToken("UINT64");
-    IElementType UNATIVEINT = createToken("UNATIVEINT");
-    IElementType VERBATIM_BYTEARRAY = createToken("VERBATIM_BYTEARRAY");
-    IElementType VERBATIM_STRING = createToken("VERBATIM_STRING");
-    IElementType VERBATIM_INTERPOLATED_STRING = createToken("VERBATIM_INTERPOLATED_STRING");
-    IElementType VERBATIM_INTERPOLATED_STRING_START = createToken("VERBATIM_INTERPOLATED_STRING_START");
-    IElementType VERBATIM_INTERPOLATED_STRING_MIDDLE = createToken("VERBATIM_INTERPOLATED_STRING_MIDDLE");
-    IElementType VERBATIM_INTERPOLATED_STRING_END = createToken("VERBATIM_INTERPOLATED_STRING_END");
-    IElementType NEW_LINE = createToken("NEW_LINE");
-    IElementType WHITESPACE = createToken("WHITESPACE");
-    IElementType KEYWORD_STRING_SOURCE_DIRECTORY = createToken("KEYWORD_STRING_SOURCE_DIRECTORY");
-    IElementType KEYWORD_STRING_SOURCE_FILE = createToken("KEYWORD_STRING_SOURCE_FILE");
-    IElementType KEYWORD_STRING_LINE = createToken("KEYWORD_STRING_LINE");
-    IElementType UNFINISHED_STRING = createToken("UNFINISHED_STRING");
-    IElementType UNFINISHED_VERBATIM_STRING = createToken("UNFINISHED_VERBATIM_STRING");
-    IElementType UNFINISHED_TRIPLE_QUOTED_STRING = createToken("UNFINISHED_TRIPLE_QUOTED_STRING");
-    IElementType UNFINISHED_REGULAR_INTERPOLATED_STRING = createToken("UNFINISHED_REGULAR_INTERPOLATED_STRING");
-    IElementType UNFINISHED_VERBATIM_INTERPOLATED_STRING = createToken("UNFINISHED_VERBATIM_INTERPOLATED_STRING");
-    IElementType UNFINISHED_TRIPLE_QUOTE_INTERPOLATED_STRING = createToken("UNFINISHED_TRIPLE_QUOTE_INTERPOLATED_STRING");
-    IElementType DOLLAR = createToken("DOLLAR");
-    IElementType PERCENT = createToken("PERCENT");
-    IElementType PERCENT_PERCENT = createToken("PERCENT_PERCENT");
-    IElementType AMP = createToken("AMP");
-    IElementType AMP_AMP = createToken("AMP_AMP");
-    IElementType COMMA = createToken("COMMA");
-    IElementType BAD_TAB = createToken("BAD_TAB");
+  IElementType BIGNUM = createToken("BIGNUM");
+  IElementType BLOCK_COMMENT = createToken("BLOCK_COMMENT");
+  IElementType BYTE = createToken("BYTE");
+  IElementType BYTEARRAY = createToken("BYTEARRAY");
+  IElementType BYTECHAR = createToken("BYTECHAR");
+  IElementType CHARACTER_LITERAL = createToken("CHARACTER_LITERAL");
+  IElementType DECIMAL = createToken("DECIMAL");
+  IElementType LINE_COMMENT = createToken("LINE_COMMENT");
+  IElementType SHEBANG = createToken("SHEBANG");
+  IElementType IDENT = createToken("IDENT");
+  IElementType IEEE32 = createToken("IEEE32");
+  IElementType IEEE64 = createToken("IEEE64");
+  IElementType INT16 = createToken("INT16");
+  IElementType INT32 = createToken("INT32");
+  IElementType INT64 = createToken("INT64");
+  IElementType NATIVEINT = createToken("NATIVEINT");
+  IElementType LQUOTE_TYPED = createToken("LQUOTE_TYPED");
+  IElementType RQUOTE_TYPED = createToken("RQUOTE_TYPED");
+  IElementType LQUOTE_UNTYPED = createToken("LQUOTE_UNTYPED");
+  IElementType RQUOTE_UNTYPED = createToken("RQUOTE_UNTYPED");
+  IElementType RESERVED_IDENT_FORMATS = createToken("RESERVED_IDENT_FORMATS");
+  IElementType RESERVED_IDENT_KEYWORD = createToken("RESERVED_IDENT_KEYWORD");
+  IElementType RESERVED_LITERAL_FORMATS = createToken("RESERVED_LITERAL_FORMATS");
+  IElementType RESERVED_SYMBOLIC_SEQUENCE = createToken("RESERVED_SYMBOLIC_SEQUENCE");
+  IElementType SBYTE = createToken("SBYTE");
+  IElementType STRING = createToken("STRING");
+  IElementType REGULAR_INTERPOLATED_STRING = createToken("REGULAR_INTERPOLATED_STRING");
+  IElementType REGULAR_INTERPOLATED_STRING_START = createToken("REGULAR_INTERPOLATED_STRING_START");
+  IElementType REGULAR_INTERPOLATED_STRING_MIDDLE = createToken("REGULAR_INTERPOLATED_STRING_MIDDLE");
+  IElementType REGULAR_INTERPOLATED_STRING_END = createToken("REGULAR_INTERPOLATED_STRING_END");
+  IElementType LET_BANG = createToken("LET_BANG");
+  IElementType USE_BANG = createToken("USE_BANG");
+  IElementType DO_BANG = createToken("DO_BANG");
+  IElementType YIELD_BANG = createToken("YIELD_BANG");
+  IElementType RETURN_BANG = createToken("RETURN_BANG");
+  IElementType MATCH_BANG = createToken("MATCH_BANG");
+  IElementType AND_BANG = createToken("AND_BANG");
+  IElementType BAR = createToken("BAR");
+  IElementType RARROW = createToken("RARROW");
+  IElementType LARROW = createToken("LARROW");
+  IElementType DOT = createToken("DOT");
+  IElementType COLON = createToken("COLON");
+  IElementType LPAREN = createToken("LPAREN");
+  IElementType RPAREN = createToken("RPAREN");
+  IElementType STAR = createToken("STAR");
+  IElementType LBRACK = createToken("LBRACK");
+  IElementType RBRACK = createToken("RBRACK");
+  IElementType LBRACK_LESS = createToken("LBRACK_LESS");
+  IElementType GREATER_RBRACK = createToken("GREATER_RBRACK");
+  IElementType LBRACK_BAR = createToken("LBRACK_BAR");
+  IElementType LBRACE_BAR = createToken("LBRACE_BAR");
+  IElementType LESS = createToken("LESS");
+  IElementType GREATER = createToken("GREATER");
+  IElementType GREATER_BAR_RBRACK = createToken("GREATER_BAR_RBRACK");
+  IElementType BAR_RBRACK = createToken("BAR_RBRACK");
+  IElementType BAR_RBRACE = createToken("BAR_RBRACE");
+  IElementType LBRACE = createToken("LBRACE");
+  IElementType RBRACE = createToken("RBRACE");
+  IElementType QUOTE = createToken("QUOTE");
+  IElementType HASH = createToken("HASH");
+  IElementType COLON_QMARK_GREATER = createToken("COLON_QMARK_GREATER");
+  IElementType COLON_QMARK = createToken("COLON_QMARK");
+  IElementType COLON_GREATER = createToken("COLON_GREATER");
+  IElementType DOT_DOT = createToken("DOT_DOT");
+  IElementType COLON_COLON = createToken("COLON_COLON");
+  IElementType COLON_EQUALS = createToken("COLON_EQUALS");
+  IElementType SEMICOLON_SEMICOLON = createToken("SEMICOLON_SEMICOLON");
+  IElementType SEMICOLON = createToken("SEMICOLON");
+  IElementType EQUALS = createToken("EQUALS");
+  IElementType UNDERSCORE = createToken("UNDERSCORE");
+  IElementType QMARK = createToken("QMARK");
+  IElementType QMARK_QMARK = createToken("QMARK_QMARK");
+  IElementType LPAREN_STAR_RPAREN = createToken("LPAREN_STAR_RPAREN");
+  IElementType MINUS = createToken("MINUS");
+  IElementType PLUS = createToken("PLUS");
+  IElementType SYMBOLIC_OP = createToken("SYMBOLIC_OP");
+  IElementType BAD_SYMBOLIC_OP = createToken("BAD_SYMBOLIC_OP");
+  IElementType TRIPLE_QUOTED_STRING = createToken("TRIPLE_QUOTED_STRING");
+  IElementType TRIPLE_QUOTE_INTERPOLATED_STRING = createToken("TRIPLE_QUOTED_STRING");
+  IElementType TRIPLE_QUOTE_INTERPOLATED_STRING_START = createToken("TRIPLE_QUOTE_INTERPOLATED_STRING_START");
+  IElementType TRIPLE_QUOTE_INTERPOLATED_STRING_MIDDLE = createToken("TRIPLE_QUOTED_STRING_MIDDLE");
+  IElementType TRIPLE_QUOTE_INTERPOLATED_STRING_END = createToken("TRIPLE_QUOTED_STRING_END");
+  IElementType UINT16 = createToken("UINT16");
+  IElementType UINT32 = createToken("UINT32");
+  IElementType UINT64 = createToken("UINT64");
+  IElementType UNATIVEINT = createToken("UNATIVEINT");
+  IElementType VERBATIM_BYTEARRAY = createToken("VERBATIM_BYTEARRAY");
+  IElementType VERBATIM_STRING = createToken("VERBATIM_STRING");
+  IElementType VERBATIM_INTERPOLATED_STRING = createToken("VERBATIM_INTERPOLATED_STRING");
+  IElementType VERBATIM_INTERPOLATED_STRING_START = createToken("VERBATIM_INTERPOLATED_STRING_START");
+  IElementType VERBATIM_INTERPOLATED_STRING_MIDDLE = createToken("VERBATIM_INTERPOLATED_STRING_MIDDLE");
+  IElementType VERBATIM_INTERPOLATED_STRING_END = createToken("VERBATIM_INTERPOLATED_STRING_END");
+  IElementType NEW_LINE = createToken("NEW_LINE");
+  IElementType WHITESPACE = createToken("WHITESPACE");
+  IElementType KEYWORD_STRING_SOURCE_DIRECTORY = createToken("KEYWORD_STRING_SOURCE_DIRECTORY");
+  IElementType KEYWORD_STRING_SOURCE_FILE = createToken("KEYWORD_STRING_SOURCE_FILE");
+  IElementType KEYWORD_STRING_LINE = createToken("KEYWORD_STRING_LINE");
+  IElementType UNFINISHED_STRING = createToken("UNFINISHED_STRING");
+  IElementType UNFINISHED_VERBATIM_STRING = createToken("UNFINISHED_VERBATIM_STRING");
+  IElementType UNFINISHED_TRIPLE_QUOTED_STRING = createToken("UNFINISHED_TRIPLE_QUOTED_STRING");
+  IElementType UNFINISHED_REGULAR_INTERPOLATED_STRING = createToken("UNFINISHED_REGULAR_INTERPOLATED_STRING");
+  IElementType UNFINISHED_VERBATIM_INTERPOLATED_STRING = createToken("UNFINISHED_VERBATIM_INTERPOLATED_STRING");
+  IElementType UNFINISHED_TRIPLE_QUOTE_INTERPOLATED_STRING = createToken("UNFINISHED_TRIPLE_QUOTE_INTERPOLATED_STRING");
+  IElementType DOLLAR = createToken("DOLLAR");
+  IElementType PERCENT = createToken("PERCENT");
+  IElementType PERCENT_PERCENT = createToken("PERCENT_PERCENT");
+  IElementType AMP = createToken("AMP");
+  IElementType AMP_AMP = createToken("AMP_AMP");
+  IElementType COMMA = createToken("COMMA");
+  IElementType BAD_TAB = createToken("BAD_TAB");
 
-    IElementType ABSTRACT = createKeywordToken("ABSTRACT", "abstract");
-    IElementType AND = createKeywordToken("AND", "and");
-    IElementType AS = createKeywordToken("AS", "as");
-    IElementType ASSERT = createKeywordToken("ASSERT", "assert");
-    IElementType BASE = createKeywordToken("BASE", "base");
-    IElementType BEGIN = createKeywordToken("BEGIN", "begin");
-    IElementType CLASS = createKeywordToken("CLASS", "class");
-    IElementType DEFAULT = createKeywordToken("DEFAULT", "default");
-    IElementType DELEGATE = createKeywordToken("DELEGATE", "delegate");
-    IElementType DO = createKeywordToken("DO", "do");
-    IElementType DONE = createKeywordToken("DONE", "done");
-    IElementType DOWNCAST = createKeywordToken("DOWNCAST", "downcast");
-    IElementType DOWNTO = createKeywordToken("DOWNTO", "downto");
-    IElementType ELIF = createKeywordToken("ELIF", "elif");
-    IElementType ELSE = createKeywordToken("ELSE", "else");
-    IElementType END = createKeywordToken("END", "end");
-    IElementType EXCEPTION = createKeywordToken("EXCEPTION", "exception");
-    IElementType EXTERN = createKeywordToken("EXTERN", "extern");
-    IElementType FALSE = createKeywordToken("FALSE", "false");
-    IElementType FINALLY = createKeywordToken("FINALLY", "finally");
-    IElementType FOR = createKeywordToken("FOR", "for");
-    IElementType FUN = createKeywordToken("FUN", "fun");
-    IElementType FUNCTION = createKeywordToken("FUNCTION", "function");
-    IElementType GLOBAL = createKeywordToken("GLOBAL", "global");
-    IElementType IF = createKeywordToken("IF", "if");
-    IElementType IN = createKeywordToken("IN", "in");
-    IElementType INHERIT = createKeywordToken("INHERIT", "inherit");
-    IElementType INLINE = createKeywordToken("INLINE", "inline");
-    IElementType INTERFACE = createKeywordToken("INTERFACE", "interface");
-    IElementType INTERNAL = createKeywordToken("INTERNAL", "internal");
-    IElementType LAZY = createKeywordToken("LAZY", "lazy");
-    IElementType LET = createKeywordToken("LET", "let");
-    IElementType MATCH = createKeywordToken("MATCH", "match");
-    IElementType MEMBER = createKeywordToken("MEMBER", "member");
-    IElementType MODULE = createKeywordToken("MODULE", "module");
-    IElementType MUTABLE = createKeywordToken("MUTABLE", "mutable");
-    IElementType NAMESPACE = createKeywordToken("NAMESPACE", "namespace");
-    IElementType NEW = createKeywordToken("NEW", "new");
-    IElementType NULL = createKeywordToken("NULL", "null");
-    IElementType OF = createKeywordToken("OF", "of");
-    IElementType OPEN = createKeywordToken("OPEN", "open");
-    IElementType OR = createKeywordToken("OR", "or");
-    IElementType OVERRIDE = createKeywordToken("OVERRIDE", "override");
-    IElementType PRIVATE = createKeywordToken("PRIVATE", "private");
-    IElementType PUBLIC = createKeywordToken("PUBLIC", "public");
-    IElementType REC = createKeywordToken("REC", "rec");
-    IElementType RETURN = createKeywordToken("RETURN", "return");
-    IElementType SIG = createKeywordToken("SIG", "sig");
-    IElementType STATIC = createKeywordToken("STATIC", "static");
-    IElementType STRUCT = createKeywordToken("STRUCT", "struct");
-    IElementType THEN = createKeywordToken("THEN", "then");
-    IElementType TO = createKeywordToken("TO", "to");
-    IElementType TRUE = createKeywordToken("TRUE", "true");
-    IElementType TRY = createKeywordToken("TRY", "try");
-    IElementType TYPE = createKeywordToken("TYPE", "type");
-    IElementType UPCAST = createKeywordToken("UPCAST", "upcast");
-    IElementType USE = createKeywordToken("USE", "use");
-    IElementType VAL = createKeywordToken("VAL", "val");
-    IElementType VOID = createKeywordToken("VOID", "void");
-    IElementType WHEN = createKeywordToken("WHEN", "when");
-    IElementType WHILE = createKeywordToken("WHILE", "while");
-    IElementType WITH = createKeywordToken("WITH", "with");
-    IElementType YIELD = createKeywordToken("YIELD", "yield");
+  IElementType ABSTRACT = createKeywordToken("ABSTRACT", "abstract");
+  IElementType AND = createKeywordToken("AND", "and");
+  IElementType AS = createKeywordToken("AS", "as");
+  IElementType ASSERT = createKeywordToken("ASSERT", "assert");
+  IElementType BASE = createKeywordToken("BASE", "base");
+  IElementType BEGIN = createKeywordToken("BEGIN", "begin");
+  IElementType CLASS = createKeywordToken("CLASS", "class");
+  IElementType DEFAULT = createKeywordToken("DEFAULT", "default");
+  IElementType DELEGATE = createKeywordToken("DELEGATE", "delegate");
+  IElementType DO = createKeywordToken("DO", "do");
+  IElementType DONE = createKeywordToken("DONE", "done");
+  IElementType DOWNCAST = createKeywordToken("DOWNCAST", "downcast");
+  IElementType DOWNTO = createKeywordToken("DOWNTO", "downto");
+  IElementType ELIF = createKeywordToken("ELIF", "elif");
+  IElementType ELSE = createKeywordToken("ELSE", "else");
+  IElementType END = createKeywordToken("END", "end");
+  IElementType EXCEPTION = createKeywordToken("EXCEPTION", "exception");
+  IElementType EXTERN = createKeywordToken("EXTERN", "extern");
+  IElementType FALSE = createKeywordToken("FALSE", "false");
+  IElementType FINALLY = createKeywordToken("FINALLY", "finally");
+  IElementType FOR = createKeywordToken("FOR", "for");
+  IElementType FUN = createKeywordToken("FUN", "fun");
+  IElementType FUNCTION = createKeywordToken("FUNCTION", "function");
+  IElementType GLOBAL = createKeywordToken("GLOBAL", "global");
+  IElementType IF = createKeywordToken("IF", "if");
+  IElementType IN = createKeywordToken("IN", "in");
+  IElementType INHERIT = createKeywordToken("INHERIT", "inherit");
+  IElementType INLINE = createKeywordToken("INLINE", "inline");
+  IElementType INTERFACE = createKeywordToken("INTERFACE", "interface");
+  IElementType INTERNAL = createKeywordToken("INTERNAL", "internal");
+  IElementType LAZY = createKeywordToken("LAZY", "lazy");
+  IElementType LET = createKeywordToken("LET", "let");
+  IElementType MATCH = createKeywordToken("MATCH", "match");
+  IElementType MEMBER = createKeywordToken("MEMBER", "member");
+  IElementType MODULE = createKeywordToken("MODULE", "module");
+  IElementType MUTABLE = createKeywordToken("MUTABLE", "mutable");
+  IElementType NAMESPACE = createKeywordToken("NAMESPACE", "namespace");
+  IElementType NEW = createKeywordToken("NEW", "new");
+  IElementType NULL = createKeywordToken("NULL", "null");
+  IElementType OF = createKeywordToken("OF", "of");
+  IElementType OPEN = createKeywordToken("OPEN", "open");
+  IElementType OR = createKeywordToken("OR", "or");
+  IElementType OVERRIDE = createKeywordToken("OVERRIDE", "override");
+  IElementType PRIVATE = createKeywordToken("PRIVATE", "private");
+  IElementType PUBLIC = createKeywordToken("PUBLIC", "public");
+  IElementType REC = createKeywordToken("REC", "rec");
+  IElementType RETURN = createKeywordToken("RETURN", "return");
+  IElementType SIG = createKeywordToken("SIG", "sig");
+  IElementType STATIC = createKeywordToken("STATIC", "static");
+  IElementType STRUCT = createKeywordToken("STRUCT", "struct");
+  IElementType THEN = createKeywordToken("THEN", "then");
+  IElementType TO = createKeywordToken("TO", "to");
+  IElementType TRUE = createKeywordToken("TRUE", "true");
+  IElementType TRY = createKeywordToken("TRY", "try");
+  IElementType TYPE = createKeywordToken("TYPE", "type");
+  IElementType UPCAST = createKeywordToken("UPCAST", "upcast");
+  IElementType USE = createKeywordToken("USE", "use");
+  IElementType VAL = createKeywordToken("VAL", "val");
+  IElementType VOID = createKeywordToken("VOID", "void");
+  IElementType WHEN = createKeywordToken("WHEN", "when");
+  IElementType WHILE = createKeywordToken("WHILE", "while");
+  IElementType WITH = createKeywordToken("WITH", "with");
+  IElementType YIELD = createKeywordToken("YIELD", "yield");
 
-    IElementType ATOMIC = createKeywordToken("ATOMIC", "atomic");
-    IElementType BREAK = createKeywordToken("BREAK", "break");
-    IElementType CHECKED = createKeywordToken("CHECKED", "checked");
-    IElementType COMPONENT = createKeywordToken("COMPONENT", "component");
-    IElementType CONST = createKeywordToken("CONST", "const");
-    IElementType CONSTRAINT = createKeywordToken("CONSTRAINT", "constraint");
-    IElementType CONSTRUCTOR = createKeywordToken("CONSTRUCTOR", "constructor");
-    IElementType CONTINUE = createKeywordToken("CONTINUE", "continue");
-    IElementType EAGER = createKeywordToken("EAGER", "eager");
-    IElementType FIXED = createKeywordToken("FIXED", "fixed");
-    IElementType FORI = createKeywordToken("FORI", "fori");
-    IElementType FUNCTOR = createKeywordToken("FUNCTOR", "functor");
-    IElementType INCLUDE = createKeywordToken("INCLUDE", "include");
-    IElementType MEASURE = createKeywordToken("MEASURE", "measure");
-    IElementType METHOD = createKeywordToken("METHOD", "method");
-    IElementType MIXIN = createKeywordToken("MIXIN", "mixin");
-    IElementType OBJECT = createKeywordToken("OBJECT", "object");
-    IElementType PARALLEL = createKeywordToken("PARALLEL", "parallel");
-    IElementType PARAMS = createKeywordToken("PARAMS", "params");
-    IElementType PROCESS = createKeywordToken("PROCESS", "process");
-    IElementType PROTECTED = createKeywordToken("PROTECTED", "protected");
-    IElementType PURE = createKeywordToken("PURE", "pure");
-    IElementType RECURSIVE = createKeywordToken("RECURSIVE", "recursive");
-    IElementType SEALED = createKeywordToken("SEALED", "sealed");
-    IElementType TAILCALL = createKeywordToken("TAILCALL", "tailcall");
-    IElementType TRAIT = createKeywordToken("TRAIT", "trait");
-    IElementType VIRTUAL = createKeywordToken("VIRTUAL", "virtual");
-    IElementType VOLATILE = createKeywordToken("VOLATILE", "volatile");
+  IElementType ATOMIC = createKeywordToken("ATOMIC", "atomic");
+  IElementType BREAK = createKeywordToken("BREAK", "break");
+  IElementType CHECKED = createKeywordToken("CHECKED", "checked");
+  IElementType COMPONENT = createKeywordToken("COMPONENT", "component");
+  IElementType CONST = createKeywordToken("CONST", "const");
+  IElementType CONSTRAINT = createKeywordToken("CONSTRAINT", "constraint");
+  IElementType CONSTRUCTOR = createKeywordToken("CONSTRUCTOR", "constructor");
+  IElementType CONTINUE = createKeywordToken("CONTINUE", "continue");
+  IElementType EAGER = createKeywordToken("EAGER", "eager");
+  IElementType FIXED = createKeywordToken("FIXED", "fixed");
+  IElementType FORI = createKeywordToken("FORI", "fori");
+  IElementType FUNCTOR = createKeywordToken("FUNCTOR", "functor");
+  IElementType INCLUDE = createKeywordToken("INCLUDE", "include");
+  IElementType MEASURE = createKeywordToken("MEASURE", "measure");
+  IElementType METHOD = createKeywordToken("METHOD", "method");
+  IElementType MIXIN = createKeywordToken("MIXIN", "mixin");
+  IElementType OBJECT = createKeywordToken("OBJECT", "object");
+  IElementType PARALLEL = createKeywordToken("PARALLEL", "parallel");
+  IElementType PARAMS = createKeywordToken("PARAMS", "params");
+  IElementType PROCESS = createKeywordToken("PROCESS", "process");
+  IElementType PROTECTED = createKeywordToken("PROTECTED", "protected");
+  IElementType PURE = createKeywordToken("PURE", "pure");
+  IElementType RECURSIVE = createKeywordToken("RECURSIVE", "recursive");
+  IElementType SEALED = createKeywordToken("SEALED", "sealed");
+  IElementType TAILCALL = createKeywordToken("TAILCALL", "tailcall");
+  IElementType TRAIT = createKeywordToken("TRAIT", "trait");
+  IElementType VIRTUAL = createKeywordToken("VIRTUAL", "virtual");
+  IElementType VOLATILE = createKeywordToken("VOLATILE", "volatile");
 
-    IElementType PP_LIGHT = createToken("PP_LIGHT");
-    IElementType PP_ELSE_SECTION = createToken("PP_ELSE_SECTION");
-    IElementType PP_ENDIF = createToken("PP_ENDIF");
-    IElementType PP_LINE = createToken("PP_LINE");
-    IElementType PP_HELP = createToken("PP_HELP");
-    IElementType PP_LOAD = createToken("PP_LOAD");
-    IElementType PP_QUIT = createToken("PP_QUIT");
-    IElementType PP_I = createToken("PP_I");
-    IElementType PP_NOWARN = createToken("PP_NOWARN");
-    IElementType PP_REFERENCE = createToken("PP_REFERENCE");
-    IElementType PP_TIME = createToken("PP_TIME");
-    IElementType PP_IF_SECTION = createToken("PP_IF_SECTION");
-    IElementType PP_BAD_CHARACTER = createToken("PP_BAD_CHARACTER");
-    IElementType PP_CONDITIONAL_SYMBOL = createToken("PP_CONDITIONAL_SYMBOL");
-    IElementType PP_OR = createToken("PP_OR");
-    IElementType PP_AND = createToken("PP_AND");
-    IElementType PP_NOT = createToken("PP_NOT");
-    IElementType PP_LPAR = createToken("PP_LPAR");
-    IElementType PP_RPAR = createToken("PP_RPAR");
-    IElementType PP_DIRECTIVE= createToken("PP_DIRECTIVE");
+  IElementType PP_LIGHT = createToken("PP_LIGHT");
+  IElementType PP_ELSE_SECTION = createToken("PP_ELSE_SECTION");
+  IElementType PP_ENDIF = createToken("PP_ENDIF");
+  IElementType PP_LINE = createToken("PP_LINE");
+  IElementType PP_HELP = createToken("PP_HELP");
+  IElementType PP_LOAD = createToken("PP_LOAD");
+  IElementType PP_QUIT = createToken("PP_QUIT");
+  IElementType PP_I = createToken("PP_I");
+  IElementType PP_NOWARN = createToken("PP_NOWARN");
+  IElementType PP_REFERENCE = createToken("PP_REFERENCE");
+  IElementType PP_TIME = createToken("PP_TIME");
+  IElementType PP_IF_SECTION = createToken("PP_IF_SECTION");
+  IElementType PP_BAD_CHARACTER = createToken("PP_BAD_CHARACTER");
+  IElementType PP_CONDITIONAL_SYMBOL = createToken("PP_CONDITIONAL_SYMBOL");
+  IElementType PP_OR = createToken("PP_OR");
+  IElementType PP_AND = createToken("PP_AND");
+  IElementType PP_NOT = createToken("PP_NOT");
+  IElementType PP_LPAR = createToken("PP_LPAR");
+  IElementType PP_RPAR = createToken("PP_RPAR");
+  IElementType PP_DIRECTIVE = createToken("PP_DIRECTIVE");
 
-    TokenSet STRINGS = TokenSet.create(
-            STRING,
-            UNFINISHED_STRING,
-            UNFINISHED_VERBATIM_STRING,
-            UNFINISHED_TRIPLE_QUOTED_STRING,
-            VERBATIM_STRING,
-            TRIPLE_QUOTED_STRING,
-            BYTEARRAY,
-            VERBATIM_BYTEARRAY
-    );
+  TokenSet STRINGS = TokenSet.create(
+    STRING,
+    UNFINISHED_STRING,
+    UNFINISHED_VERBATIM_STRING,
+    UNFINISHED_TRIPLE_QUOTED_STRING,
+    VERBATIM_STRING,
+    TRIPLE_QUOTED_STRING,
+    BYTEARRAY,
+    VERBATIM_BYTEARRAY
+  );
 
-    TokenSet INTERPOLATED_STRINGS = TokenSet.create(
-            REGULAR_INTERPOLATED_STRING,
-            REGULAR_INTERPOLATED_STRING_START,
-            REGULAR_INTERPOLATED_STRING_MIDDLE,
-            REGULAR_INTERPOLATED_STRING_END,
-            VERBATIM_INTERPOLATED_STRING,
-            VERBATIM_INTERPOLATED_STRING_START,
-            VERBATIM_INTERPOLATED_STRING_MIDDLE,
-            VERBATIM_INTERPOLATED_STRING_END,
-            TRIPLE_QUOTE_INTERPOLATED_STRING,
-            TRIPLE_QUOTE_INTERPOLATED_STRING_START,
-            TRIPLE_QUOTE_INTERPOLATED_STRING_MIDDLE,
-            TRIPLE_QUOTE_INTERPOLATED_STRING_END,
-            UNFINISHED_REGULAR_INTERPOLATED_STRING,
-            UNFINISHED_VERBATIM_INTERPOLATED_STRING,
-            UNFINISHED_TRIPLE_QUOTE_INTERPOLATED_STRING
-    );
+  TokenSet INTERPOLATED_STRINGS = TokenSet.create(
+    REGULAR_INTERPOLATED_STRING,
+    REGULAR_INTERPOLATED_STRING_START,
+    REGULAR_INTERPOLATED_STRING_MIDDLE,
+    REGULAR_INTERPOLATED_STRING_END,
+    VERBATIM_INTERPOLATED_STRING,
+    VERBATIM_INTERPOLATED_STRING_START,
+    VERBATIM_INTERPOLATED_STRING_MIDDLE,
+    VERBATIM_INTERPOLATED_STRING_END,
+    TRIPLE_QUOTE_INTERPOLATED_STRING,
+    TRIPLE_QUOTE_INTERPOLATED_STRING_START,
+    TRIPLE_QUOTE_INTERPOLATED_STRING_MIDDLE,
+    TRIPLE_QUOTE_INTERPOLATED_STRING_END,
+    UNFINISHED_REGULAR_INTERPOLATED_STRING,
+    UNFINISHED_VERBATIM_INTERPOLATED_STRING,
+    UNFINISHED_TRIPLE_QUOTE_INTERPOLATED_STRING
+  );
 
-    TokenSet INTERPOLATED_STRING_ENDS = TokenSet.create(
-            REGULAR_INTERPOLATED_STRING_END,
-            VERBATIM_INTERPOLATED_STRING_END,
-            TRIPLE_QUOTE_INTERPOLATED_STRING_END
-    );
+  TokenSet INTERPOLATED_STRING_ENDS = TokenSet.create(
+    REGULAR_INTERPOLATED_STRING_END,
+    VERBATIM_INTERPOLATED_STRING_END,
+    TRIPLE_QUOTE_INTERPOLATED_STRING_END
+  );
 
-    TokenSet COMMENTS = TokenSet.create(
-            SHEBANG,
-            BLOCK_COMMENT
-    );
+  TokenSet COMMENTS = TokenSet.create(
+    SHEBANG,
+    BLOCK_COMMENT
+  );
 
-    TokenSet IDENT_KEYWORDS = TokenSet.create(
-            ABSTRACT,
-            AND,
-            AND_BANG,
-            AS,
-            ASSERT,
-            BASE,
-            BEGIN,
-            CLASS,
-            CONST,
-            DEFAULT,
-            DELEGATE,
-            DO,
-            DO_BANG,
-            DONE,
-            DOWNCAST,
-            DOWNTO,
-            ELIF,
-            ELSE,
-            END,
-            EXCEPTION,
-            EXTERN,
-            FALSE,
-            FINALLY,
-            FOR,
-            FUN,
-            FUNCTION,
-            GLOBAL,
-            HASH,
-            IF,
-            IN,
-            INHERIT,
-            INLINE,
-            INTERFACE,
-            INTERNAL,
-            LARROW,
-            LAZY,
-            LET,
-            LET_BANG,
-            MATCH,
-            MATCH_BANG,
-            MEMBER,
-            MODULE,
-            MUTABLE,
-            NAMESPACE,
-            NEW,
-            NULL,
-            OF,
-            OPEN,
-            OR,
-            OVERRIDE,
-            PRIVATE,
-            PUBLIC,
-            RARROW,
-            REC,
-            RETURN,
-            RETURN_BANG,
-            SIG,
-            STATIC,
-            STRUCT,
-            THEN,
-            TO,
-            TRUE,
-            TRY,
-            TYPE,
-            UPCAST,
-            USE,
-            USE_BANG,
-            VAL,
-            VOID,
-            WHEN,
-            WHILE,
-            WITH,
-            YIELD,
-            YIELD_BANG,
-            KEYWORD_STRING_LINE,
-            KEYWORD_STRING_SOURCE_DIRECTORY,
-            KEYWORD_STRING_SOURCE_FILE
-    );
+  TokenSet IDENT_KEYWORDS = TokenSet.create(
+    ABSTRACT,
+    AND,
+    AND_BANG,
+    AS,
+    ASSERT,
+    BASE,
+    BEGIN,
+    CLASS,
+    CONST,
+    DEFAULT,
+    DELEGATE,
+    DO,
+    DO_BANG,
+    DONE,
+    DOWNCAST,
+    DOWNTO,
+    ELIF,
+    ELSE,
+    END,
+    EXCEPTION,
+    EXTERN,
+    FALSE,
+    FINALLY,
+    FOR,
+    FUN,
+    FUNCTION,
+    GLOBAL,
+    HASH,
+    IF,
+    IN,
+    INHERIT,
+    INLINE,
+    INTERFACE,
+    INTERNAL,
+    LARROW,
+    LAZY,
+    LET,
+    LET_BANG,
+    MATCH,
+    MATCH_BANG,
+    MEMBER,
+    MODULE,
+    MUTABLE,
+    NAMESPACE,
+    NEW,
+    NULL,
+    OF,
+    OPEN,
+    OR,
+    OVERRIDE,
+    PRIVATE,
+    PUBLIC,
+    RARROW,
+    REC,
+    RETURN,
+    RETURN_BANG,
+    SIG,
+    STATIC,
+    STRUCT,
+    THEN,
+    TO,
+    TRUE,
+    TRY,
+    TYPE,
+    UPCAST,
+    USE,
+    USE_BANG,
+    VAL,
+    VOID,
+    WHEN,
+    WHILE,
+    WITH,
+    YIELD,
+    YIELD_BANG,
+    KEYWORD_STRING_LINE,
+    KEYWORD_STRING_SOURCE_DIRECTORY,
+    KEYWORD_STRING_SOURCE_FILE
+  );
 
-    TokenSet RESERVED_IDENT_KEYWORDS = TokenSet.create(
-            ATOMIC,
-            BREAK,
-            CHECKED,
-            COMPONENT,
-            CONST,
-            CONSTRAINT,
-            CONSTRUCTOR,
-            CONTINUE,
-            EAGER,
-            FIXED,
-            FORI,
-            FUNCTOR,
-            INCLUDE,
-            MEASURE,
-            METHOD,
-            MIXIN,
-            OBJECT,
-            PARALLEL,
-            PARAMS,
-            PROCESS,
-            PROTECTED,
-            PURE,
-            RECURSIVE,
-            SEALED,
-            TAILCALL,
-            TRAIT,
-            VIRTUAL,
-            VOLATILE
-    );
+  TokenSet RESERVED_IDENT_KEYWORDS = TokenSet.create(
+    ATOMIC,
+    BREAK,
+    CHECKED,
+    COMPONENT,
+    CONST,
+    CONSTRAINT,
+    CONSTRUCTOR,
+    CONTINUE,
+    EAGER,
+    FIXED,
+    FORI,
+    FUNCTOR,
+    INCLUDE,
+    MEASURE,
+    METHOD,
+    MIXIN,
+    OBJECT,
+    PARALLEL,
+    PARAMS,
+    PROCESS,
+    PROTECTED,
+    PURE,
+    RECURSIVE,
+    SEALED,
+    TAILCALL,
+    TRAIT,
+    VIRTUAL,
+    VOLATILE
+  );
 
-    TokenSet PP_KEYWORDS = TokenSet.create(
-            PP_IF_SECTION,
-            PP_ELSE_SECTION,
-            PP_ENDIF,
-            PP_LIGHT,
-            PP_LINE,
-            PP_REFERENCE,
-            PP_LOAD,
-            PP_I,
-            PP_TIME,
-            PP_NOWARN,
-            PP_HELP,
-            PP_QUIT,
-            PP_DIRECTIVE
-    );
+  TokenSet PP_KEYWORDS = TokenSet.create(
+    PP_IF_SECTION,
+    PP_ELSE_SECTION,
+    PP_ENDIF,
+    PP_LIGHT,
+    PP_LINE,
+    PP_REFERENCE,
+    PP_LOAD,
+    PP_I,
+    PP_TIME,
+    PP_NOWARN,
+    PP_HELP,
+    PP_QUIT,
+    PP_DIRECTIVE
+  );
 
-    TokenSet NUMBERS = TokenSet.create(
-            SBYTE,
-            BYTE,
-            INT16,
-            UINT16,
-            INT32,
-            INT32,
-            UINT32,
-            NATIVEINT,
-            UNATIVEINT,
-            INT64,
-            UINT64,
-            BIGNUM,
-            IEEE32,
-            IEEE64,
-            DECIMAL
-    );
+  TokenSet NUMBERS = TokenSet.create(
+    SBYTE,
+    BYTE,
+    INT16,
+    UINT16,
+    INT32,
+    INT32,
+    UINT32,
+    NATIVEINT,
+    UNATIVEINT,
+    INT64,
+    UINT64,
+    BIGNUM,
+    IEEE32,
+    IEEE64,
+    DECIMAL
+  );
 
-    @NotNull
-    static FSharpTokenNodeType createToken(@NotNull String value) {
-        return new FSharpTokenNodeType(value);
-    }
+  @NotNull
+  static FSharpTokenNodeType createToken(@NotNull String value) {
+    return new FSharpTokenNodeType(value);
+  }
 
-    @NotNull
-    static FSharpTokenNodeType createToken(@NotNull String value, @NotNull String representation) {
-        return new FSharpTokenNodeType(value, representation);
-    }
+  @NotNull
+  static FSharpTokenNodeType createToken(@NotNull String value, @NotNull String representation) {
+    return new FSharpTokenNodeType(value, representation);
+  }
 
-    @NotNull
-    static FSharpKeywordTokenNodeType createKeywordToken(String value, @NotNull String representation) {
-        return new FSharpKeywordTokenNodeType(value, representation, false);
-    }
+  @NotNull
+  static FSharpKeywordTokenNodeType createKeywordToken(String value, @NotNull String representation) {
+    return new FSharpKeywordTokenNodeType(value, representation, false);
+  }
 }

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/lexer/InterpolatedStringStackItem.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/lexer/InterpolatedStringStackItem.kt
@@ -1,7 +1,7 @@
 package com.jetbrains.rider.ideaInterop.fileTypes.fsharp.lexer
 
 enum class InterpolatedStringStackItem {
-    Paren,
-    Brace,
-    Bracket
+  Paren,
+  Brace,
+  Bracket
 }

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/lexer/RiderElementType.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/lexer/RiderElementType.kt
@@ -3,4 +3,5 @@ package com.jetbrains.rider.ideaInterop.fileTypes.fsharp.lexer
 import com.intellij.psi.tree.IElementType
 import com.jetbrains.rider.ideaInterop.fileTypes.RiderLanguageBase
 
-open class RiderElementType(value: String, val representation: String, language: RiderLanguageBase) : IElementType(value, language)
+open class RiderElementType(value: String, val representation: String, language: RiderLanguageBase) :
+  IElementType(value, language)

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/FSharpHost.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/FSharpHost.kt
@@ -9,27 +9,27 @@ import com.jetbrains.rdclient.util.idea.LifetimedProjectComponent
 import com.jetbrains.rider.projectView.solution
 
 class FSharpHost(project: Project) : LifetimedProjectComponent(project) {
-    private val fSharpModel = project.solution.rdFSharpModel
+  private val fSharpModel = project.solution.rdFSharpModel
 
-    companion object {
-        const val fcsBusyDelayRegistryKey = "rider.fsharp.fcsBusyDelay.ms"
-    }
+  companion object {
+    const val fcsBusyDelayRegistryKey = "rider.fsharp.fcsBusyDelay.ms"
+  }
 
-    init {
-        initRegistryValue(fcsBusyDelayRegistryKey, RegistryValue::asInteger, fSharpModel.fcsBusyDelayMs)
-    }
+  init {
+    initRegistryValue(fcsBusyDelayRegistryKey, RegistryValue::asInteger, fSharpModel.fcsBusyDelayMs)
+  }
 
-    private fun <T : Any> initRegistryValue(
-        registryKey: String,
-        registryToValue: (registryValue: RegistryValue) -> T,
-        property: IOptProperty<T>
-    ) {
-        val registryValue = Registry.get(registryKey)
-        property.set(registryToValue(registryValue))
-        registryValue.addListener(object : RegistryValueListener {
-            override fun afterValueChanged(value: RegistryValue) {
-                property.set(registryToValue(value))
-            }
-        }, project)
-    }
+  private fun <T : Any> initRegistryValue(
+    registryKey: String,
+    registryToValue: (registryValue: RegistryValue) -> T,
+    property: IOptProperty<T>
+  ) {
+    val registryValue = Registry.get(registryKey)
+    property.set(registryToValue(registryValue))
+    registryValue.addListener(object : RegistryValueListener {
+      override fun afterValueChanged(value: RegistryValue) {
+        property.set(registryToValue(value))
+      }
+    }, project)
+  }
 }

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/FSharpIcons.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/FSharpIcons.kt
@@ -3,7 +3,7 @@ package com.jetbrains.rider.plugins.fsharp
 import com.intellij.openapi.util.IconLoader
 
 object FSharpIcons {
-    val FSharp = IconLoader.getIcon("/icons/Fsharp.svg", FSharpIcons::class.java)
-    val FSharpScript = IconLoader.getIcon("/icons/FsharpScript.svg", FSharpIcons::class.java)
-    val FSharpConsole = IconLoader.getIcon("/icons/fsharpConsole.png", FSharpIcons::class.java)
+  val FSharp = IconLoader.getIcon("/icons/Fsharp.svg", FSharpIcons::class.java)
+  val FSharpScript = IconLoader.getIcon("/icons/FsharpScript.svg", FSharpIcons::class.java)
+  val FSharpConsole = IconLoader.getIcon("/icons/fsharpConsole.png", FSharpIcons::class.java)
 }

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/actions/FSharpDummyLineIndentProvider.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/actions/FSharpDummyLineIndentProvider.kt
@@ -4,5 +4,5 @@ import com.jetbrains.rdclient.editorActions.FrontendDummyLineIndentProvider
 import com.jetbrains.rider.ideaInterop.fileTypes.fsharp.FSharpLanguage
 import com.jetbrains.rider.ideaInterop.fileTypes.fsharp.FSharpScriptLanguage
 
-object FSharpDummyLineIndentProvider: FrontendDummyLineIndentProvider(FSharpLanguage)
-object FSharpScriptDummyLineIndentProvider: FrontendDummyLineIndentProvider(FSharpScriptLanguage)
+object FSharpDummyLineIndentProvider : FrontendDummyLineIndentProvider(FSharpLanguage)
+object FSharpScriptDummyLineIndentProvider : FrontendDummyLineIndentProvider(FSharpScriptLanguage)

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/actions/FSharpScratchCreationHelper.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/actions/FSharpScratchCreationHelper.kt
@@ -6,9 +6,9 @@ import com.intellij.openapi.project.Project
 import com.jetbrains.rider.ideaInterop.fileTypes.fsharp.FSharpScriptLanguage
 
 class FSharpScratchCreationHelper : ScratchFileCreationHelper() {
-    override fun prepareText(project: Project, context: Context, dataContext: DataContext): Boolean {
-        context.language = FSharpScriptLanguage
-        context.fileExtension = "fsx"
-        return false
-    }
+  override fun prepareText(project: Project, context: Context, dataContext: DataContext): Boolean {
+    context.language = FSharpScriptLanguage
+    context.fileExtension = "fsx"
+    return false
+  }
 }

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/breadcrumbs/breadcrumbs.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/breadcrumbs/breadcrumbs.kt
@@ -5,9 +5,9 @@ import com.jetbrains.rider.ideaInterop.fileTypes.fsharp.FSharpLanguage
 import com.jetbrains.rider.ideaInterop.fileTypes.fsharp.FSharpScriptLanguage
 
 class FSharpBreadcrumbsInfoProvider : BackendBreadcrumbsInfoProvider() {
-    override val language get() = FSharpLanguage
+  override val language get() = FSharpLanguage
 }
 
 class FSharpScriptBreadcrumbsInfoProvider : BackendBreadcrumbsInfoProvider() {
-    override val language get() = FSharpScriptLanguage
+  override val language get() = FSharpScriptLanguage
 }

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/logs/FSharpLogTraceScenarios.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/logs/FSharpLogTraceScenarios.kt
@@ -3,13 +3,15 @@ package com.jetbrains.rider.plugins.fsharp.logs
 import com.jetbrains.rd.platform.diagnostics.LogTraceScenario
 
 object FSharpLogTraceScenarios {
-    object FSharpProjectModel : LogTraceScenario(
-        "JetBrains.ReSharper.Plugins.FSharp.Checker.FcsCheckerService",
-        "JetBrains.ReSharper.Plugins.FSharp.Checker.FcsProjectProvider",
-        "JetBrains.ReSharper.Plugins.FSharp.Shim.AssemblyReader.AssemblyReaderShim")
+  object FSharpProjectModel : LogTraceScenario(
+    "JetBrains.ReSharper.Plugins.FSharp.Checker.FcsCheckerService",
+    "JetBrains.ReSharper.Plugins.FSharp.Checker.FcsProjectProvider",
+    "JetBrains.ReSharper.Plugins.FSharp.Shim.AssemblyReader.AssemblyReaderShim"
+  )
 
-    object FSharpFileSystem : LogTraceScenario(
-            "JetBrains.ReSharper.Plugins.FSharp.DelegatingFileSystemShim",
-            "JetBrains.ReSharper.Plugins.FSharp.Shim.FileSystem.FSharpSourceCache",
-            "JetBrains.ReSharper.Plugins.FSharp.Shim.FileSystem.AssemblyInfoShim")
+  object FSharpFileSystem : LogTraceScenario(
+    "JetBrains.ReSharper.Plugins.FSharp.DelegatingFileSystemShim",
+    "JetBrains.ReSharper.Plugins.FSharp.Shim.FileSystem.FSharpSourceCache",
+    "JetBrains.ReSharper.Plugins.FSharp.Shim.FileSystem.AssemblyInfoShim"
+  )
 }

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/projectView/FSharpMoveProviderExtension.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/projectView/FSharpMoveProviderExtension.kt
@@ -18,180 +18,193 @@ import com.jetbrains.rider.util.idea.application
 
 class FSharpMoveProviderExtension(project: Project) : MoveProviderExtension(project) {
 
-    companion object {
-        const val CompileBeforeType: String = "CompileBefore"
-        const val CompileAfterType: String = "CompileAfter"
+  companion object {
+    const val CompileBeforeType: String = "CompileBefore"
+    const val CompileAfterType: String = "CompileAfter"
 
-        fun isSpecialCompileType(descriptor: RdProjectFileDescriptor) : Boolean {
-            return descriptor.buildAction in arrayOf(CompileBeforeType, CompileAfterType)
-        }
+    fun isSpecialCompileType(descriptor: RdProjectFileDescriptor): Boolean {
+      return descriptor.buildAction in arrayOf(CompileBeforeType, CompileAfterType)
+    }
+  }
+
+  private fun ProjectModelEntity.prevSibling() = getSibling { index -> index - 1 }
+  private fun ProjectModelEntity.nextSibling() = getSibling { index -> index + 1 }
+
+  private fun ProjectModelEntity.getSibling(indexFunc: (Int) -> Int): ProjectModelEntity? {
+    val parent = parentEntity ?: return null
+    val siblings = parent.getSortedChildren()
+    val index = siblings.indexOf(this)
+    val newIndex = indexFunc(index)
+    if (newIndex < 0 || newIndex > siblings.count() - 1)
+      return null
+    return siblings[newIndex]
+  }
+
+  private fun ProjectModelEntity.getSortedChildren(): List<ProjectModelEntity> {
+    val comparator = Comparator<ProjectModelEntity> { p0, p1 ->
+      if (p0 == null && p1 == null) return@Comparator 0
+      if (p0 == null) return@Comparator 1
+      if (p1 == null) return@Comparator -1
+      compareProjectModelEntities(project, p0, p1)
+    }
+    return childrenEntities.sortedWith(comparator).toList()
+  }
+
+  override fun supportOrdering(element: ProjectElementView): NodeOrderType {
+    if (element is ProjectEntityView && isFSharpNode(element.entity)) {
+      if (element.entity.isProjectFile()) return NodeOrderType.BeforeAfter
+      if (element.entity.isProjectFolder()) return NodeOrderType.BeforeAfterInside
+      return NodeOrderType.None
+    }
+    return super.supportOrdering(element)
+  }
+
+  override fun allowPaste(
+    entities: Collection<ProjectModelEntity>,
+    relativeTo: ProjectElementView,
+    orderType: ActionOrderType
+  ): Boolean {
+    if (entities.any { it.isProjectFolder() && it.containingProjectEntity()?.url?.toVirtualFile()?.extension == "fsproj" })
+      return false
+
+    if (orderType == ActionOrderType.None) {
+      return super.allowPaste(entities, relativeTo, orderType)
     }
 
-    private fun ProjectModelEntity.prevSibling() = getSibling { index -> index - 1 }
-    private fun ProjectModelEntity.nextSibling() = getSibling { index -> index + 1 }
+    if (relativeTo is ProjectEntityView && isFSharpNode(relativeTo.entity)) {
+      val nodesItemType = getNodesItemType(entities)
+      if (nodesItemType == FSharpItemType.Mix) return false
 
-    private fun ProjectModelEntity.getSibling(indexFunc: (Int) -> Int): ProjectModelEntity? {
-        val parent = parentEntity ?: return null
-        val siblings = parent.getSortedChildren()
-        val index = siblings.indexOf(this)
-        val newIndex = indexFunc(index)
-        if (newIndex < 0 || newIndex > siblings.count() - 1)
-            return null
-        return siblings[newIndex]
-    }
-
-    private fun ProjectModelEntity.getSortedChildren(): List<ProjectModelEntity> {
-        val comparator = Comparator<ProjectModelEntity> { p0, p1 ->
-            if (p0 == null && p1 == null) return@Comparator 0
-            if (p0 == null) return@Comparator 1
-            if (p1 == null) return@Comparator -1
-            compareProjectModelEntities(project, p0, p1)
-        }
-        return childrenEntities.sortedWith(comparator).toList()
-    }
-
-    override fun supportOrdering(element: ProjectElementView): NodeOrderType {
-        if (element is ProjectEntityView && isFSharpNode(element.entity)) {
-            if (element.entity.isProjectFile()) return NodeOrderType.BeforeAfter
-            if (element.entity.isProjectFolder()) return NodeOrderType.BeforeAfterInside
-            return NodeOrderType.None
-        }
-        return super.supportOrdering(element)
-    }
-
-    override fun allowPaste(entities: Collection<ProjectModelEntity>, relativeTo: ProjectElementView, orderType: ActionOrderType): Boolean {
-        if (entities.any { it.isProjectFolder() && it.containingProjectEntity()?.url?.toVirtualFile()?.extension == "fsproj" })
-            return false
-
-        if (orderType == ActionOrderType.None) {
-            return super.allowPaste(entities, relativeTo, orderType)
-        }
-
-        if (relativeTo is ProjectEntityView && isFSharpNode(relativeTo.entity)) {
-            val nodesItemType = getNodesItemType(entities)
-            if (nodesItemType == FSharpItemType.Mix) return false
-
-            val relativeToEntity = relativeTo.entity
-            when (orderType) {
-                ActionOrderType.Before -> {
-                    when (nodesItemType) {
-                        FSharpItemType.Default -> {
-                            if (relativeToEntity.isCompileBefore(ActionOrderType.Before))
-                                return false
-                            if (relativeToEntity.prevSibling().isCompileAfter(ActionOrderType.After))
-                                return false
-                            return true
-                        }
-                        FSharpItemType.CompileBefore ->
-                            return relativeToEntity.isCompileBefore(ActionOrderType.Before) ||
-                                    relativeToEntity.prevSibling().isCompileBefore(ActionOrderType.After)
-                        FSharpItemType.CompileAfter -> return relativeToEntity.isCompileAfter(ActionOrderType.Before)
-                        else -> {
-                        }
-                    }
-                }
-                ActionOrderType.After -> {
-                    when (nodesItemType) {
-                        FSharpItemType.Default -> {
-                            if (relativeToEntity.isCompileAfter(ActionOrderType.After))
-                                return false
-                            if (relativeToEntity.nextSibling().isCompileBefore(ActionOrderType.Before))
-                                return false
-                            return true
-                        }
-                        FSharpItemType.CompileBefore -> return relativeToEntity.isCompileBefore(ActionOrderType.After)
-                        FSharpItemType.CompileAfter ->
-                            return relativeToEntity.isCompileAfter(ActionOrderType.After) ||
-                                    relativeToEntity.nextSibling().isCompileAfter(ActionOrderType.Before)
-                        else -> {
-                        }
-                    }
-                }
-                ActionOrderType.None -> throw Exception()
+      val relativeToEntity = relativeTo.entity
+      when (orderType) {
+        ActionOrderType.Before -> {
+          when (nodesItemType) {
+            FSharpItemType.Default -> {
+              if (relativeToEntity.isCompileBefore(ActionOrderType.Before))
+                return false
+              if (relativeToEntity.prevSibling().isCompileAfter(ActionOrderType.After))
+                return false
+              return true
             }
 
-        }
-        return super.allowPaste(entities, relativeTo, orderType)
-    }
+            FSharpItemType.CompileBefore ->
+              return relativeToEntity.isCompileBefore(ActionOrderType.Before) ||
+                relativeToEntity.prevSibling().isCompileBefore(ActionOrderType.After)
 
-    private fun getNodesItemType(entities: Collection<ProjectModelEntity>): FSharpItemType {
-        var compileBeforeFound = false
-        var compileAfterFound = false
-        var other = false
-        for (node in entities) {
-            if (node.isProjectFile()) {
-                when {
-                    node.isCompileBefore(ActionOrderType.None) -> compileBeforeFound = true
-                    node.isCompileAfter(ActionOrderType.None) -> compileAfterFound = true
-                    else -> other = true
-                }
+            FSharpItemType.CompileAfter -> return relativeToEntity.isCompileAfter(ActionOrderType.Before)
+            else -> {
             }
-            if (node.isProjectFolder()) {
-                when (getNodesItemType(node.childrenEntities.toList())) {
-                    FSharpItemType.Default -> {
-                        other = true
-                    }
-                    FSharpItemType.Mix -> {
-                        compileBeforeFound = true
-                        compileAfterFound = true
-                    }
-                    FSharpItemType.CompileBefore -> {
-                        compileBeforeFound = true
-                    }
-                    FSharpItemType.CompileAfter -> {
-                        compileAfterFound = true
-                    }
-                }
+          }
+        }
+
+        ActionOrderType.After -> {
+          when (nodesItemType) {
+            FSharpItemType.Default -> {
+              if (relativeToEntity.isCompileAfter(ActionOrderType.After))
+                return false
+              if (relativeToEntity.nextSibling().isCompileBefore(ActionOrderType.Before))
+                return false
+              return true
             }
-        }
 
-        if (!compileBeforeFound && !compileAfterFound) return FSharpItemType.Default
-        if (compileBeforeFound && !compileAfterFound && !other) return FSharpItemType.CompileBefore
-        if (!compileBeforeFound && compileAfterFound && !other) return FSharpItemType.CompileAfter
-        return FSharpItemType.Mix
-    }
+            FSharpItemType.CompileBefore -> return relativeToEntity.isCompileBefore(ActionOrderType.After)
+            FSharpItemType.CompileAfter ->
+              return relativeToEntity.isCompileAfter(ActionOrderType.After) ||
+                relativeToEntity.nextSibling().isCompileAfter(ActionOrderType.Before)
 
-    private fun isFSharpNode(entity: ProjectModelEntity): Boolean {
-        return entity.containingProjectEntity()?.url?.toVirtualFile()?.extension == "fsproj" ||
-                application.isUnitTestMode // todo: workaround for dummy project?
-    }
-
-    private fun ProjectModelEntity?.isCompileBefore(orderType: ActionOrderType): Boolean {
-        this ?: return false
-        val descriptor = descriptor
-        if (descriptor is RdProjectFileDescriptor) {
-            return descriptor.buildAction == CompileBeforeType
-        }
-        if (isProjectFolder()) {
-            return when (orderType) {
-                ActionOrderType.Before -> getSortedChildren().firstOrNull()?.isCompileBefore(orderType) == true
-                ActionOrderType.After -> getSortedChildren().lastOrNull()?.isCompileBefore(orderType) == true
-                ActionOrderType.None -> false
+            else -> {
             }
+          }
         }
-        return false
+
+        ActionOrderType.None -> throw Exception()
+      }
+
+    }
+    return super.allowPaste(entities, relativeTo, orderType)
+  }
+
+  private fun getNodesItemType(entities: Collection<ProjectModelEntity>): FSharpItemType {
+    var compileBeforeFound = false
+    var compileAfterFound = false
+    var other = false
+    for (node in entities) {
+      if (node.isProjectFile()) {
+        when {
+          node.isCompileBefore(ActionOrderType.None) -> compileBeforeFound = true
+          node.isCompileAfter(ActionOrderType.None) -> compileAfterFound = true
+          else -> other = true
+        }
+      }
+      if (node.isProjectFolder()) {
+        when (getNodesItemType(node.childrenEntities.toList())) {
+          FSharpItemType.Default -> {
+            other = true
+          }
+
+          FSharpItemType.Mix -> {
+            compileBeforeFound = true
+            compileAfterFound = true
+          }
+
+          FSharpItemType.CompileBefore -> {
+            compileBeforeFound = true
+          }
+
+          FSharpItemType.CompileAfter -> {
+            compileAfterFound = true
+          }
+        }
+      }
     }
 
-    private fun ProjectModelEntity?.isCompileAfter(orderType: ActionOrderType): Boolean {
-        this ?: return false
-        val descriptor = descriptor
-        if (descriptor is RdProjectFileDescriptor) {
-            return descriptor.buildAction == CompileAfterType
-        }
-        if (isProjectFolder()) {
-            return when (orderType) {
-                ActionOrderType.Before -> getSortedChildren().firstOrNull()?.isCompileAfter(orderType) == true
-                ActionOrderType.After -> getSortedChildren().lastOrNull()?.isCompileAfter(orderType) == true
-                ActionOrderType.None -> false
-            }
-        }
-        return false
-    }
+    if (!compileBeforeFound && !compileAfterFound) return FSharpItemType.Default
+    if (compileBeforeFound && !compileAfterFound && !other) return FSharpItemType.CompileBefore
+    if (!compileBeforeFound && compileAfterFound && !other) return FSharpItemType.CompileAfter
+    return FSharpItemType.Mix
+  }
 
-    enum class FSharpItemType {
-        Default,
-        Mix,
-        CompileBefore,
-        CompileAfter
+  private fun isFSharpNode(entity: ProjectModelEntity): Boolean {
+    return entity.containingProjectEntity()?.url?.toVirtualFile()?.extension == "fsproj" ||
+      application.isUnitTestMode // todo: workaround for dummy project?
+  }
+
+  private fun ProjectModelEntity?.isCompileBefore(orderType: ActionOrderType): Boolean {
+    this ?: return false
+    val descriptor = descriptor
+    if (descriptor is RdProjectFileDescriptor) {
+      return descriptor.buildAction == CompileBeforeType
     }
+    if (isProjectFolder()) {
+      return when (orderType) {
+        ActionOrderType.Before -> getSortedChildren().firstOrNull()?.isCompileBefore(orderType) == true
+        ActionOrderType.After -> getSortedChildren().lastOrNull()?.isCompileBefore(orderType) == true
+        ActionOrderType.None -> false
+      }
+    }
+    return false
+  }
+
+  private fun ProjectModelEntity?.isCompileAfter(orderType: ActionOrderType): Boolean {
+    this ?: return false
+    val descriptor = descriptor
+    if (descriptor is RdProjectFileDescriptor) {
+      return descriptor.buildAction == CompileAfterType
+    }
+    if (isProjectFolder()) {
+      return when (orderType) {
+        ActionOrderType.Before -> getSortedChildren().firstOrNull()?.isCompileAfter(orderType) == true
+        ActionOrderType.After -> getSortedChildren().lastOrNull()?.isCompileAfter(orderType) == true
+        ActionOrderType.None -> false
+      }
+    }
+    return false
+  }
+
+  enum class FSharpItemType {
+    Default,
+    Mix,
+    CompileBefore,
+    CompileAfter
+  }
 }

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/projectView/FSharpProjectModelNodeExtensions.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/projectView/FSharpProjectModelNodeExtensions.kt
@@ -7,11 +7,11 @@ import com.jetbrains.rider.projectView.workspace.ProjectModelEntity
 import com.jetbrains.rider.projectView.workspace.containingProjectEntity
 
 fun ProjectModelEntity.isFromFSharpProject(): Boolean =
-        containingProjectEntity()?.url?.toVirtualFile()?.extension.equals("fsproj", true)
+  containingProjectEntity()?.url?.toVirtualFile()?.extension.equals("fsproj", true)
 
 fun ProjectModelEntity.getSortKey(): Int =
-        when (val descriptor = this.descriptor) {
-            is RdProjectFileDescriptor -> descriptor.sortKey ?: -1
-            is RdProjectFolderDescriptor -> descriptor.sortKey ?: -1
-            else -> -1
-        }
+  when (val descriptor = this.descriptor) {
+    is RdProjectFileDescriptor -> descriptor.sortKey ?: -1
+    is RdProjectFolderDescriptor -> descriptor.sortKey ?: -1
+    else -> -1
+  }

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/projectView/FSharpProjectModelViewExtensions.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/projectView/FSharpProjectModelViewExtensions.kt
@@ -8,9 +8,9 @@ import com.jetbrains.rider.projectView.workspace.ProjectModelEntity
 import com.jetbrains.rider.projectView.workspace.getProjectModelEntities
 
 class FSharpProjectModelViewExtensions(project: Project) : ProjectModelViewExtensions(project) {
-    override fun getBestParentProjectModelNode(targetLocation: VirtualFile): ProjectModelEntity? {
-        val entities = WorkspaceModel.getInstance(project).getProjectModelEntities(targetLocation, project).toList()
-        if (entities.isEmpty() || !entities[0].isFromFSharpProject()) return null
-        return entities.maxByOrNull { it.getSortKey() }
-    }
+  override fun getBestParentProjectModelNode(targetLocation: VirtualFile): ProjectModelEntity? {
+    val entities = WorkspaceModel.getInstance(project).getProjectModelEntities(targetLocation, project).toList()
+    if (entities.isEmpty() || !entities[0].isFromFSharpProject()) return null
+    return entities.maxByOrNull { it.getSortKey() }
+  }
 }

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/projectView/FSharpSolutionExplorerCustomization.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/projectView/FSharpSolutionExplorerCustomization.kt
@@ -9,12 +9,12 @@ import com.jetbrains.rider.projectView.workspace.ProjectModelEntity
 
 class FSharpSolutionExplorerCustomization(project: Project) : SolutionExplorerCustomization(project) {
 
-    override fun updateNode(presentation: PresentationData, entity: ProjectModelEntity) {
-        val descriptor = entity.descriptor
-        if (descriptor is RdProjectFileDescriptor && FSharpMoveProviderExtension.isSpecialCompileType(descriptor)) {
-            presentation.addText(" [${descriptor.buildAction}]", SimpleTextAttributes.GRAY_ATTRIBUTES)
-        }
+  override fun updateNode(presentation: PresentationData, entity: ProjectModelEntity) {
+    val descriptor = entity.descriptor
+    if (descriptor is RdProjectFileDescriptor && FSharpMoveProviderExtension.isSpecialCompileType(descriptor)) {
+      presentation.addText(" [${descriptor.buildAction}]", SimpleTextAttributes.GRAY_ATTRIBUTES)
     }
+  }
 
-    override fun ignoreFoldersOnTop(entity: ProjectModelEntity) = entity.isFromFSharpProject()
+  override fun ignoreFoldersOnTop(entity: ProjectModelEntity) = entity.isFromFSharpProject()
 }

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/completion/FSharpCompletionStrategy.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/completion/FSharpCompletionStrategy.kt
@@ -6,7 +6,7 @@ import com.intellij.psi.PsiFile
 import com.jetbrains.rider.completion.CompletionSessionStrategy
 
 class FSharpCompletionStrategy : CompletionSessionStrategy {
-    override fun shouldForbidCompletion(editor: Editor, type: CompletionType) = editor.selectionModel.hasSelection()
-    override fun shouldRescheduleCompletion(prefix: String, psiFile: PsiFile, char: Char?, offset: Int) =
-            prefix.isEmpty()
+  override fun shouldForbidCompletion(editor: Editor, type: CompletionType) = editor.selectionModel.hasSelection()
+  override fun shouldRescheduleCompletion(prefix: String, psiFile: PsiFile, char: Char?, offset: Int) =
+    prefix.isEmpty()
 }

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/CommandHistory.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/CommandHistory.kt
@@ -3,28 +3,28 @@ package com.jetbrains.rider.plugins.fsharp.services.fsi
 import com.intellij.openapi.util.text.StringUtil
 
 class CommandHistory {
-    class Entry(val visibleText: String, val executableText: String) {
-        override fun toString(): String {
-            val lines = StringUtil.splitByLines(visibleText)
-            return if (lines.size > 1) lines[0] + " ..." else lines[0]
-        }
+  class Entry(val visibleText: String, val executableText: String) {
+    override fun toString(): String {
+      val lines = StringUtil.splitByLines(visibleText)
+      return if (lines.size > 1) lines[0] + " ..." else lines[0]
     }
+  }
 
-    val entries = arrayListOf<Entry>()
-    val size get() = entries.size
+  val entries = arrayListOf<Entry>()
+  val size get() = entries.size
 
-    operator fun get(i: Int) = entries[i]
+  operator fun get(i: Int) = entries[i]
 
-    val listeners = arrayListOf<HistoryUpdateListener>()
+  val listeners = arrayListOf<HistoryUpdateListener>()
 
-    fun addEntry(entry: Entry) {
-        if (!StringUtil.isEmptyOrSpaces(entry.visibleText))
-            entries.add(entry)
-        listeners.forEach { it.onNewEntry(entry) }
-    }
+  fun addEntry(entry: Entry) {
+    if (!StringUtil.isEmptyOrSpaces(entry.visibleText))
+      entries.add(entry)
+    listeners.forEach { it.onNewEntry(entry) }
+  }
 
 }
 
 interface HistoryUpdateListener {
-    fun onNewEntry(entry: CommandHistory.Entry)
+  fun onNewEntry(entry: CommandHistory.Entry)
 }

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/FsiConsoleIndicatorRenderer.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/FsiConsoleIndicatorRenderer.kt
@@ -3,9 +3,9 @@ package com.jetbrains.rider.plugins.fsharp.services.fsi
 import com.intellij.openapi.editor.markup.GutterIconRenderer
 
 class FsiConsoleIndicatorRenderer(private val iconWithTooltip: IconWithTooltip) : GutterIconRenderer() {
-    override fun getIcon() = iconWithTooltip.icon
-    override fun getTooltipText() = iconWithTooltip.tooltip
+  override fun getIcon() = iconWithTooltip.icon
+  override fun getTooltipText() = iconWithTooltip.tooltip
 
-    override fun equals(other: Any?) = icon == (other as? FsiConsoleIndicatorRenderer)?.icon
-    override fun hashCode() = icon.hashCode()
+  override fun equals(other: Any?) = icon == (other as? FsiConsoleIndicatorRenderer)?.icon
+  override fun hashCode() = icon.hashCode()
 }

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/FsiConsoleRunner.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/FsiConsoleRunner.kt
@@ -54,265 +54,276 @@ import javax.swing.BorderFactory
 import javax.swing.event.HyperlinkEvent
 import kotlin.properties.Delegates
 
-class FsiConsoleRunner(sessionInfo: RdFsiSessionInfo, val fsiHost: FsiHost, debug: Boolean)
-    : AbstractConsoleRunnerWithHistory<LanguageConsoleView>(fsiHost.project, fsiTitle, null) {
+class FsiConsoleRunner(sessionInfo: RdFsiSessionInfo, val fsiHost: FsiHost, debug: Boolean) :
+  AbstractConsoleRunnerWithHistory<LanguageConsoleView>(fsiHost.project, fsiTitle, null) {
 
-    companion object {
-        const val fsiTitle = "F# Interactive"
-        private const val debugNotConfiguredTitle = "The session is not configured for debugging"
-        private const val debugNotConfiguredDescription = "F# Interactive should be relaunched."
-        private const val notificationLinks = "<br/>${RelaunchFsiWithDebugAction.link}&nbsp;&nbsp;&nbsp;&nbsp;${ShowFsiSettingsAction.link}"
+  companion object {
+    const val fsiTitle = "F# Interactive"
+    private const val debugNotConfiguredTitle = "The session is not configured for debugging"
+    private const val debugNotConfiguredDescription = "F# Interactive should be relaunched."
+    private const val notificationLinks =
+      "<br/>${RelaunchFsiWithDebugAction.link}&nbsp;&nbsp;&nbsp;&nbsp;${ShowFsiSettingsAction.link}"
 
-        private val debugFsiArgs = listOf("--optimize-", "--debug+")
+    private val debugFsiArgs = listOf("--optimize-", "--debug+")
 
-        private const val waitForDebugSessionTimeout = 15000L
+    private const val waitForDebugSessionTimeout = 15000L
+  }
+
+  val optimizeForDebug = debug || sessionInfo.fixArgsForAttach
+  private val fsiArgs = sessionInfo.args + (if (optimizeForDebug) debugFsiArgs else emptyList())
+  private var cmdLine = GeneralCommandLine()
+    .withExePath(sessionInfo.fsiPath)
+    .withParameters(fsiArgs)
+  private val inputSeparatorGutterContentProvider = InputSeparatorGutterContentProvider(true)
+
+  private val fsiInputOutputProcessor = FsiInputOutputProcessor(this)
+
+  init {
+    val runtimeHost = project.getComponent<RiderDotNetActiveRuntimeHost>()
+    if (sessionInfo.runtime == RdFsiRuntime.Core) {
+      runtimeHost.dotNetCoreRuntime.value?.patchRunCommandLine(cmdLine, listOf())
+    } else {
+      val runtime = runtimeHost.getCurrentClassicNetRuntime(false).runtime
+      if (runtime != null && runtime is MonoRuntime && sessionInfo.fsiPath.endsWith(".exe", true)) {
+        runtime.patchRunCommandLine(cmdLine, listOf())
+      }
     }
 
-    val optimizeForDebug = debug || sessionInfo.fixArgsForAttach
-    private val fsiArgs = sessionInfo.args + (if (optimizeForDebug) debugFsiArgs else emptyList())
-    private var cmdLine = GeneralCommandLine()
-            .withExePath(sessionInfo.fsiPath)
-            .withParameters(fsiArgs)
-    private val inputSeparatorGutterContentProvider = InputSeparatorGutterContentProvider(true)
+    if (project.isDirectoryBased) {
+      val projectDir = project.baseDir
+      val workingDir = if (projectDir.exists()) projectDir else VfsUtil.getUserHomeDir()
+      if (workingDir != null)
+        cmdLine.workDirectory = File(workingDir.path)
+    }
+  }
 
-    private val fsiInputOutputProcessor = FsiInputOutputProcessor(this)
+  private var contentDescriptor by Delegates.notNull<RunContentDescriptor>()
+  private var pid by Delegates.notNull<Int>()
 
-    init {
-        val runtimeHost = project.getComponent<RiderDotNetActiveRuntimeHost>()
-        if (sessionInfo.runtime == RdFsiRuntime.Core) {
-            runtimeHost.dotNetCoreRuntime.value?.patchRunCommandLine(cmdLine, listOf())
+  private val isAttached
+    get() = getDebugProcessForThisFsi() != null
+
+  private val lockObject = Object()
+
+  val sendActionExecutor = SendToFsiActionExecutor(this)
+  val commandHistory = CommandHistory()
+
+  private val listener = object : NotificationListener.Adapter() {
+    override fun hyperlinkActivated(notification: Notification, e: HyperlinkEvent) {
+      if (!project.isDisposed) {
+        val actionEvent =
+          AnActionEvent.createFromDataContext(ActionPlaces.UNKNOWN, null, DataManager.getInstance().dataContext)
+        when (e.description) {
+          RelaunchFsiWithDebugAction.actionName -> RelaunchFsiWithDebugAction(project).actionPerformed(actionEvent)
+          ShowFsiSettingsAction.actionName -> ShowFsiSettingsAction(project).actionPerformed(actionEvent)
+        }
+        notification.expire()
+
+      }
+    }
+  }
+
+  fun isValid() = !processHandler.isProcessTerminated && !processHandler.isProcessTerminating
+
+  private fun getDebugProcessForThisFsi() = XDebuggerManager.getInstance(project).debugSessions
+    .map { it.debugProcess }.filterIsInstance<DotNetDebugProcess>().firstOrNull()
+
+  fun attachToProcess(): Boolean {
+    if (!optimizeForDebug) {
+      val notification = Notification(
+        fsiTitle, debugNotConfiguredTitle, debugNotConfiguredDescription + notificationLinks,
+        NotificationType.WARNING, listener
+      )
+      notification.icon = FSharpIcons.FSharpConsole
+      Notifications.Bus.notify(notification, project)
+      return false
+    }
+
+    val processInfo = OSProcessUtil.getProcessList().firstOrNull { it.pid == pid } ?: return false
+    val dataHolder = UserDataHolderBase()
+    val debugger = Extensions.getExtensions(XAttachDebuggerProvider.EP).flatMap { provider ->
+      provider.getAvailableDebuggers(project, LocalAttachHost.INSTANCE, processInfo, dataHolder)
+    }.firstOrNull() ?: return false
+    debugger.attachDebugSession(project, LocalAttachHost.INSTANCE, processInfo)
+    return true
+  }
+
+  private fun sendText(visibleText: String, fsiText: String) {
+    UIUtil.invokeLaterIfNeeded {
+      inputSeparatorGutterContentProvider.addLineSeparator(consoleView.historyViewer.document.lineCount)
+
+      fsiInputOutputProcessor.printInputText(visibleText, ConsoleViewContentType.USER_INPUT)
+
+      commandHistory.addEntry(CommandHistory.Entry(visibleText, fsiText))
+
+      // show the window without getting focus
+      RunContentManager.getInstance(project).selectRunContent(contentDescriptor)
+      ToolWindowManager.getInstance(project).getToolWindow(executor.id)?.show(null)
+
+      val stream = processHandler.processInput ?: error("Broken Fsi stream")
+      if (!StringUtil.isEmptyOrSpaces(visibleText)) {
+        stream.write(fsiText.toByteArray(Charsets.UTF_8))
+        stream.flush()
+      }
+    }
+  }
+
+  fun sendText(visibleText: String, fsiText: String, debug: Boolean) {
+    attachDebuggerIfNeeded(debug).onSuccess {
+      sendText(visibleText, fsiText)
+    }.onError {
+      sendText(visibleText, fsiText)
+      Logger.getInstance(FsiConsoleRunner::class.java).warn(it)
+    }
+  }
+
+  private fun attachDebuggerIfNeeded(debug: Boolean): Promise<Unit> {
+    if (!debug || isAttached) {
+      return resolvedPromise()
+    }
+    synchronized(lockObject) {
+      val promise = AsyncPromise<Unit>()
+      if (!attachToProcess()) {
+        promise.setResult(Unit)
+        return promise
+      }
+      //need to free dispatcher thread to pump messages over protocol for async debug runner
+      application.executeOnPooledThread {
+        if (!pumpMessages(Duration.ofSeconds(waitForDebugSessionTimeout)) {
+            getDebugProcessForThisFsi() != null
+          }) {
+          promise.setError(IllegalStateException("Failed to get debug process for fsi.exe with pid $pid"))
         } else {
-            val runtime = runtimeHost.getCurrentClassicNetRuntime(false).runtime
-            if (runtime != null && runtime is MonoRuntime && sessionInfo.fsiPath.endsWith(".exe", true)) {
-                runtime.patchRunCommandLine(cmdLine, listOf())
-            }
+          promise.setResult(Unit)
         }
+      }
+      return promise
+    }
+  }
 
-        if (project.isDirectoryBased) {
-            val projectDir = project.baseDir
-            val workingDir = if (projectDir.exists()) projectDir else VfsUtil.getUserHomeDir()
-            if (workingDir != null)
-                cmdLine.workDirectory = File(workingDir.path)
-        }
+  override fun createProcess(): Process? {
+    val process = cmdLine.createProcess()
+    pid = OSProcessUtil.getProcessID(process)
+    return process
+  }
+
+  override fun isAutoFocusContent() = false
+
+  override fun createExecuteActionHandler(): ProcessBackedConsoleExecuteActionHandler {
+    return object : ProcessBackedConsoleExecuteActionHandler(processHandler, false) {
+      override fun runExecuteAction(consoleView: LanguageConsoleView) {
+        val visibleText = consoleView.consoleEditor.document.text
+        if (visibleText.isBlank()) return
+
+        val fsiText = "\n$visibleText\n# 1 \"stdin\"\n;;\n"
+        sendText(visibleText, fsiText, false)
+        consoleView.setInputText("")
+      }
+    }
+  }
+
+  override fun getConsoleIcon() = FSharpIcons.FSharpConsole
+
+  override fun fillToolBarActions(
+    toolbarActions: DefaultActionGroup, defaultExecutor: Executor,
+    contentDescriptor: RunContentDescriptor
+  ): MutableList<AnAction> {
+    this.contentDescriptor = contentDescriptor
+    val actionList = ContainerUtil.newArrayList<AnAction>(
+      createCloseAction(defaultExecutor, contentDescriptor),
+      ResetFsiAction(this.fsiHost),
+      Separator(),
+      CommandHistoryAction(this),
+      Separator(),
+      OpenSettings(project)
+    )
+    toolbarActions.addAll(actionList)
+    actionList.add(createConsoleExecAction(consoleExecuteActionHandler))
+    return actionList
+  }
+
+  override fun initAndRun() {
+    super.initAndRun()
+
+    setupGutters()
+  }
+
+  private fun setupGutters() {
+    val historyEditor = consoleView.historyViewer
+    historyEditor.settings.isLineMarkerAreaShown = true
+    historyEditor.settings.isFoldingOutlineShown = true
+    historyEditor.gutterComponentEx.setPaintBackground(true)
+
+    historyEditor.colorsScheme.setColor(EditorColors.GUTTER_BACKGROUND, JBColor(Gray.xF2, Gray.x41))
+  }
+
+  override fun createConsoleView(): LanguageConsoleView {
+    var createdConsoleView: LanguageConsoleView? = null
+
+    withGenericSandBoxing(createFSharpSandbox("do ()\n\n", false, emptyList()), project) {
+      val consoleView = LanguageConsoleBuilder().gutterContentProvider(inputSeparatorGutterContentProvider)
+        .build(project, FSharpScriptLanguage)
+
+      val consoleEditorBorder = BorderFactory.createMatteBorder(
+        2, 0, 0, 0, consoleView.consoleEditor.colorsScheme.getColor(EditorColors.INDENT_GUIDE_COLOR)
+      )
+      consoleView.consoleEditor.component.border = consoleEditorBorder
+
+      val historyKeyListener = HistoryKeyListener(fsiHost.project, consoleView.consoleEditor, commandHistory)
+      consoleView.consoleEditor.contentComponent.addKeyListener(historyKeyListener)
+      commandHistory.listeners.add(historyKeyListener)
+
+      createdConsoleView = consoleView
     }
 
-    private var contentDescriptor by Delegates.notNull<RunContentDescriptor>()
-    private var pid by Delegates.notNull<Int>()
+    return createdConsoleView ?: error("Cannot create fsi")
+  }
 
-    private val isAttached
-        get() = getDebugProcessForThisFsi() != null
+  override fun createProcessHandler(process: Process): OSProcessHandler {
+    val fsiProcessHandler = FsiProcessHandler(fsiInputOutputProcessor, process, cmdLine.commandLineString)
 
-    private val lockObject = Object()
+    val sandboxInfoUpdater = FsiSandboxInfoUpdater(fsiHost.project, consoleView.consoleEditor, commandHistory)
+    fsiProcessHandler.addSandboxInfoUpdater(sandboxInfoUpdater)
 
-    val sendActionExecutor = SendToFsiActionExecutor(this)
-    val commandHistory = CommandHistory()
+    return fsiProcessHandler
+  }
 
-    private val listener = object : NotificationListener.Adapter() {
-        override fun hyperlinkActivated(notification: Notification, e: HyperlinkEvent) {
-            if (!project.isDisposed) {
-                val actionEvent = AnActionEvent.createFromDataContext(ActionPlaces.UNKNOWN, null, DataManager.getInstance().dataContext)
-                when (e.description) {
-                    RelaunchFsiWithDebugAction.actionName -> RelaunchFsiWithDebugAction(project).actionPerformed(actionEvent)
-                    ShowFsiSettingsAction.actionName -> ShowFsiSettingsAction(project).actionPerformed(actionEvent)
-                }
-                notification.expire()
-
-            }
-        }
+  private class ResetFsiAction(private val host: FsiHost) :
+    AnAction("Reset F# Interactive", null, AllIcons.Actions.Restart) {
+    override fun actionPerformed(e: AnActionEvent) {
+      host.resetFsiConsole(host.consoleRunner?.optimizeForDebug ?: false)
     }
+  }
 
-    fun isValid() = !processHandler.isProcessTerminated && !processHandler.isProcessTerminating
-
-    private fun getDebugProcessForThisFsi() = XDebuggerManager.getInstance(project).debugSessions
-            .map { it.debugProcess }.filterIsInstance<DotNetDebugProcess>().firstOrNull()
-
-    fun attachToProcess(): Boolean {
-        if (!optimizeForDebug) {
-            val notification = Notification(fsiTitle, debugNotConfiguredTitle, debugNotConfiguredDescription + notificationLinks,
-                    NotificationType.WARNING, listener)
-            notification.icon = FSharpIcons.FSharpConsole
-            Notifications.Bus.notify(notification, project)
-            return false
-        }
-
-        val processInfo = OSProcessUtil.getProcessList().firstOrNull { it.pid == pid } ?: return false
-        val dataHolder = UserDataHolderBase()
-        val debugger = Extensions.getExtensions(XAttachDebuggerProvider.EP).flatMap { provider ->
-            provider.getAvailableDebuggers(project, LocalAttachHost.INSTANCE, processInfo, dataHolder)
-        }.firstOrNull() ?: return false
-        debugger.attachDebugSession(project, LocalAttachHost.INSTANCE, processInfo)
-        return true
+  private class OpenSettings(val project: Project) :
+    AnAction("F# Interactive settings", null, AllIcons.General.Settings) {
+    override fun actionPerformed(e: AnActionEvent) {
+      ShowSettingsUtil.getInstance().showSettingsDialog(project, "Fsi")
     }
-
-    private fun sendText(visibleText: String, fsiText: String) {
-        UIUtil.invokeLaterIfNeeded {
-            inputSeparatorGutterContentProvider.addLineSeparator(consoleView.historyViewer.document.lineCount)
-
-            fsiInputOutputProcessor.printInputText(visibleText, ConsoleViewContentType.USER_INPUT)
-
-            commandHistory.addEntry(CommandHistory.Entry(visibleText, fsiText))
-
-            // show the window without getting focus
-            RunContentManager.getInstance(project).selectRunContent(contentDescriptor)
-            ToolWindowManager.getInstance(project).getToolWindow(executor.id)?.show(null)
-
-            val stream = processHandler.processInput ?: error("Broken Fsi stream")
-            if (!StringUtil.isEmptyOrSpaces(visibleText)) {
-                stream.write(fsiText.toByteArray(Charsets.UTF_8))
-                stream.flush()
-            }
-        }
-    }
-
-    fun sendText(visibleText: String, fsiText: String, debug: Boolean) {
-        attachDebuggerIfNeeded(debug).onSuccess {
-            sendText(visibleText, fsiText)
-        }.onError {
-            sendText(visibleText, fsiText)
-            Logger.getInstance(FsiConsoleRunner::class.java).warn(it)
-        }
-    }
-
-    private fun attachDebuggerIfNeeded(debug: Boolean): Promise<Unit> {
-        if (!debug || isAttached) {
-            return resolvedPromise()
-        }
-        synchronized(lockObject) {
-            val promise = AsyncPromise<Unit>()
-            if (!attachToProcess()) {
-                promise.setResult(Unit)
-                return promise
-            }
-            //need to free dispatcher thread to pump messages over protocol for async debug runner
-            application.executeOnPooledThread {
-                if (!pumpMessages(Duration.ofSeconds(waitForDebugSessionTimeout)) {
-                            getDebugProcessForThisFsi() != null
-                        }) {
-                    promise.setError(IllegalStateException("Failed to get debug process for fsi.exe with pid $pid"))
-                } else {
-                    promise.setResult(Unit)
-                }
-            }
-            return promise
-        }
-    }
-
-    override fun createProcess(): Process? {
-        val process = cmdLine.createProcess()
-        pid = OSProcessUtil.getProcessID(process)
-        return process
-    }
-
-    override fun isAutoFocusContent() = false
-
-    override fun createExecuteActionHandler(): ProcessBackedConsoleExecuteActionHandler {
-        return object : ProcessBackedConsoleExecuteActionHandler(processHandler, false) {
-            override fun runExecuteAction(consoleView: LanguageConsoleView) {
-                val visibleText = consoleView.consoleEditor.document.text
-                if (visibleText.isBlank()) return
-
-                val fsiText = "\n$visibleText\n# 1 \"stdin\"\n;;\n"
-                sendText(visibleText, fsiText, false)
-                consoleView.setInputText("")
-            }
-        }
-    }
-
-    override fun getConsoleIcon() = FSharpIcons.FSharpConsole
-
-    override fun fillToolBarActions(toolbarActions: DefaultActionGroup, defaultExecutor: Executor,
-                                    contentDescriptor: RunContentDescriptor): MutableList<AnAction> {
-        this.contentDescriptor = contentDescriptor
-        val actionList = ContainerUtil.newArrayList<AnAction>(
-                createCloseAction(defaultExecutor, contentDescriptor),
-                ResetFsiAction(this.fsiHost),
-                Separator(),
-                CommandHistoryAction(this),
-                Separator(),
-                OpenSettings(project))
-        toolbarActions.addAll(actionList)
-        actionList.add(createConsoleExecAction(consoleExecuteActionHandler))
-        return actionList
-    }
-
-    override fun initAndRun() {
-        super.initAndRun()
-
-        setupGutters()
-    }
-
-    private fun setupGutters() {
-        val historyEditor = consoleView.historyViewer
-        historyEditor.settings.isLineMarkerAreaShown = true
-        historyEditor.settings.isFoldingOutlineShown = true
-        historyEditor.gutterComponentEx.setPaintBackground(true)
-
-        historyEditor.colorsScheme.setColor(EditorColors.GUTTER_BACKGROUND, JBColor(Gray.xF2, Gray.x41))
-    }
-
-    override fun createConsoleView(): LanguageConsoleView {
-        var createdConsoleView: LanguageConsoleView? = null
-
-        withGenericSandBoxing(createFSharpSandbox("do ()\n\n", false, emptyList()), project) {
-            val consoleView = LanguageConsoleBuilder().gutterContentProvider(inputSeparatorGutterContentProvider).build(project, FSharpScriptLanguage)
-
-            val consoleEditorBorder = BorderFactory.createMatteBorder(
-                    2, 0, 0, 0, consoleView.consoleEditor.colorsScheme.getColor(EditorColors.INDENT_GUIDE_COLOR))
-            consoleView.consoleEditor.component.border = consoleEditorBorder
-
-            val historyKeyListener = HistoryKeyListener(fsiHost.project, consoleView.consoleEditor, commandHistory)
-            consoleView.consoleEditor.contentComponent.addKeyListener(historyKeyListener)
-            commandHistory.listeners.add(historyKeyListener)
-
-            createdConsoleView = consoleView
-        }
-
-        return createdConsoleView ?: error("Cannot create fsi")
-    }
-
-    override fun createProcessHandler(process: Process): OSProcessHandler {
-        val fsiProcessHandler = FsiProcessHandler(fsiInputOutputProcessor, process, cmdLine.commandLineString)
-
-        val sandboxInfoUpdater = FsiSandboxInfoUpdater(fsiHost.project, consoleView.consoleEditor, commandHistory)
-        fsiProcessHandler.addSandboxInfoUpdater(sandboxInfoUpdater)
-
-        return fsiProcessHandler
-    }
-
-    private class ResetFsiAction(private val host: FsiHost) : AnAction("Reset F# Interactive", null, AllIcons.Actions.Restart) {
-        override fun actionPerformed(e: AnActionEvent) {
-            host.resetFsiConsole(host.consoleRunner?.optimizeForDebug ?: false)
-        }
-    }
-
-    private class OpenSettings(val project: Project) : AnAction("F# Interactive settings", null, AllIcons.General.Settings) {
-        override fun actionPerformed(e: AnActionEvent) {
-            ShowSettingsUtil.getInstance().showSettingsDialog(project, "Fsi")
-        }
-    }
+  }
 }
 
 class RelaunchFsiWithDebugAction(private val currentProject: Project? = null) : AnAction() {
-    override fun actionPerformed(e: AnActionEvent) {
-        val project = e.project ?: currentProject ?: return
-        val fsiHost = project.getComponent<FsiHost>()
-        fsiHost.resetFsiConsole(true, true)
-    }
+  override fun actionPerformed(e: AnActionEvent) {
+    val project = e.project ?: currentProject ?: return
+    val fsiHost = project.getComponent<FsiHost>()
+    fsiHost.resetFsiConsole(true, true)
+  }
 
-    companion object {
-        const val actionName = "relaunchWithDebug"
-        const val link = "<a href='$actionName'>Relaunch with debug enabled</a>"
-    }
+  companion object {
+    const val actionName = "relaunchWithDebug"
+    const val link = "<a href='$actionName'>Relaunch with debug enabled</a>"
+  }
 }
 
 class ShowFsiSettingsAction(private val currentProject: Project? = null) : AnAction() {
-    override fun actionPerformed(e: AnActionEvent) {
-        val project = e.project ?: currentProject ?: return
-        ShowSettingsUtil.getInstance().showSettingsDialog(project, "F# Interactive")
-    }
+  override fun actionPerformed(e: AnActionEvent) {
+    val project = e.project ?: currentProject ?: return
+    ShowSettingsUtil.getInstance().showSettingsDialog(project, "F# Interactive")
+  }
 
-    companion object {
-        const val actionName = "settings"
-        const val link = "<a href='$actionName'>Configure...</a>"
-    }
+  companion object {
+    const val actionName = "settings"
+    const val link = "<a href='$actionName'>Configure...</a>"
+  }
 }

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/FsiHost.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/FsiHost.kt
@@ -19,91 +19,98 @@ import org.jetbrains.concurrency.AsyncPromise
 import org.jetbrains.concurrency.Promise
 
 class FsiHost(project: Project) : LifetimedProjectComponent(project) {
-    private val rdFsiHost = project.solution.rdFSharpModel.fSharpInteractiveHost
+  private val rdFsiHost = project.solution.rdFSharpModel.fSharpInteractiveHost
 
-    val moveCaretOnSendLine = Property(true)
-    val moveCaretOnSendSelection = Property(true)
-    val copyRecentToEditor = Property(false)
+  val moveCaretOnSendLine = Property(true)
+  val moveCaretOnSendSelection = Property(true)
+  val copyRecentToEditor = Property(false)
 
-    init {
-        rdFsiHost.moveCaretOnSendLine.flowInto(componentLifetime, moveCaretOnSendLine)
-        rdFsiHost.moveCaretOnSendSelection.flowInto(componentLifetime, moveCaretOnSendSelection)
-        rdFsiHost.copyRecentToEditor.flowInto(componentLifetime, copyRecentToEditor)
+  init {
+    rdFsiHost.moveCaretOnSendLine.flowInto(componentLifetime, moveCaretOnSendLine)
+    rdFsiHost.moveCaretOnSendSelection.flowInto(componentLifetime, moveCaretOnSendSelection)
+    rdFsiHost.copyRecentToEditor.flowInto(componentLifetime, copyRecentToEditor)
+  }
+
+  var consoleRunner: FsiConsoleRunner? = null
+    private set
+
+  private val lockObj = Object()
+
+  fun sendToFsi(editor: Editor, file: PsiFile, debug: Boolean) {
+    getOrCreateConsoleRunner(debug).onSuccess {
+      it.sendActionExecutor.execute(editor, file, debug)
+    }
+  }
+
+  fun sendToFsi(visibleText: String, fsiText: String, debug: Boolean) {
+    getOrCreateConsoleRunner(debug).onSuccess {
+      it.sendText(visibleText, fsiText, debug)
+    }
+  }
+
+  fun resetFsiConsole(forceOptimizeForDebug: Boolean, attach: Boolean = false) {
+    synchronized(lockObj) {
+      if (consoleRunner?.isValid() == true) {
+        consoleRunner!!.processHandler.destroyProcess()
+      }
+      tryCreateConsoleRunner(forceOptimizeForDebug, attach)
+    }
+  }
+
+  private fun getOrCreateConsoleRunner(forceOptimizeForDebug: Boolean): Promise<FsiConsoleRunner> {
+    if (consoleRunner?.isValid() == true) {
+      val result = AsyncPromise<FsiConsoleRunner>()
+      result.setResult(consoleRunner!!)
+      return result
     }
 
-    var consoleRunner: FsiConsoleRunner? = null
-        private set
+    return tryCreateConsoleRunner(forceOptimizeForDebug)
+  }
 
-    private val lockObj = Object()
+  private fun createConsoleRunner(
+    sessionInfo: RdFsiSessionInfo,
+    forceOptimizeForDebug: Boolean,
+    attach: Boolean
+  ): FsiConsoleRunner? =
+    synchronized(lockObj) {
+      // Might have already been created.
+      if (consoleRunner?.isValid() == true)
+        return consoleRunner
 
-    fun sendToFsi(editor: Editor, file: PsiFile, debug: Boolean) {
-        getOrCreateConsoleRunner(debug).onSuccess {
-            it.sendActionExecutor.execute(editor, file, debug)
-        }
+      val fsiPath = sessionInfo.fsiPath
+      if (sessionInfo.runtime != RdFsiRuntime.Core && !FileUtil.exists(fsiPath)) {
+        notifyFsiNotFound(fsiPath)
+        return null
+      }
+
+      val runner = FsiConsoleRunner(sessionInfo, this, forceOptimizeForDebug)
+      runner.initAndRun()
+      this.consoleRunner = runner
+
+      if (attach)
+        runner.attachToProcess()
+
+      return runner
     }
 
-    fun sendToFsi(visibleText: String, fsiText: String, debug: Boolean) {
-        getOrCreateConsoleRunner(debug).onSuccess {
-            it.sendText(visibleText, fsiText, debug)
-        }
+  private fun tryCreateConsoleRunner(
+    forceOptimizeForDebug: Boolean,
+    attach: Boolean = false
+  ): Promise<FsiConsoleRunner> {
+    val result = AsyncPromise<FsiConsoleRunner>()
+    rdFsiHost.requestNewFsiSessionInfo.start(componentLifetime, Unit).result.advise(componentLifetime) {
+      val consoleRunner = createConsoleRunner(it.unwrap(), forceOptimizeForDebug, attach)
+      if (consoleRunner != null)
+        result.setResult(consoleRunner)
     }
+    return result
+  }
 
-    fun resetFsiConsole(forceOptimizeForDebug: Boolean, attach: Boolean = false) {
-        synchronized(lockObj) {
-            if (consoleRunner?.isValid() == true) {
-                consoleRunner!!.processHandler.destroyProcess()
-            }
-            tryCreateConsoleRunner(forceOptimizeForDebug, attach)
-        }
-    }
-
-    private fun getOrCreateConsoleRunner(forceOptimizeForDebug: Boolean): Promise<FsiConsoleRunner> {
-        if (consoleRunner?.isValid() == true) {
-            val result = AsyncPromise<FsiConsoleRunner>()
-            result.setResult(consoleRunner!!)
-            return result
-        }
-
-        return tryCreateConsoleRunner(forceOptimizeForDebug)
-    }
-
-    private fun createConsoleRunner(sessionInfo: RdFsiSessionInfo, forceOptimizeForDebug: Boolean, attach: Boolean): FsiConsoleRunner? =
-            synchronized(lockObj) {
-                // Might have already been created.
-                if (consoleRunner?.isValid() == true)
-                    return consoleRunner
-
-                val fsiPath = sessionInfo.fsiPath
-                if (sessionInfo.runtime != RdFsiRuntime.Core && !FileUtil.exists(fsiPath)) {
-                    notifyFsiNotFound(fsiPath)
-                    return null
-                }
-
-                val runner = FsiConsoleRunner(sessionInfo, this, forceOptimizeForDebug)
-                runner.initAndRun()
-                this.consoleRunner = runner
-
-                if (attach)
-                    runner.attachToProcess()
-
-                return runner
-            }
-
-    private fun tryCreateConsoleRunner(forceOptimizeForDebug: Boolean, attach: Boolean = false): Promise<FsiConsoleRunner> {
-        val result = AsyncPromise<FsiConsoleRunner>()
-        rdFsiHost.requestNewFsiSessionInfo.start(componentLifetime, Unit).result.advise(componentLifetime) {
-            val consoleRunner = createConsoleRunner(it.unwrap(), forceOptimizeForDebug, attach)
-            if (consoleRunner != null)
-                result.setResult(consoleRunner)
-        }
-        return result
-    }
-
-    private fun notifyFsiNotFound(fsiPath: String) {
-        val title = "Could not start F# Interactive"
-        val content = "The file '$fsiPath' was not found."
-        val notification = Notification(FsiConsoleRunner.fsiTitle, title, content, NotificationType.WARNING)
-        notification.icon = FSharpIcons.FSharpConsole
-        Notifications.Bus.notify(notification, project)
-    }
+  private fun notifyFsiNotFound(fsiPath: String) {
+    val title = "Could not start F# Interactive"
+    val content = "The file '$fsiPath' was not found."
+    val notification = Notification(FsiConsoleRunner.fsiTitle, title, content, NotificationType.WARNING)
+    notification.icon = FSharpIcons.FSharpConsole
+    Notifications.Bus.notify(notification, project)
+  }
 }

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/FsiIcons.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/FsiIcons.kt
@@ -6,7 +6,7 @@ import javax.swing.Icon
 data class IconWithTooltip(val icon: Icon, val tooltip: String?)
 
 object FsiIcons {
-    val COMMAND_MARKER = IconWithTooltip(AllIcons.Actions.Execute, "Executed command")
-    val RESULT = IconWithTooltip(AllIcons.Vcs.Equal, "Result")
-    val ERROR = IconWithTooltip(AllIcons.General.Warning, "Error")
+  val COMMAND_MARKER = IconWithTooltip(AllIcons.Actions.Execute, "Executed command")
+  val RESULT = IconWithTooltip(AllIcons.Vcs.Equal, "Result")
+  val ERROR = IconWithTooltip(AllIcons.General.Warning, "Error")
 }

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/FsiInputOutputProcessor.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/FsiInputOutputProcessor.kt
@@ -11,82 +11,85 @@ import com.intellij.openapi.editor.markup.HighlighterTargetArea
 import com.jetbrains.rider.ideaInterop.fileTypes.fsharp.highlighting.FSharpSyntaxHighlighter
 
 class FsiInputOutputProcessor(private val fsiRunner: FsiConsoleRunner) {
-    private var isInitialText = true
-    private var nextOutputTextIsFirst = true
+  private var isInitialText = true
+  private var nextOutputTextIsFirst = true
 
-    private val fSharpSyntaxHighlighter = FSharpSyntaxHighlighter()
+  private val fSharpSyntaxHighlighter = FSharpSyntaxHighlighter()
 
-    private fun textOffsets(text: String): Pair<Int, Int> {
-        (fsiRunner.consoleView as ConsoleViewImpl).flushDeferredText()
+  private fun textOffsets(text: String): Pair<Int, Int> {
+    (fsiRunner.consoleView as ConsoleViewImpl).flushDeferredText()
 
-        val historyEditor = fsiRunner.consoleView.historyViewer
-        val startOffset = historyEditor.document.textLength
-        val endOffset = startOffset + text.length
+    val historyEditor = fsiRunner.consoleView.historyViewer
+    val startOffset = historyEditor.document.textLength
+    val endOffset = startOffset + text.length
 
-        return Pair(startOffset, endOffset)
+    return Pair(startOffset, endOffset)
+  }
+
+  private fun fsiIconWithTooltipOnOutputText(outputType: ConsoleViewContentType): IconWithTooltip? {
+    if (nextOutputTextIsFirst) {
+      when (outputType) {
+        ConsoleViewContentType.NORMAL_OUTPUT -> return FsiIcons.RESULT
+        ConsoleViewContentType.ERROR_OUTPUT -> return FsiIcons.ERROR
+      }
     }
 
-    private fun fsiIconWithTooltipOnOutputText(outputType: ConsoleViewContentType): IconWithTooltip? {
-        if (nextOutputTextIsFirst) {
-            when (outputType) {
-                ConsoleViewContentType.NORMAL_OUTPUT -> return FsiIcons.RESULT
-                ConsoleViewContentType.ERROR_OUTPUT -> return FsiIcons.ERROR
-            }
-        }
+    return null
+  }
 
-        return null
+  fun printInputText(text: String, outputType: ConsoleViewContentType) {
+    printText(text + "\n", FsiIcons.COMMAND_MARKER, fSharpSyntaxHighlighter, outputType)
+    EditorUtil.scrollToTheEnd(fsiRunner.consoleView.historyViewer)
+
+    nextOutputTextIsFirst = true
+  }
+
+  fun printOutputText(text: String, outputType: ConsoleViewContentType) {
+    if (isInitialText) {
+      printOutputInitialText(text, outputType)
+    } else {
+      val fsiResultIconWithTooltip = fsiIconWithTooltipOnOutputText(outputType)
+
+      when (outputType) {
+        ConsoleViewContentType.NORMAL_OUTPUT ->
+          printText(text, fsiResultIconWithTooltip, fSharpSyntaxHighlighter, outputType)
+
+        ConsoleViewContentType.ERROR_OUTPUT ->
+          printText(text, fsiResultIconWithTooltip, null, outputType)
+      }
+
+      nextOutputTextIsFirst = false
+    }
+  }
+
+  private fun printText(
+    text: String, iconWithTooltip: IconWithTooltip?, highlighter: FSharpSyntaxHighlighter?,
+    outputType: ConsoleViewContentType
+  ) =
+    WriteCommandAction.runWriteCommandAction(fsiRunner.project) {
+      val (startOffset, endOffset) = textOffsets(text)
+
+      if (highlighter == null) {
+        fsiRunner.consoleView.print(text, outputType)
+      } else {
+        ConsoleViewUtil.printWithHighlighting(fsiRunner.consoleView, text, highlighter)
+      }
+
+      (fsiRunner.consoleView as LanguageConsoleImpl).flushDeferredText()
+
+      if (iconWithTooltip == null) return@runWriteCommandAction
+
+      fsiRunner.consoleView.historyViewer.markupModel.addRangeHighlighter(
+        startOffset, endOffset, HighlighterLayer.LAST, null, HighlighterTargetArea.LINES_IN_RANGE
+      ).apply { gutterIconRenderer = FsiConsoleIndicatorRenderer(iconWithTooltip) }
     }
 
-    fun printInputText(text: String, outputType: ConsoleViewContentType) {
-        printText(text + "\n", FsiIcons.COMMAND_MARKER, fSharpSyntaxHighlighter, outputType)
-        EditorUtil.scrollToTheEnd(fsiRunner.consoleView.historyViewer)
-
-        nextOutputTextIsFirst = true
+  private fun printOutputInitialText(text: String, outputType: ConsoleViewContentType) =
+    WriteCommandAction.runWriteCommandAction(fsiRunner.project) {
+      fsiRunner.consoleView.print(text, outputType)
     }
 
-    fun printOutputText(text: String, outputType: ConsoleViewContentType) {
-        if (isInitialText) {
-            printOutputInitialText(text, outputType)
-        } else {
-            val fsiResultIconWithTooltip = fsiIconWithTooltipOnOutputText(outputType)
-
-            when (outputType) {
-                ConsoleViewContentType.NORMAL_OUTPUT ->
-                    printText(text, fsiResultIconWithTooltip, fSharpSyntaxHighlighter, outputType)
-                ConsoleViewContentType.ERROR_OUTPUT ->
-                    printText(text, fsiResultIconWithTooltip, null, outputType)
-            }
-
-            nextOutputTextIsFirst = false
-        }
-    }
-
-    private fun printText(text: String, iconWithTooltip: IconWithTooltip?, highlighter: FSharpSyntaxHighlighter?,
-                          outputType: ConsoleViewContentType) =
-            WriteCommandAction.runWriteCommandAction(fsiRunner.project) {
-                val (startOffset, endOffset) = textOffsets(text)
-
-                if (highlighter == null) {
-                    fsiRunner.consoleView.print(text, outputType)
-                } else {
-                    ConsoleViewUtil.printWithHighlighting(fsiRunner.consoleView, text, highlighter)
-                }
-
-                (fsiRunner.consoleView as LanguageConsoleImpl).flushDeferredText()
-
-                if (iconWithTooltip == null) return@runWriteCommandAction
-
-                fsiRunner.consoleView.historyViewer.markupModel.addRangeHighlighter(
-                        startOffset, endOffset, HighlighterLayer.LAST, null, HighlighterTargetArea.LINES_IN_RANGE
-                ).apply { gutterIconRenderer = FsiConsoleIndicatorRenderer(iconWithTooltip) }
-            }
-
-    private fun printOutputInitialText(text: String, outputType: ConsoleViewContentType) =
-            WriteCommandAction.runWriteCommandAction(fsiRunner.project) {
-                fsiRunner.consoleView.print(text, outputType)
-            }
-
-    fun onServerPrompt() {
-        isInitialText = false
-    }
+  fun onServerPrompt() {
+    isInitialText = false
+  }
 }

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/FsiProcessHandler.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/FsiProcessHandler.kt
@@ -6,54 +6,57 @@ import com.intellij.execution.process.ProcessOutputTypes
 import com.intellij.execution.ui.ConsoleViewContentType
 import com.intellij.openapi.util.Key
 
-class FsiProcessHandler (
-        private val fsiInputOutputProcessor: FsiInputOutputProcessor,
-        process: Process,
-        commandLine: String?) : OSProcessHandler(process, commandLine, Charsets.UTF_8) {
+class FsiProcessHandler(
+  private val fsiInputOutputProcessor: FsiInputOutputProcessor,
+  process: Process,
+  commandLine: String?
+) : OSProcessHandler(process, commandLine, Charsets.UTF_8) {
 
-    private val sandboxInfoUpdaters = mutableListOf<FsiSandboxInfoUpdater>()
-    private val fsiProcessOutputListeners = mutableListOf<FsiSandboxInfoUpdater.FsiSandboxInfoUpdaterProcessOutputListener>()
+  private val sandboxInfoUpdaters = mutableListOf<FsiSandboxInfoUpdater>()
+  private val fsiProcessOutputListeners =
+    mutableListOf<FsiSandboxInfoUpdater.FsiSandboxInfoUpdaterProcessOutputListener>()
 
-    override fun isSilentlyDestroyOnClose(): Boolean = true
+  override fun isSilentlyDestroyOnClose(): Boolean = true
 
-    override fun notifyTextAvailable(text: String, outputType: Key<*>) {
-        if (text != "SERVER-PROMPT>\n") {
-            when (outputType) {
-                ProcessOutputTypes.STDOUT -> {
-                    fsiInputOutputProcessor.printOutputText(text, ConsoleViewContentType.NORMAL_OUTPUT)
-                }
-                ProcessOutputTypes.STDERR -> {
-                    fsiInputOutputProcessor.printOutputText(text, ConsoleViewContentType.ERROR_OUTPUT)
-                }
-                else -> {
-                    super.notifyTextAvailable(text, outputType)
-                }
-            }
-
-            fsiProcessOutputListeners.forEach { it.onTextAvailable(ProcessEvent(this, text), outputType) }
+  override fun notifyTextAvailable(text: String, outputType: Key<*>) {
+    if (text != "SERVER-PROMPT>\n") {
+      when (outputType) {
+        ProcessOutputTypes.STDOUT -> {
+          fsiInputOutputProcessor.printOutputText(text, ConsoleViewContentType.NORMAL_OUTPUT)
         }
-        else {
-            sandboxInfoUpdaters.forEach { it.onOutputEnd() }
 
-            fsiInputOutputProcessor.onServerPrompt()
+        ProcessOutputTypes.STDERR -> {
+          fsiInputOutputProcessor.printOutputText(text, ConsoleViewContentType.ERROR_OUTPUT)
         }
+
+        else -> {
+          super.notifyTextAvailable(text, outputType)
+        }
+      }
+
+      fsiProcessOutputListeners.forEach { it.onTextAvailable(ProcessEvent(this, text), outputType) }
+    } else {
+      sandboxInfoUpdaters.forEach { it.onOutputEnd() }
+
+      fsiInputOutputProcessor.onServerPrompt()
     }
+  }
 
-    override fun startNotify() {
-        super.startNotify()
+  override fun startNotify() {
+    super.startNotify()
 
-        fsiProcessOutputListeners.forEach { it.startNotified(ProcessEvent(this,  "")) }
-    }
+    fsiProcessOutputListeners.forEach { it.startNotified(ProcessEvent(this, "")) }
+  }
 
-    override fun notifyProcessTerminated(exitCode: Int) {
-        super.notifyProcessTerminated(exitCode)
+  override fun notifyProcessTerminated(exitCode: Int) {
+    super.notifyProcessTerminated(exitCode)
 
-        fsiProcessOutputListeners.forEach { it.processTerminated(ProcessEvent(this, "")) }
-    }
+    fsiProcessOutputListeners.forEach { it.processTerminated(ProcessEvent(this, "")) }
+  }
 
-    fun addSandboxInfoUpdater (sandboxInfoUpdater: FsiSandboxInfoUpdater) {
-        fsiProcessOutputListeners.add(sandboxInfoUpdater.fsiProcessOutputListener)
+  fun addSandboxInfoUpdater(sandboxInfoUpdater: FsiSandboxInfoUpdater) {
+    fsiProcessOutputListeners.add(sandboxInfoUpdater.fsiProcessOutputListener)
 
-        sandboxInfoUpdaters.add(sandboxInfoUpdater)
-    }
+    sandboxInfoUpdaters.add(sandboxInfoUpdater)
+  }
 }

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/HistoryKeyListener.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/HistoryKeyListener.kt
@@ -9,77 +9,78 @@ import java.awt.event.KeyAdapter
 import java.awt.event.KeyEvent
 
 class HistoryKeyListener(
-        private val project: Project, private val consoleEditor: EditorEx, private val history: CommandHistory)
-    : KeyAdapter(), HistoryUpdateListener {
+  private val project: Project, private val consoleEditor: EditorEx, private val history: CommandHistory
+) : KeyAdapter(), HistoryUpdateListener {
 
-    private var historyPos = 0
-    private var unfinishedCommand = ""
+  private var historyPos = 0
+  private var unfinishedCommand = ""
 
-    private var curCursorLine = 0
-    private var prevCursorLine = 0
+  private var curCursorLine = 0
+  private var prevCursorLine = 0
 
-    override fun onNewEntry(entry: CommandHistory.Entry) {
-        // reset history positions
-        historyPos = history.size
-        unfinishedCommand = ""
+  override fun onNewEntry(entry: CommandHistory.Entry) {
+    // reset history positions
+    historyPos = history.size
+    unfinishedCommand = ""
+  }
+
+  private enum class HistoryMove {
+    UP, DOWN
+  }
+
+  override fun keyReleased(e: KeyEvent) {
+    prevCursorLine = curCursorLine
+
+    when (e.keyCode) {
+      KeyEvent.VK_UP -> moveHistoryCursor(HistoryMove.UP)
+      KeyEvent.VK_DOWN -> moveHistoryCursor(HistoryMove.DOWN)
+      else -> {
+        curCursorLine = consoleEditor.document.getLineNumber(consoleEditor.document.textLength)
+      }
     }
+  }
 
-    private enum class HistoryMove {
-        UP, DOWN
-    }
+  private fun moveHistoryCursor(move: HistoryMove) {
+    if (history.size == 0) return
+    if (LookupManager.getInstance(project).activeLookup != null) return
 
-    override fun keyReleased(e: KeyEvent) {
-        prevCursorLine = curCursorLine
+    val caret = consoleEditor.caretModel
+    val document = consoleEditor.document
 
-        when (e.keyCode) {
-            KeyEvent.VK_UP -> moveHistoryCursor(HistoryMove.UP)
-            KeyEvent.VK_DOWN -> moveHistoryCursor(HistoryMove.DOWN)
-            else -> {
-                curCursorLine = consoleEditor.document.getLineNumber(consoleEditor.document.textLength)
-            }
+    val curOffset = caret.offset
+    curCursorLine = document.getLineNumber(curOffset)
+    val totalLines = document.lineCount
+
+    when (move) {
+      HistoryMove.UP -> {
+        if (curCursorLine != 0 || prevCursorLine != curCursorLine) return
+
+        if (historyPos == history.size) {
+          unfinishedCommand = document.text
         }
-    }
 
-    private fun moveHistoryCursor(move: HistoryMove) {
-        if (history.size == 0) return
-        if (LookupManager.getInstance(project).activeLookup != null) return
+        historyPos = Math.max(historyPos - 1, 0)
+        WriteCommandAction.runWriteCommandAction(project) {
+          document.setText(history[historyPos].visibleText)
+          EditorUtil.scrollToTheEnd(consoleEditor)
+          caret.moveToOffset(document.textLength)
 
-        val caret = consoleEditor.caretModel
-        val document = consoleEditor.document
-
-        val curOffset = caret.offset
-        curCursorLine = document.getLineNumber(curOffset)
-        val totalLines = document.lineCount
-
-        when (move) {
-            HistoryMove.UP -> {
-                if (curCursorLine != 0 || prevCursorLine != curCursorLine) return
-
-                if (historyPos == history.size) {
-                    unfinishedCommand = document.text
-                }
-
-                historyPos = Math.max(historyPos - 1, 0)
-                WriteCommandAction.runWriteCommandAction(project) {
-                    document.setText(history[historyPos].visibleText)
-                    EditorUtil.scrollToTheEnd(consoleEditor)
-                    caret.moveToOffset(document.textLength)
-
-                    curCursorLine = document.getLineNumber(document.textLength)
-                }
-            }
-            HistoryMove.DOWN -> {
-                if (historyPos == history.size || curCursorLine != totalLines - 1 || curCursorLine != prevCursorLine) return
-
-                historyPos = Math.min(historyPos + 1, history.size)
-                WriteCommandAction.runWriteCommandAction(project) {
-                    document.setText(if (historyPos == history.size) unfinishedCommand else history[historyPos].visibleText)
-                    caret.moveToOffset(document.textLength)
-                    EditorUtil.scrollToTheEnd(consoleEditor)
-
-                    curCursorLine = document.getLineNumber(document.textLength)
-                }
-            }
+          curCursorLine = document.getLineNumber(document.textLength)
         }
+      }
+
+      HistoryMove.DOWN -> {
+        if (historyPos == history.size || curCursorLine != totalLines - 1 || curCursorLine != prevCursorLine) return
+
+        historyPos = Math.min(historyPos + 1, history.size)
+        WriteCommandAction.runWriteCommandAction(project) {
+          document.setText(if (historyPos == history.size) unfinishedCommand else history[historyPos].visibleText)
+          caret.moveToOffset(document.textLength)
+          EditorUtil.scrollToTheEnd(consoleEditor)
+
+          curCursorLine = document.getLineNumber(document.textLength)
+        }
+      }
     }
+  }
 }

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/InputSeparatorGutterContentProvider.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/InputSeparatorGutterContentProvider.kt
@@ -4,19 +4,19 @@ import com.intellij.execution.console.BasicGutterContentProvider
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.editor.Editor
 
-class InputSeparatorGutterContentProvider(isLineRelationshipComputable: Boolean)
-    : BasicGutterContentProvider(isLineRelationshipComputable) {
+class InputSeparatorGutterContentProvider(isLineRelationshipComputable: Boolean) :
+  BasicGutterContentProvider(isLineRelationshipComputable) {
 
-    private val separatorLines = mutableSetOf<Int>()
+  private val separatorLines = mutableSetOf<Int>()
 
-    override fun doIsShowSeparatorLine(line: Int, editor: Editor, document: Document): Boolean {
-        val actualEditorLine = line + 2
-        return separatorLines.contains(actualEditorLine)
-    }
+  override fun doIsShowSeparatorLine(line: Int, editor: Editor, document: Document): Boolean {
+    val actualEditorLine = line + 2
+    return separatorLines.contains(actualEditorLine)
+  }
 
-    fun addLineSeparator(line: Int) {
-        separatorLines.add(line)
-    }
+  fun addLineSeparator(line: Int) {
+    separatorLines.add(line)
+  }
 
-    override fun beforeEvaluate(editor: Editor) = Unit
+  override fun beforeEvaluate(editor: Editor) = Unit
 }

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/SendProjectReferencesToFsiAction.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/SendProjectReferencesToFsiAction.kt
@@ -13,16 +13,19 @@ import com.jetbrains.rider.projectView.workspace.getId
 import com.jetbrains.rider.projectView.workspace.isProject
 
 class SendProjectReferencesToFsiAction : ProjectViewActionBase() {
-    override fun actionPerformedInternal(entity: ProjectModelEntity, project: Project) {
-        val id = entity.getId(project) ?: return
-        val fSharpInteractiveHost = project.solution.rdFSharpModel.fSharpInteractiveHost
-        fSharpInteractiveHost.getProjectReferences.start(project.lifetime, id).result.adviseOnce(Lifetime.Eternal) { result ->
-            val text = result.unwrap().joinToString("\n") { "#r @\"$it\"" } +
-                    "\n" +
-                    "# 1 \"stdin\"\n;;\n"
-            project.getComponent<FsiHost>().sendToFsi(text, text, false)
-        }
+  override fun actionPerformedInternal(entity: ProjectModelEntity, project: Project) {
+    val id = entity.getId(project) ?: return
+    val fSharpInteractiveHost = project.solution.rdFSharpModel.fSharpInteractiveHost
+    fSharpInteractiveHost.getProjectReferences.start(
+      project.lifetime,
+      id
+    ).result.adviseOnce(Lifetime.Eternal) { result ->
+      val text = result.unwrap().joinToString("\n") { "#r @\"$it\"" } +
+        "\n" +
+        "# 1 \"stdin\"\n;;\n"
+      project.getComponent<FsiHost>().sendToFsi(text, text, false)
     }
+  }
 
-    override fun getItemInternal(entity: ProjectModelEntity, project: Project) = if (entity.isProject()) entity else null
+  override fun getItemInternal(entity: ProjectModelEntity, project: Project) = if (entity.isProject()) entity else null
 }

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/SendToFsiActionExecutor.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/SendToFsiActionExecutor.kt
@@ -5,36 +5,36 @@ import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiFile
 
 class SendToFsiActionExecutor(private val consoleRunner: FsiConsoleRunner) {
-    fun execute(editor: Editor, file: PsiFile, debug: Boolean) {
-        val selectionModel = editor.selectionModel
-        val hasSelection = selectionModel.hasSelection()
-        val visibleText = getVisibleText(editor, hasSelection)
-        if (visibleText.isNotEmpty()) {
-            val fsiText = "\n" +
-                    "# silentCd @\"${file.containingDirectory.virtualFile.path}\" ;; \n" +
-                    (if (debug) "# dbgbreak\n" else "") +
-                    "# ${getTextStartLine(editor, hasSelection) + 1} @\"${file.virtualFile.path}\" \n" +
-                    visibleText + "\n" +
-                    "# 1 \"stdin\"\n;;\n"
-            consoleRunner.sendText(visibleText, fsiText, debug)
-        }
-        if (!hasSelection && consoleRunner.fsiHost.moveCaretOnSendLine.value)
-            editor.caretModel.moveCaretRelatively(0, 1, false, false, true)
+  fun execute(editor: Editor, file: PsiFile, debug: Boolean) {
+    val selectionModel = editor.selectionModel
+    val hasSelection = selectionModel.hasSelection()
+    val visibleText = getVisibleText(editor, hasSelection)
+    if (visibleText.isNotEmpty()) {
+      val fsiText = "\n" +
+        "# silentCd @\"${file.containingDirectory.virtualFile.path}\" ;; \n" +
+        (if (debug) "# dbgbreak\n" else "") +
+        "# ${getTextStartLine(editor, hasSelection) + 1} @\"${file.virtualFile.path}\" \n" +
+        visibleText + "\n" +
+        "# 1 \"stdin\"\n;;\n"
+      consoleRunner.sendText(visibleText, fsiText, debug)
+    }
+    if (!hasSelection && consoleRunner.fsiHost.moveCaretOnSendLine.value)
+      editor.caretModel.moveCaretRelatively(0, 1, false, false, true)
 
-        if (hasSelection && consoleRunner.fsiHost.moveCaretOnSendSelection.value) {
-            editor.caretModel.moveToOffset(selectionModel.selectionEnd)
-            editor.caretModel.currentCaret.removeSelection()
-        }
+    if (hasSelection && consoleRunner.fsiHost.moveCaretOnSendSelection.value) {
+      editor.caretModel.moveToOffset(selectionModel.selectionEnd)
+      editor.caretModel.currentCaret.removeSelection()
+    }
+  }
+
+  private fun getVisibleText(editor: Editor, hasSelection: Boolean) =
+    if (hasSelection) editor.selectionModel.selectedText!!
+    else {
+      val caretModel = editor.caretModel
+      editor.document.getText(TextRange(caretModel.visualLineStart, caretModel.visualLineEnd)).substringBeforeLast("\n")
     }
 
-    private fun getVisibleText(editor: Editor, hasSelection: Boolean) =
-            if (hasSelection) editor.selectionModel.selectedText!!
-            else {
-                val caretModel = editor.caretModel
-                editor.document.getText(TextRange(caretModel.visualLineStart, caretModel.visualLineEnd)).substringBeforeLast("\n")
-            }
-
-    private fun getTextStartLine(editor: Editor, hasSelection: Boolean) =
-            if (hasSelection) editor.document.getLineNumber(editor.selectionModel.selectionStart)
-            else editor.caretModel.logicalPosition.line
+  private fun getTextStartLine(editor: Editor, hasSelection: Boolean) =
+    if (hasSelection) editor.document.getLineNumber(editor.selectionModel.selectionStart)
+    else editor.caretModel.logicalPosition.line
 }

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/SendToFsiActions.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/SendToFsiActions.kt
@@ -15,88 +15,98 @@ import icons.ReSharperIcons
 import javax.swing.Icon
 
 object Fsi {
-    const val sendToFsiActionId = "Rider.Plugins.FSharp.SendToFsi"
-    const val debugInFsiActionId = "Rider.Plugins.FSharp.DebugInFsi"
+  const val sendToFsiActionId = "Rider.Plugins.FSharp.SendToFsi"
+  const val debugInFsiActionId = "Rider.Plugins.FSharp.DebugInFsi"
 
-    const val sendLineText = "Send Line to F# Interactive"
-    const val debugLineText = "Debug Line in F# Interactive"
+  const val sendLineText = "Send Line to F# Interactive"
+  const val debugLineText = "Debug Line in F# Interactive"
 
-    const val sendSelectionText = "Send Selection to F# Interactive"
-    const val debugSelectionText = "Debug Selection in F# Interactive"
+  const val sendSelectionText = "Send Selection to F# Interactive"
+  const val debugSelectionText = "Debug Selection in F# Interactive"
 }
 
 class StartFsiAction : AnAction() {
-    override fun actionPerformed(e: AnActionEvent) {
-        val project = CommonDataKeys.PROJECT.getData(e.dataContext) ?: return
-        project.getComponent<FsiHost>().resetFsiConsole(false)
-    }
+  override fun actionPerformed(e: AnActionEvent) {
+    val project = CommonDataKeys.PROJECT.getData(e.dataContext) ?: return
+    project.getComponent<FsiHost>().resetFsiConsole(false)
+  }
 }
 
 class SendToFsiAction : SendToFsiActionBase(false, Fsi.sendLineText, Fsi.sendSelectionText)
 
 class DebugInFsiAction : SendToFsiActionBase(true, Fsi.debugLineText, Fsi.debugSelectionText)
 
-open class SendToFsiActionBase(private val debug: Boolean, private val sendLineText: String,
-                               private val sendSelectionText: String) : AnAction(), DumbAware {
+open class SendToFsiActionBase(
+  private val debug: Boolean, private val sendLineText: String,
+  private val sendSelectionText: String
+) : AnAction(), DumbAware {
 
-    override fun actionPerformed(e: AnActionEvent) {
-        val editor = CommonDataKeys.EDITOR.getData(e.dataContext)!!
-        val file = CommonDataKeys.PSI_FILE.getData(e.dataContext)!!
-        val project = CommonDataKeys.PROJECT.getData(e.dataContext) ?: return
-        project.getComponent(FsiHost::class.java).sendToFsi(editor, file, debug)
-    }
+  override fun actionPerformed(e: AnActionEvent) {
+    val editor = CommonDataKeys.EDITOR.getData(e.dataContext)!!
+    val file = CommonDataKeys.PSI_FILE.getData(e.dataContext)!!
+    val project = CommonDataKeys.PROJECT.getData(e.dataContext) ?: return
+    project.getComponent(FsiHost::class.java).sendToFsi(editor, file, debug)
+  }
 
-    override fun update(e: AnActionEvent) {
-        if (debug && !SystemInfo.isWindows) {
-            // todo: enable when we can read needed metadata on Mono, RIDER-7148
-            e.presentation.isEnabled = false
-            e.presentation.isVisible = false
-            return
-        }
-        val file = CommonDataKeys.PSI_FILE.getData(e.dataContext)
-        val editor = CommonDataKeys.EDITOR.getData(e.dataContext)
-        if (file?.language !is FSharpLanguageBase || editor?.caretModel?.caretCount != 1) {
-            e.presentation.isEnabled = false
-            return
-        }
-        e.presentation.isEnabled = true
-        e.presentation.text = if (editor.selectionModel.hasSelection()) sendSelectionText else sendLineText
+  override fun update(e: AnActionEvent) {
+    if (debug && !SystemInfo.isWindows) {
+      // todo: enable when we can read needed metadata on Mono, RIDER-7148
+      e.presentation.isEnabled = false
+      e.presentation.isVisible = false
+      return
     }
+    val file = CommonDataKeys.PSI_FILE.getData(e.dataContext)
+    val editor = CommonDataKeys.EDITOR.getData(e.dataContext)
+    if (file?.language !is FSharpLanguageBase || editor?.caretModel?.caretCount != 1) {
+      e.presentation.isEnabled = false
+      return
+    }
+    e.presentation.isEnabled = true
+    e.presentation.text = if (editor.selectionModel.hasSelection()) sendSelectionText else sendLineText
+  }
 }
 
-class SendLineToFsiIntentionAction : SendLineToFsiIntentionActionBase(false, Fsi.sendLineText, Fsi.sendToFsiActionId), HighPriorityAction
+class SendLineToFsiIntentionAction : SendLineToFsiIntentionActionBase(false, Fsi.sendLineText, Fsi.sendToFsiActionId),
+  HighPriorityAction
+
 class DebugLineInFsiIntentionAction : SendLineToFsiIntentionActionBase(true, Fsi.debugLineText, Fsi.debugInFsiActionId)
 
-class SendSelectionToFsiIntentionAction : SendSelectionToFsiIntentionActionBase(false, Fsi.sendSelectionText, Fsi.sendToFsiActionId), HighPriorityAction
-class DebugSelectionInFsiIntentionAction : SendSelectionToFsiIntentionActionBase(true, Fsi.debugSelectionText, Fsi.debugInFsiActionId)
+class SendSelectionToFsiIntentionAction :
+  SendSelectionToFsiIntentionActionBase(false, Fsi.sendSelectionText, Fsi.sendToFsiActionId), HighPriorityAction
 
-open class SendLineToFsiIntentionActionBase(debug: Boolean, private val titleText: String, actionId: String) : BaseSendToFsiIntentionAction(debug, actionId) {
-    override fun getText() = titleText
-    override fun isAvailable(project: Project, editor: Editor?, file: PsiElement) =
-            super.isAvailable(project, editor, file) && !editor!!.selectionModel.hasSelection()
+class DebugSelectionInFsiIntentionAction :
+  SendSelectionToFsiIntentionActionBase(true, Fsi.debugSelectionText, Fsi.debugInFsiActionId)
+
+open class SendLineToFsiIntentionActionBase(debug: Boolean, private val titleText: String, actionId: String) :
+  BaseSendToFsiIntentionAction(debug, actionId) {
+  override fun getText() = titleText
+  override fun isAvailable(project: Project, editor: Editor?, file: PsiElement) =
+    super.isAvailable(project, editor, file) && !editor!!.selectionModel.hasSelection()
 }
 
-open class SendSelectionToFsiIntentionActionBase(debug: Boolean, private val titleText: String, actionId: String) : BaseSendToFsiIntentionAction(debug, actionId) {
-    override fun getText() = titleText
-    override fun isAvailable(project: Project, editor: Editor?, file: PsiElement) =
-            super.isAvailable(project, editor, file) && editor!!.selectionModel.hasSelection()
+open class SendSelectionToFsiIntentionActionBase(debug: Boolean, private val titleText: String, actionId: String) :
+  BaseSendToFsiIntentionAction(debug, actionId) {
+  override fun getText() = titleText
+  override fun isAvailable(project: Project, editor: Editor?, file: PsiElement) =
+    super.isAvailable(project, editor, file) && editor!!.selectionModel.hasSelection()
 }
 
-abstract class BaseSendToFsiIntentionAction(private val debug: Boolean, private val actionId: String) : BaseElementAtCaretIntentionAction(), ShortcutProvider, Iconable, DumbAware {
-    private val isAvailable = !debug || SystemInfo.isWindows
+abstract class BaseSendToFsiIntentionAction(private val debug: Boolean, private val actionId: String) :
+  BaseElementAtCaretIntentionAction(), ShortcutProvider, Iconable, DumbAware {
+  private val isAvailable = !debug || SystemInfo.isWindows
 
-    override fun getFamilyName(): String = "Send to F# Interactive"
-    override fun startInWriteAction() = false
+  override fun getFamilyName(): String = "Send to F# Interactive"
+  override fun startInWriteAction() = false
 
-    override fun isAvailable(project: Project, editor: Editor?, file: PsiElement) =
-            isAvailable && file.language is FSharpLanguageBase && editor?.caretModel?.caretCount == 1
+  override fun isAvailable(project: Project, editor: Editor?, file: PsiElement) =
+    isAvailable && file.language is FSharpLanguageBase && editor?.caretModel?.caretCount == 1
 
-    override fun invoke(project: Project, editor: Editor, element: PsiElement) {
-        project.getComponent<FsiHost>().sendToFsi(editor, element.containingFile, debug)
-    }
+  override fun invoke(project: Project, editor: Editor, element: PsiElement) {
+    project.getComponent<FsiHost>().sendToFsi(editor, element.containingFile, debug)
+  }
 
-    override fun getIcon(flags: Int): Icon = ReSharperIcons.Bulb.GhostBulb
+  override fun getIcon(flags: Int): Icon = ReSharperIcons.Bulb.GhostBulb
 
-    override fun getShortcut() =
-            ActionManager.getInstance().getAction(actionId)?.shortcutSet
+  override fun getShortcut() =
+    ActionManager.getInstance().getAction(actionId)?.shortcutSet
 }

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/settings/FsiOptionsPage.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/settings/FsiOptionsPage.kt
@@ -3,5 +3,5 @@ package com.jetbrains.rider.plugins.fsharp.services.settings
 import com.jetbrains.rider.settings.simple.SimpleOptionsPage
 
 class FsiOptionsPage : SimpleOptionsPage("F# Interactive", "FsiOptionsPage") {
-    override fun getId(): String = "Fsi"
+  override fun getId(): String = "Fsi"
 }

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/settings/FSharpCodeFoldingSettingsProvider.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/settings/FSharpCodeFoldingSettingsProvider.kt
@@ -13,12 +13,16 @@ class FSharpCodeFoldingProvider : RiderCodeFoldingOptionsProvider<FSharpCodeFold
 @Suppress("unused")
 @State(name = "FSharpCodeFoldingSettings", storages = [(Storage("editor.codeinsight.xml"))])
 class FSharpCodeFoldingSettings : RiderCodeFoldingSettings(), PersistentStateComponent<FSharpCodeFoldingSettings> {
-    var collapseHashDirectives by foldingCheckBox("ReSharper F# Hash Directives Block Folding", "F# hash directives blocks", true)
+  var collapseHashDirectives by foldingCheckBox(
+    "ReSharper F# Hash Directives Block Folding",
+    "F# hash directives blocks",
+    true
+  )
 
-    override fun getState(): FSharpCodeFoldingSettings = this
-    override fun loadState(state: FSharpCodeFoldingSettings) = XmlSerializerUtil.copyBean(state, this)
+  override fun getState(): FSharpCodeFoldingSettings = this
+  override fun loadState(state: FSharpCodeFoldingSettings) = XmlSerializerUtil.copyBean(state, this)
 
-    companion object {
-        val instance: FSharpCodeFoldingSettings by lazy { ServiceManager.getService(FSharpCodeFoldingSettings::class.java) }
-    }
+  companion object {
+    val instance: FSharpCodeFoldingSettings by lazy { ServiceManager.getService(FSharpCodeFoldingSettings::class.java) }
+  }
 }

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/settings/FSharpOptionsPage.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/settings/FSharpOptionsPage.kt
@@ -3,5 +3,5 @@ package com.jetbrains.rider.plugins.fsharp.settings
 import com.jetbrains.rider.settings.simple.SimpleOptionsPage
 
 class FSharpOptionsPage : SimpleOptionsPage("F#", "FSharpOptionsPage") {
-    override fun getId(): String = "FSharp"
+  override fun getId(): String = "FSharp"
 }

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/projectView/projectTypes/FSharpProjectProvider.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/projectView/projectTypes/FSharpProjectProvider.kt
@@ -1,9 +1,9 @@
 package com.jetbrains.rider.projectView.projectTypes
 
 class FSharpProjectTypeProvider : RiderProjectTypesProvider {
-    companion object {
-        val FSharpProjectType = RiderProjectType("fsproj", "{F2A71F9B-5D33-465A-A702-920D77279786}")
-    }
+  companion object {
+    val FSharpProjectType = RiderProjectType("fsproj", "{F2A71F9B-5D33-465A-A702-920D77279786}")
+  }
 
-    override fun getProjectType() = listOf(FSharpProjectType)
+  override fun getProjectType() = listOf(FSharpProjectType)
 }

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/settings/FSharpCodeStyleSettingsProvider.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/settings/FSharpCodeStyleSettingsProvider.kt
@@ -7,12 +7,13 @@ import com.jetbrains.rider.ideaInterop.fileTypes.fsharp.FSharpScriptLanguage
 
 class FSharpCodeStyleSettingsProvider : FSharpCodeStyleSettingsProviderBase(FSharpLanguage)
 
-abstract class FSharpCodeStyleSettingsProviderBase(private val lang: Language) : RiderLanguageCodeStyleSettingsProvider() {
-    override fun createConfigurable(baseSettings: CodeStyleSettings, modelSettings: CodeStyleSettings) =
-            createRiderConfigurable(baseSettings, modelSettings, language, configurableDisplayName)
+abstract class FSharpCodeStyleSettingsProviderBase(private val lang: Language) :
+  RiderLanguageCodeStyleSettingsProvider() {
+  override fun createConfigurable(baseSettings: CodeStyleSettings, modelSettings: CodeStyleSettings) =
+    createRiderConfigurable(baseSettings, modelSettings, language, configurableDisplayName)
 
-    override fun getLanguage() = lang
-    override fun getHelpTopic() = "Settings_Code_Style_FSHARP"
-    override fun getConfigurableDisplayName() = lang.displayName
-    override fun getPagesId() = mapOf("FSharpCodeStylePage" to "Formatting Style", "FantomasPage" to "Fantomas")
+  override fun getLanguage() = lang
+  override fun getHelpTopic() = "Settings_Code_Style_FSHARP"
+  override fun getConfigurableDisplayName() = lang.displayName
+  override fun getPagesId() = mapOf("FSharpCodeStylePage" to "Formatting Style", "FantomasPage" to "Fantomas")
 }

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/settings/RiderFSharpFileTemplatesOptionPage.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/settings/RiderFSharpFileTemplatesOptionPage.kt
@@ -3,6 +3,7 @@ package com.jetbrains.rider.settings
 import com.intellij.openapi.options.Configurable
 import com.jetbrains.rider.settings.simple.SimpleOptionsPage
 
-class RiderFSharpFileTemplatesOptionPage : SimpleOptionsPage("F#", "RiderFSharpFileTemplatesSettings"), Configurable.NoScroll {
-    override fun getId(): String = "RiderFSharpFileTemplatesSettings"
+class RiderFSharpFileTemplatesOptionPage : SimpleOptionsPage("F#", "RiderFSharpFileTemplatesSettings"),
+  Configurable.NoScroll {
+  override fun getId(): String = "RiderFSharpFileTemplatesSettings"
 }

--- a/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/Extensions.kt
+++ b/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/Extensions.kt
@@ -19,80 +19,85 @@ import java.io.PrintStream
 import java.nio.file.Path
 
 fun com.intellij.openapi.editor.Editor.dumpTypeProviders(stream: PrintStream) {
-    with(stream) {
-        println((project ?: return).solution.rdFSharpModel.fsharpTestHost.dumpTypeProvidersProcess.sync(Unit))
-        println("\nSevereHighlighters:")
-        dumpSevereHighlighters(this)
-    }
+  with(stream) {
+    println((project ?: return).solution.rdFSharpModel.fsharpTestHost.dumpTypeProvidersProcess.sync(Unit))
+    println("\nSevereHighlighters:")
+    dumpSevereHighlighters(this)
+  }
 }
 
 fun withSetting(project: Project, setting: String, enterValue: String, exitValue: String, function: () -> Unit) {
-    TestHost.getInstance(project.protocolHost).setSetting(setting, enterValue)
-    try {
-        function()
-    } finally {
-        TestHost.getInstance(project.protocolHost).setSetting(setting, exitValue)
-    }
+  TestHost.getInstance(project.protocolHost).setSetting(setting, enterValue)
+  try {
+    function()
+  } finally {
+    TestHost.getInstance(project.protocolHost).setSetting(setting, exitValue)
+  }
 }
 
 fun BaseTestWithSolution.withDisabledOutOfProcessTypeProviders(function: () -> Unit) {
-    withSetting(project, "FSharp/FSharpOptions/FSharpExperimentalFeatures/OutOfProcessTypeProviders/@EntryValue", "false", "true") {
-        function()
-    }
+  withSetting(
+    project,
+    "FSharp/FSharpOptions/FSharpExperimentalFeatures/OutOfProcessTypeProviders/@EntryValue",
+    "false",
+    "true"
+  ) {
+    function()
+  }
 }
 
 fun BaseTestWithSolution.withNonFSharpProjectReferences(function: () -> Unit) {
-    withSetting(project, "FSharp/FSharpOptions/NonFSharpProjectInMemoryAnalysis/@EntryValue", "true", "false") {
-        function()
-    }
+  withSetting(project, "FSharp/FSharpOptions/NonFSharpProjectInMemoryAnalysis/@EntryValue", "true", "false") {
+    function()
+  }
 }
 
 fun withEditorConfig(project: Project, function: () -> Unit) {
-    withSetting(project, "CodeStyle/EditorConfig/EnableEditorConfigSupport", "true", "false", function)
+  withSetting(project, "CodeStyle/EditorConfig/EnableEditorConfigSupport", "true", "false", function)
 }
 
 //TODO: move to test framework
 fun runProcessWaitForExit(cmd: Path, args: List<String>, env: Map<String, String>, timeoutMinutes: Int = 10) {
-    val cmdArray = mutableListOf(cmd.toAbsolutePath().toString())
-    cmdArray.addAll(args)
+  val cmdArray = mutableListOf(cmd.toAbsolutePath().toString())
+  cmdArray.addAll(args)
 
-    if (!SystemInfo.isWindows) {
-        cmdArray.add(0, RiderEnvironment.getBundledFile("runtime.sh").absolutePath)
-    }
+  if (!SystemInfo.isWindows) {
+    cmdArray.add(0, RiderEnvironment.getBundledFile("runtime.sh").absolutePath)
+  }
 
-    val cmdline = GeneralCommandLine()
-        .withExePath(cmdArray.first().toString())
-        .withEnvironment(env)
-        .withParameters(cmdArray.drop(1))
+  val cmdline = GeneralCommandLine()
+    .withExePath(cmdArray.first().toString())
+    .withEnvironment(env)
+    .withParameters(cmdArray.drop(1))
 
-    frameworkLogger.info("Starting $cmdline")
+  frameworkLogger.info("Starting $cmdline")
 
-    val processOutput = CapturingProcessHandler(cmdline).runProcess(timeoutMinutes * 60 * 1000, true)
+  val processOutput = CapturingProcessHandler(cmdline).runProcess(timeoutMinutes * 60 * 1000, true)
 
-    frameworkLogger.debug("$cmdline stdout: ${processOutput.stdout}")
-    frameworkLogger.debug("$cmdline stderr: ${processOutput.stderr}")
+  frameworkLogger.debug("$cmdline stdout: ${processOutput.stdout}")
+  frameworkLogger.debug("$cmdline stderr: ${processOutput.stderr}")
 
-    if (processOutput.checkSuccess(Logger.getInstance("com.jetbrains.rider.test.framework"))) {
-        frameworkLogger.info("$cmdline was successfully executed")
-    } else {
-        throw Exception("Unable to run process $cmdline: cancelled: ${processOutput.isCancelled} timeout: ${processOutput.isTimeout} exitcode: ${processOutput.exitCode} stderr: [[[${processOutput.stderr}]]] stdout: [[[${processOutput.stdout}]]]")
-    }
+  if (processOutput.checkSuccess(Logger.getInstance("com.jetbrains.rider.test.framework"))) {
+    frameworkLogger.info("$cmdline was successfully executed")
+  } else {
+    throw Exception("Unable to run process $cmdline: cancelled: ${processOutput.isCancelled} timeout: ${processOutput.isTimeout} exitcode: ${processOutput.exitCode} stderr: [[[${processOutput.stderr}]]] stdout: [[[${processOutput.stdout}]]]")
+  }
 }
 
 fun withCultureInfo(project: Project, culture: String, function: () -> Unit) {
-    val getCultureInfoAndSetNew = project.fcsHost.getCultureInfoAndSetNew
-    val oldCulture = getCultureInfoAndSetNew.sync(culture)
-    try {
-        function()
-    } finally {
-        getCultureInfoAndSetNew.sync(oldCulture)
-    }
+  val getCultureInfoAndSetNew = project.fcsHost.getCultureInfoAndSetNew
+  val oldCulture = getCultureInfoAndSetNew.sync(culture)
+  try {
+    function()
+  } finally {
+    getCultureInfoAndSetNew.sync(oldCulture)
+  }
 }
 
 fun flushFileChanges(project: Project) {
-    val fs = LocalFileSystem.getInstance()
-    fs.refresh(false)
-    waitBackend(project.protocolHost)
+  val fs = LocalFileSystem.getInstance()
+  fs.refresh(false)
+  waitBackend(project.protocolHost)
 }
 
 val Project.fcsHost get() = this.solution.rdFSharpModel.fsharpTestHost

--- a/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/FSharpCompletionTest.kt
+++ b/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/FSharpCompletionTest.kt
@@ -12,46 +12,46 @@ import org.testng.annotations.Test
 @Test
 @TestEnvironment(coreVersion = CoreVersion.LATEST_STABLE)
 class FSharpCompletionTest : CompletionTestBase() {
-    override fun getSolutionDirectoryName() = "CoreConsoleApp"
-    override val restoreNuGetPackages = true
+  override fun getSolutionDirectoryName() = "CoreConsoleApp"
+  override val restoreNuGetPackages = true
 
-    @Test
-    fun namespaceKeyword() = doTestTyping("names")
+  @Test
+  fun namespaceKeyword() = doTestTyping("names")
 
-    @Test
-    fun listModule() = doTestChooseItem("List")
+  @Test
+  fun listModule() = doTestChooseItem("List")
 
-    @Test
-    fun listModuleValue() = doTestTyping("filt")
+  @Test
+  fun listModuleValue() = doTestTyping("filt")
 
-    @Test(enabled = false)
-    fun localVal01() = doTestChooseItem("x")
+  @Test(enabled = false)
+  fun localVal01() = doTestChooseItem("x")
 
-    @Test
-    fun localVal02() = doTestTyping("x")
+  @Test
+  fun localVal02() = doTestTyping("x")
 
-    @Test
-    fun qualified01() = doTestChooseItem("a")
+  @Test
+  fun qualified01() = doTestChooseItem("a")
 
-    @Test
-    fun qualified02() = doTestChooseItem("a")
+  @Test
+  fun qualified02() = doTestChooseItem("a")
 
-    private fun doTestTyping(typed: String) {
-        dumpOpenedEditor("Program.fs", "Program.fs") {
-            waitForDaemon()
-            typeWithLatency(typed)
-            callBasicCompletion()
-            waitForCompletion()
-            completeWithTab()
-        }
+  private fun doTestTyping(typed: String) {
+    dumpOpenedEditor("Program.fs", "Program.fs") {
+      waitForDaemon()
+      typeWithLatency(typed)
+      callBasicCompletion()
+      waitForCompletion()
+      completeWithTab()
     }
+  }
 
-    private fun doTestChooseItem(item: String) {
-        dumpOpenedEditor("Program.fs", "Program.fs") {
-            waitForDaemon()
-            callBasicCompletion()
-            waitForCompletion()
-            completeWithTab(item)
-        }
+  private fun doTestChooseItem(item: String) {
+    dumpOpenedEditor("Program.fs", "Program.fs") {
+      waitForDaemon()
+      callBasicCompletion()
+      waitForCompletion()
+      completeWithTab(item)
     }
+  }
 }

--- a/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/FileSystemShimTest.kt
+++ b/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/FileSystemShimTest.kt
@@ -16,26 +16,30 @@ import java.time.Duration
 @Test
 @TestEnvironment(coreVersion = CoreVersion.LATEST_STABLE)
 class FileSystemShimTest : BaseTestWithSolution() {
-    override fun getSolutionDirectoryName() = "CoreConsoleApp"
+  override fun getSolutionDirectoryName() = "CoreConsoleApp"
 
-    @Test
-    fun externalFileChange() {
-        val file = activeSolutionDirectory.resolve("Program.fs")
-        val stampBefore = getTimestamp(file)
+  @Test
+  fun externalFileChange() {
+    val file = activeSolutionDirectory.resolve("Program.fs")
+    val stampBefore = getTimestamp(file)
 
-        val newText = "namespace NewTextHere"
-        changeFileContent(project, file) { newText }
+    val newText = "namespace NewTextHere"
+    changeFileContent(project, file) { newText }
 
-        LocalFileSystem.getInstance().refresh(false)
-        waitAndPump(project.lifetime, { getTimestamp(file) > stampBefore }, Duration.ofSeconds(15000), { "Timestamp wasn't changed." })
-        val stampAfter = getTimestamp(file)
+    LocalFileSystem.getInstance().refresh(false)
+    waitAndPump(
+      project.lifetime,
+      { getTimestamp(file) > stampBefore },
+      Duration.ofSeconds(15000),
+      { "Timestamp wasn't changed." })
+    val stampAfter = getTimestamp(file)
 
-        val (source, timestamp) = project.fcsHost.getSourceCache.sync(file.path).shouldNotBeNull("Couldn't get the source.")
-        assert(source == newText) { "Source differs from new text." }
-        assert(timestamp == stampAfter) { "Timestamp differs from expected." }
-    }
+    val (source, timestamp) = project.fcsHost.getSourceCache.sync(file.path).shouldNotBeNull("Couldn't get the source.")
+    assert(source == newText) { "Source differs from new text." }
+    assert(timestamp == stampAfter) { "Timestamp differs from expected." }
+  }
 
-    private fun getTimestamp(file: File) =
-            project.fcsHost.getLastModificationStamp.sync(file.path)
+  private fun getTimestamp(file: File) =
+    project.fcsHost.getLastModificationStamp.sync(file.path)
 
 }

--- a/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/LogErrorTest.kt
+++ b/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/LogErrorTest.kt
@@ -8,9 +8,9 @@ import org.testng.annotations.Test
 
 class LogErrorTest : IntegrationTestCaseRunner() {
 
-    @Test(expectedExceptions = [(BackendException::class)])
-    fun testThrowEx() {
-        Logger.getInstance("Projected Logger").error(BackendException("a"))
-        testCaseErrorsProcessor.throwIfNotEmpty()
-    }
+  @Test(expectedExceptions = [(BackendException::class)])
+  fun testThrowEx() {
+    Logger.getInstance("Projected Logger").error(BackendException("a"))
+    testCaseErrorsProcessor.throwIfNotEmpty()
+  }
 }

--- a/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/debugger/AsyncDebuggerTest.kt
+++ b/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/debugger/AsyncDebuggerTest.kt
@@ -11,22 +11,22 @@ import org.testng.annotations.Test
 @Test
 @TestEnvironment(toolset = ToolsetVersion.TOOLSET_17_CORE, coreVersion = CoreVersion.DOT_NET_6)
 class AsyncDebuggerTest : DebuggerTestBase() {
-    override val projectName = "AsyncProgram"
-    override fun getSolutionDirectoryName() = projectName
+  override val projectName = "AsyncProgram"
+  override fun getSolutionDirectoryName() = projectName
 
-    override val waitForCaches = true
-    override val restoreNuGetPackages = true
+  override val waitForCaches = true
+  override val restoreNuGetPackages = true
 
-    @Test(description = "RIDER-27263")
-    fun testAsyncBreakpoint() {
-        // Note that this test doesn't checks the behavior of FSharpBreakpointVariantsProvider, since it's never called
-        // in tests. But the test breakpoints are multi-method by default, and we should just check that multi-method
-        // breakpoints work well in F# code.
-        testDebugProgram({
-            toggleBreakpoint("Program.fs", 9)
-        }, {
-            waitForPause()
-            dumpLocals()
-        }, true)
-    }
+  @Test(description = "RIDER-27263")
+  fun testAsyncBreakpoint() {
+    // Note that this test doesn't checks the behavior of FSharpBreakpointVariantsProvider, since it's never called
+    // in tests. But the test breakpoints are multi-method by default, and we should just check that multi-method
+    // breakpoints work well in F# code.
+    testDebugProgram({
+      toggleBreakpoint("Program.fs", 9)
+    }, {
+      waitForPause()
+      dumpLocals()
+    }, true)
+  }
 }

--- a/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/editor/CodeFoldingTest.kt
+++ b/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/editor/CodeFoldingTest.kt
@@ -10,11 +10,11 @@ import org.testng.annotations.Test
 @TestEnvironment(solution = "CoreConsoleApp", coreVersion = CoreVersion.LATEST_STABLE)
 class CodeFoldingTest : CodeFoldingTestBase() {
 
-    @Test
-    fun codeFolding() {
-        doTestWithMarkupModel("CodeFolding.fs", "CodeFolding.fs") {
-            waitForDaemon()
-            dumpFoldingHighlightersWithText()
-        }
+  @Test
+  fun codeFolding() {
+    doTestWithMarkupModel("CodeFolding.fs", "CodeFolding.fs") {
+      waitForDaemon()
+      dumpFoldingHighlightersWithText()
     }
+  }
 }

--- a/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/fantomas/FantomasRunOptionsTest.kt
+++ b/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/fantomas/FantomasRunOptionsTest.kt
@@ -33,240 +33,244 @@ import kotlin.io.path.createDirectory
 @Test
 @TestEnvironment(coreVersion = CoreVersion.DOT_NET_6, reuseSolution = false)
 class FantomasRunOptionsTest : EditorTestBase() {
-    override fun getSolutionDirectoryName() = "FormatCodeApp"
-    override val restoreNuGetPackages = false
+  override fun getSolutionDirectoryName() = "FormatCodeApp"
+  override val restoreNuGetPackages = false
 
-    private fun getDotnetCliHome() = Path(tempTestDirectory.parent, "dotnetHomeCli")
-    private val fantomasNotifications = ArrayList<String>()
-    private val bundledVersion = "5.0.0.0"
-    private val globalVersion = "4.7.2.0"
-    private var dotnetToolsInvalidated = false
+  private fun getDotnetCliHome() = Path(tempTestDirectory.parent, "dotnetHomeCli")
+  private val fantomasNotifications = ArrayList<String>()
+  private val bundledVersion = "5.0.0.0"
+  private val globalVersion = "4.7.2.0"
+  private var dotnetToolsInvalidated = false
 
-    private fun dumpRunOptions() = project.fcsHost.dumpFantomasRunOptions.sync(Unit)
-    private fun checkFantomasVersion(version: String) = project.fcsHost.fantomasVersion.sync(Unit).shouldBe(version)
-    private fun dumpNotifications(stream: PrintStream, expectedCount: Int) {
-        stream.println("\n\nNotifications:")
-        waitAndPump(project.lifetime,
-            { fantomasNotifications.size >= expectedCount },
-            Duration.ofSeconds(30),
-            { "Didn't wait for notifications. Expected $expectedCount, but was ${fantomasNotifications.size}" })
+  private fun dumpRunOptions() = project.fcsHost.dumpFantomasRunOptions.sync(Unit)
+  private fun checkFantomasVersion(version: String) = project.fcsHost.fantomasVersion.sync(Unit).shouldBe(version)
+  private fun dumpNotifications(stream: PrintStream, expectedCount: Int) {
+    stream.println("\n\nNotifications:")
+    waitAndPump(project.lifetime,
+      { fantomasNotifications.size >= expectedCount },
+      Duration.ofSeconds(30),
+      { "Didn't wait for notifications. Expected $expectedCount, but was ${fantomasNotifications.size}" })
 
-        fantomasNotifications.forEach { stream.println(it) }
+    fantomasNotifications.forEach { stream.println(it) }
+  }
+
+  private fun withFantomasSetting(value: String, function: () -> Unit) {
+    withSetting(project, "FSharp/FSharpFantomasOptions/Location/@EntryValue", value, "AutoDetected") {
+      function()
     }
+  }
 
-    private fun withFantomasSetting(value: String, function: () -> Unit) {
-        withSetting(project, "FSharp/FSharpFantomasOptions/Location/@EntryValue", value, "AutoDetected") {
-            function()
+  private fun withDotnetToolsUpdate(function: () -> Unit) {
+    dotnetToolsInvalidated = false
+    function()
+    flushFileChanges(project)
+    waitAndPump(Duration.ofSeconds(15), { dotnetToolsInvalidated == true }, { "Dotnet tools wasn't changed." })
+  }
+
+  private fun withFantomasLocalTool(name: String, version: String, restore: Boolean = true, function: () -> Unit) {
+    val manifestFile = Paths.get(project.solutionDirectory.absolutePath, ".config", "dotnet-tools.json")
+    frameworkLogger.info("Create '$manifestFile'")
+    val file = manifestFile.createFile()
+
+    try {
+      withDotnetToolsUpdate {
+        val toolsJson = """"$name": { "version": "$version", "commands": [ "fantomas" ] }"""
+        file.write("""{ "version": 1, "isRoot": true, "tools": { $toolsJson } }""")
+      }
+      if (restore) {
+        withDotnetToolsUpdate {
+          // Trigger dotnet tools restore
+          // TODO: use separate dotnet tools restore API
+          restoreNuGet(project)
         }
+      }
+      function()
+    } finally {
+      withDotnetToolsUpdate {
+        file.delete()
+        project.fcsHost.terminateFantomasHost.sync(Unit)
+      }
+    }
+  }
+
+  private fun withFantomasGlobalTool(function: () -> Unit) {
+    try {
+      val env = mapOf("DOTNET_CLI_HOME" to getDotnetCliHome().absolutePathString())
+
+      withDotnetToolsUpdate {
+        runProcessWaitForExit(
+          Path(PrepareTestEnvironment.dotnetCoreCliPath),
+          listOf("tool", "install", "fantomas-tool", "-g", "--version", globalVersion),
+          env
+        )
+      }
+      function()
+    } finally {
+      project.fcsHost.terminateFantomasHost.sync(Unit)
+    }
+  }
+
+  @BeforeTest(alwaysRun = true)
+  fun prepareDotnetCliHome() {
+    application.protocolManager.protocolHosts.forEach {
+      setReSharperEnvVar("DOTNET_CLI_HOME", getDotnetCliHome().absolutePathString(), it)
+    }
+  }
+
+  override fun beforeDoTestWithDocuments() {
+    fantomasNotifications.clear()
+
+    project.fcsHost.fantomasNotificationFired.advise(testLifetimeDef.lifetime) {
+      fantomasNotifications.add(it)
+    }
+    project.fcsHost.dotnetToolInvalidated.advise(testLifetimeDef.lifetime) {
+      dotnetToolsInvalidated = true
     }
 
-    private fun withDotnetToolsUpdate(function: () -> Unit) {
-        dotnetToolsInvalidated = false
-        function()
-        flushFileChanges(project)
-        waitAndPump(Duration.ofSeconds(15), { dotnetToolsInvalidated == true }, { "Dotnet tools wasn't changed." })
+    getDotnetCliHome().delete(true)
+    getDotnetCliHome().createDirectory()
+    flushFileChanges(project)
+  }
+
+  @Test
+  fun default() {
+    executeWithGold(testGoldFile) {
+      withOpenedEditor("Program.fs") {
+        waitForDaemon()
+        it.print(dumpRunOptions())
+
+        reformatCode()
+        checkFantomasVersion(bundledVersion)
+        dumpNotifications(it, 0)
+      }
     }
+  }
 
-    private fun withFantomasLocalTool(name: String, version: String, restore: Boolean = true, function: () -> Unit) {
-        val manifestFile = Paths.get(project.solutionDirectory.absolutePath, ".config", "dotnet-tools.json")
-        frameworkLogger.info("Create '$manifestFile'")
-        val file = manifestFile.createFile()
+  @Test
+  fun `local tool`() {
+    executeWithGold(testGoldFile) {
+      withOpenedEditor("Types.fs") {
+        withFantomasLocalTool("fantomas-tool", "4.7.6") {
+          it.println("--With local dotnet tool--")
+          it.print(dumpRunOptions())
 
-        try {
-            withDotnetToolsUpdate {
-                val toolsJson = """"$name": { "version": "$version", "commands": [ "fantomas" ] }"""
-                file.write("""{ "version": 1, "isRoot": true, "tools": { $toolsJson } }""")
-            }
-            if (restore) {
-                withDotnetToolsUpdate {
-                    // Trigger dotnet tools restore
-                    // TODO: use separate dotnet tools restore API
-                    restoreNuGet(project)
-                }
-            }
-            function()
-        } finally {
-            withDotnetToolsUpdate {
-                file.delete()
-                project.fcsHost.terminateFantomasHost.sync(Unit)
-            }
+          reformatCode()
+          checkFantomasVersion("4.7.6.0")
+
+          it.println("\nFormatted:")
+          dumpOpenedDocument(it, project!!)
+          dumpNotifications(it, 0)
         }
+
+        it.println("\n--Without local dotnet tool--")
+        it.print(dumpRunOptions())
+
+        reformatCode()
+        checkFantomasVersion(bundledVersion)
+
+        it.println("\nFormatted:")
+        dumpOpenedDocument(it, project!!)
+        dumpNotifications(it, 0)
+      }
     }
+  }
 
-    private fun withFantomasGlobalTool(function: () -> Unit) {
-        try {
-            val env = mapOf("DOTNET_CLI_HOME" to getDotnetCliHome().absolutePathString())
+  @Test
+  fun `local tool 3_3`() = doLocalToolTest("fantomas-tool", "3.3.0", "3.3.0.0")
 
-            withDotnetToolsUpdate {
-                runProcessWaitForExit(
-                    Path(PrepareTestEnvironment.dotnetCoreCliPath),
-                    listOf("tool", "install", "fantomas-tool", "-g", "--version", globalVersion),
-                    env
-                )
-            }
-            function()
-        } finally {
-            project.fcsHost.terminateFantomasHost.sync(Unit)
+  @Test
+  fun `local tool 4_5`() = doLocalToolTest("fantomas-tool", "4.5.0", "4.5.0.0")
+
+  @Test
+  fun `local tool 4_6`() = doLocalToolTest("fantomas-tool", "4.6.0", "4.6.0.0")
+
+  @Test
+  fun `local tool 5_0`() = doLocalToolTest(
+    "com/jetbrains/rider/plugins/fsharp/test/cases/fantomasrains/rider/plugins/fsharp/test/cases/fantomas",
+    "5.0.0",
+    "5.0.0.0"
+  )
+
+  @Test
+  fun `global tool`() {
+    executeWithGold(testGoldFile) {
+      withOpenedEditor("Program.fs") {
+        withFantomasGlobalTool {
+          it.print(dumpRunOptions())
+
+          reformatCode()
+          checkFantomasVersion(globalVersion)
+          dumpNotifications(it, 0)
         }
+      }
     }
+  }
 
-    @BeforeTest(alwaysRun = true)
-    fun prepareDotnetCliHome() {
-        application.protocolManager.protocolHosts.forEach {
-            setReSharperEnvVar("DOTNET_CLI_HOME", getDotnetCliHome().absolutePathString(), it)
+  @Test
+  fun `local tool selected but not found`() = doSelectedButNotFoundTest("LocalDotnetTool")
+
+  @Test
+  fun `global tool selected but not found`() = doSelectedButNotFoundTest("GlobalDotnetTool")
+
+  @Test
+  fun `local tool has unsupported version`() {
+    executeWithGold(testGoldFile) {
+      withFantomasLocalTool("fantomas-tool", "wrong_version", false) {
+        withOpenedEditor("Program.fs") {
+          it.print(dumpRunOptions())
+
+          reformatCode()
+          checkFantomasVersion(bundledVersion)
+
+          dumpNotifications(it, 1)
         }
+      }
     }
+  }
 
-    override fun beforeDoTestWithDocuments() {
-        fantomasNotifications.clear()
+  @Test
+  fun `run global tool if local tool failed to run`() {
+    executeWithGold(testGoldFile) {
+      withOpenedEditor("Program.fs") {
+        withFantomasLocalTool("fantomas-tool", "wrong_version", false) {
+          withFantomasGlobalTool {
+            it.print(dumpRunOptions())
 
-        project.fcsHost.fantomasNotificationFired.advise(testLifetimeDef.lifetime) {
-            fantomasNotifications.add(it)
+            reformatCode()
+            checkFantomasVersion(globalVersion)
+
+            dumpNotifications(it, 1)
+          }
         }
-        project.fcsHost.dotnetToolInvalidated.advise(testLifetimeDef.lifetime) {
-            dotnetToolsInvalidated = true
-        }
-
-        getDotnetCliHome().delete(true)
-        getDotnetCliHome().createDirectory()
-        flushFileChanges(project)
+      }
     }
+  }
 
-    @Test
-    fun default() {
+  private fun doLocalToolTest(name: String, version: String, expectedVersion: String) {
+    withOpenedEditor("Simple.fs") {
+      withFantomasLocalTool(name, version) {
         executeWithGold(testGoldFile) {
-            withOpenedEditor("Program.fs") {
-                waitForDaemon()
-                it.print(dumpRunOptions())
-
-                reformatCode()
-                checkFantomasVersion(bundledVersion)
-                dumpNotifications(it, 0)
-            }
+          reformatCode()
+          checkFantomasVersion(expectedVersion)
+          dumpOpenedDocument(it, project!!, false)
         }
+      }
     }
+  }
 
-    @Test
-    fun `local tool`() {
-        executeWithGold(testGoldFile) {
-            withOpenedEditor("Types.fs") {
-                withFantomasLocalTool("fantomas-tool", "4.7.6") {
-                    it.println("--With local dotnet tool--")
-                    it.print(dumpRunOptions())
+  private fun doSelectedButNotFoundTest(version: String) {
+    executeWithGold(testGoldFile) {
+      withFantomasSetting(version) {
+        withOpenedEditor("Program.fs") {
+          waitForDaemon()
+          it.print(dumpRunOptions())
 
-                    reformatCode()
-                    checkFantomasVersion("4.7.6.0")
+          reformatCode()
+          checkFantomasVersion(bundledVersion)
 
-                    it.println("\nFormatted:")
-                    dumpOpenedDocument(it, project!!)
-                    dumpNotifications(it, 0)
-                }
-
-                it.println("\n--Without local dotnet tool--")
-                it.print(dumpRunOptions())
-
-                reformatCode()
-                checkFantomasVersion(bundledVersion)
-
-                it.println("\nFormatted:")
-                dumpOpenedDocument(it, project!!)
-                dumpNotifications(it, 0)
-            }
+          dumpNotifications(it, 1)
         }
+      }
     }
-
-    @Test
-    fun `local tool 3_3`() = doLocalToolTest("fantomas-tool", "3.3.0", "3.3.0.0")
-
-    @Test
-    fun `local tool 4_5`() = doLocalToolTest("fantomas-tool", "4.5.0", "4.5.0.0")
-
-    @Test
-    fun `local tool 4_6`() = doLocalToolTest("fantomas-tool", "4.6.0", "4.6.0.0")
-
-    @Test
-    fun `local tool 5_0`() = doLocalToolTest("com/jetbrains/rider/plugins/fsharp/test/cases/fantomasrains/rider/plugins/fsharp/test/cases/fantomas", "5.0.0", "5.0.0.0")
-
-    @Test
-    fun `global tool`() {
-        executeWithGold(testGoldFile) {
-            withOpenedEditor("Program.fs") {
-                withFantomasGlobalTool {
-                    it.print(dumpRunOptions())
-
-                    reformatCode()
-                    checkFantomasVersion(globalVersion)
-                    dumpNotifications(it, 0)
-                }
-            }
-        }
-    }
-
-    @Test
-    fun `local tool selected but not found`() = doSelectedButNotFoundTest("LocalDotnetTool")
-
-    @Test
-    fun `global tool selected but not found`() = doSelectedButNotFoundTest("GlobalDotnetTool")
-
-    @Test
-    fun `local tool has unsupported version`() {
-        executeWithGold(testGoldFile) {
-            withFantomasLocalTool("fantomas-tool", "wrong_version", false) {
-                withOpenedEditor("Program.fs") {
-                    it.print(dumpRunOptions())
-
-                    reformatCode()
-                    checkFantomasVersion(bundledVersion)
-
-                    dumpNotifications(it, 1)
-                }
-            }
-        }
-    }
-
-    @Test
-    fun `run global tool if local tool failed to run`() {
-        executeWithGold(testGoldFile) {
-            withOpenedEditor("Program.fs") {
-                withFantomasLocalTool("fantomas-tool", "wrong_version", false) {
-                    withFantomasGlobalTool {
-                        it.print(dumpRunOptions())
-
-                        reformatCode()
-                        checkFantomasVersion(globalVersion)
-
-                        dumpNotifications(it, 1)
-                    }
-                }
-            }
-        }
-    }
-
-    private fun doLocalToolTest(name: String, version: String, expectedVersion: String) {
-        withOpenedEditor("Simple.fs") {
-            withFantomasLocalTool(name, version) {
-                executeWithGold(testGoldFile) {
-                    reformatCode()
-                    checkFantomasVersion(expectedVersion)
-                    dumpOpenedDocument(it, project!!, false)
-                }
-            }
-        }
-    }
-
-    private fun doSelectedButNotFoundTest(version: String) {
-        executeWithGold(testGoldFile) {
-            withFantomasSetting(version) {
-                withOpenedEditor("Program.fs") {
-                    waitForDaemon()
-                    it.print(dumpRunOptions())
-
-                    reformatCode()
-                    checkFantomasVersion(bundledVersion)
-
-                    dumpNotifications(it, 1)
-                }
-            }
-        }
-    }
+  }
 }

--- a/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/fantomas/FantomasTest.kt
+++ b/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/fantomas/FantomasTest.kt
@@ -14,26 +14,26 @@ import org.testng.annotations.Test
 @Test
 @TestEnvironment(coreVersion = CoreVersion.DOT_NET_6)
 class FantomasTest : EditorTestBase() {
-    override fun getSolutionDirectoryName() = "FormatCodeApp"
+  override fun getSolutionDirectoryName() = "FormatCodeApp"
 
-    @Test
-    fun withEditorConfig() = doTest("EditorConfig.fs")
+  @Test
+  fun withEditorConfig() = doTest("EditorConfig.fs")
 
-    @Test
-    fun simpleFormatting() = doTest("Simple.fs")
+  @Test
+  fun simpleFormatting() = doTest("Simple.fs")
 
-    @Test
-    fun formatLastFile() = doTest("Program.fs")
+  @Test
+  fun formatLastFile() = doTest("Program.fs")
 
-    private fun doTest(fileName: String) {
-        withEditorConfig(project) {
-            withOpenedEditor(fileName) {
-                waitForDaemon()
-                reformatCode()
-                executeWithGold(testGoldFile) {
-                    dumpOpenedDocument(it, project!!, false)
-                }
-            }
+  private fun doTest(fileName: String) {
+    withEditorConfig(project) {
+      withOpenedEditor(fileName) {
+        waitForDaemon()
+        reformatCode()
+        executeWithGold(testGoldFile) {
+          dumpOpenedDocument(it, project!!, false)
         }
+      }
     }
+  }
 }

--- a/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/lexer/FSharpLexerTest.kt
+++ b/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/lexer/FSharpLexerTest.kt
@@ -6,12 +6,13 @@ import org.testng.annotations.Test
 
 @Test
 class FSharpLexerTest : RiderFrontendLexerTest("fs") {
-    override fun createLexer() = FSharpLexer()
+  override fun createLexer() = FSharpLexer()
 
-    @Test
-    fun testDigit() {
-        doTest("1234567890 1234567890u 1234567890l 0XABCDEFy 0x001100010s 3.0F 0x0000000000000000LF 0x0000_0000_0000_0000LF 34742626263193832612536171N 0o7 0b1 0o1___1 1F",
-                """
+  @Test
+  fun testDigit() {
+    doTest(
+      "1234567890 1234567890u 1234567890l 0XABCDEFy 0x001100010s 3.0F 0x0000000000000000LF 0x0000_0000_0000_0000LF 34742626263193832612536171N 0o7 0b1 0o1___1 1F",
+      """
                 |INT32 ('1234567890')
                 |WHITESPACE (' ')
                 |UINT32 ('1234567890u')
@@ -38,41 +39,46 @@ class FSharpLexerTest : RiderFrontendLexerTest("fs") {
                 |WHITESPACE (' ')
                 |IEEE32 ('1F')
                 """.trimMargin()
-        )
-    }
+    )
+  }
 
-    @Test
-    fun testString() {
-        doTest("\"STRING\n \\ NEW_LINE\n\"",
-                """STRING ('"STRING\n \ NEW_LINE\n"')"""
-        )
-    }
+  @Test
+  fun testString() {
+    doTest(
+      "\"STRING\n \\ NEW_LINE\n\"",
+      """STRING ('"STRING\n \ NEW_LINE\n"')"""
+    )
+  }
 
-    @Test
-    fun testVerbatimString() {
-        doTest("@\"VERBATIM STRING\"",
-                """VERBATIM_STRING ('@"VERBATIM STRING"')"""
-        )
-    }
+  @Test
+  fun testVerbatimString() {
+    doTest(
+      "@\"VERBATIM STRING\"",
+      """VERBATIM_STRING ('@"VERBATIM STRING"')"""
+    )
+  }
 
-    @Test
-    fun testByteArray() {
-        doTest("\"ByteArray\"B",
-                """BYTEARRAY ('"ByteArray"B')"""
-        )
-    }
+  @Test
+  fun testByteArray() {
+    doTest(
+      "\"ByteArray\"B",
+      """BYTEARRAY ('"ByteArray"B')"""
+    )
+  }
 
-    @Test
-    fun testTripleQuotedString() {
-        doTest("\"\"\"triple-quoted-string \ntriple-quoted-string\"\"\"",
-                "TRIPLE_QUOTED_STRING ('\"\"\"triple-quoted-string \\ntriple-quoted-string\"\"\"')"
-        )
-    }
+  @Test
+  fun testTripleQuotedString() {
+    doTest(
+      "\"\"\"triple-quoted-string \ntriple-quoted-string\"\"\"",
+      "TRIPLE_QUOTED_STRING ('\"\"\"triple-quoted-string \\ntriple-quoted-string\"\"\"')"
+    )
+  }
 
-    @Test
-    fun testSymbolicOperator() {
-        doTest("&&& ||| ?<- @-><-= ?-> >-> >>= >>- |> .>>. .>> >>",
-                """
+  @Test
+  fun testSymbolicOperator() {
+    doTest(
+      "&&& ||| ?<- @-><-= ?-> >-> >>= >>- |> .>>. .>> >>",
+      """
                 |SYMBOLIC_OP ('&&&')
                 |WHITESPACE (' ')
                 |SYMBOLIC_OP ('|||')
@@ -97,33 +103,36 @@ class FSharpLexerTest : RiderFrontendLexerTest("fs") {
                 |WHITESPACE (' ')
                 |SYMBOLIC_OP ('>>')
                 """.trimMargin()
-        )
-    }
+    )
+  }
 
-    @Test
-    fun testSimpleBlockComment() {
-        doTest("(* HAHA *)", "BLOCK_COMMENT ('(* HAHA *)')")
-    }
+  @Test
+  fun testSimpleBlockComment() {
+    doTest("(* HAHA *)", "BLOCK_COMMENT ('(* HAHA *)')")
+  }
 
-    @Test
-    fun testBlockComment() {
-        doTest("(* Here's a code snippet: let s = \"*)\" *)",
-                """BLOCK_COMMENT ('(* Here's a code snippet: let s = "*)" *)')"""
-        )
-    }
+  @Test
+  fun testBlockComment() {
+    doTest(
+      "(* Here's a code snippet: let s = \"*)\" *)",
+      """BLOCK_COMMENT ('(* Here's a code snippet: let s = "*)" *)')"""
+    )
+  }
 
-    @Test
-    fun testBlockCommentError() {
-        doTest("(* \" *)",
-                "BLOCK_COMMENT ('(* \" *)')"
-        )
-    }
+  @Test
+  fun testBlockCommentError() {
+    doTest(
+      "(* \" *)",
+      "BLOCK_COMMENT ('(* \" *)')"
+    )
+  }
 
-    @Test
-    fun testSymbolicKeyword() {
-        doTest("let! use! do! yield! return! match! | -> <- . : ( ) [ ] [< >] " +
-                "[| |] { } ' # :?> :? :> .. :: := ;; ; = _ ? ?? (*) <@ @> <@@ @@>",
-                """
+  @Test
+  fun testSymbolicKeyword() {
+    doTest(
+      "let! use! do! yield! return! match! | -> <- . : ( ) [ ] [< >] " +
+        "[| |] { } ' # :?> :? :> .. :: := ;; ; = _ ? ?? (*) <@ @> <@@ @@>",
+      """
                 |LET_BANG ('let!')
                 |WHITESPACE (' ')
                 |USE_BANG ('use!')
@@ -204,18 +213,19 @@ class FSharpLexerTest : RiderFrontendLexerTest("fs") {
                 |WHITESPACE (' ')
                 |RQUOTE_UNTYPED ('@@>')
                 """.trimMargin()
-        )
-    }
+    )
+  }
 
-    @Test
-    fun testStringEscapeChar() {
-        doTest("\"\\n\\t\\b\\r\\a\\f\\v\"", "STRING ('\"\\n\\t\\b\\r\\a\\f\\v\"')")
-    }
+  @Test
+  fun testStringEscapeChar() {
+    doTest("\"\\n\\t\\b\\r\\a\\f\\v\"", "STRING ('\"\\n\\t\\b\\r\\a\\f\\v\"')")
+  }
 
-    @Test
-    fun testEscapeChar() {
-        doTest("'\\n' '\\t' '\\b' '\\r' '\"' '\\a' '\\f' '\\v'",
-                """
+  @Test
+  fun testEscapeChar() {
+    doTest(
+      "'\\n' '\\t' '\\b' '\\r' '\"' '\\a' '\\f' '\\v'",
+      """
                 |CHARACTER_LITERAL (''\n'')
                 |WHITESPACE (' ')
                 |CHARACTER_LITERAL (''\t'')
@@ -232,81 +242,89 @@ class FSharpLexerTest : RiderFrontendLexerTest("fs") {
                 |WHITESPACE (' ')
                 |CHARACTER_LITERAL (''\v'')
                 """.trimMargin()
-        )
-    }
+    )
+  }
 
-    @Test
-    fun testKeywordString() {
-        doTest("__SOURCE_FILE__ __SOURCE_DIRECTORY__ __LINE__",
-                """
+  @Test
+  fun testKeywordString() {
+    doTest(
+      "__SOURCE_FILE__ __SOURCE_DIRECTORY__ __LINE__",
+      """
                 |KEYWORD_STRING_SOURCE_FILE ('__SOURCE_FILE__')
                 |WHITESPACE (' ')
                 |KEYWORD_STRING_SOURCE_DIRECTORY ('__SOURCE_DIRECTORY__')
                 |WHITESPACE (' ')
                 |KEYWORD_STRING_LINE ('__LINE__')
                 """.trimMargin()
-        )
-    }
+    )
+  }
 
-    @Test
-    fun testUnfinishedTripleQuoteStringInComment() {
-        doTest("(* \"\"\" *)\n" +
-                """
+  @Test
+  fun testUnfinishedTripleQuoteStringInComment() {
+    doTest(
+      "(* \"\"\" *)\n" +
+        """
                 |let str = "STRING
                 |\ NEW_LINE
                 |"
                 """.trimMargin(),
-                "BLOCK_COMMENT ('(* \"\"\" *)\\nlet str = \"STRING\\n\\ NEW_LINE\\n\"')"
-        )
-    }
+      "BLOCK_COMMENT ('(* \"\"\" *)\\nlet str = \"STRING\\n\\ NEW_LINE\\n\"')"
+    )
+  }
 
-    @Test
-    fun testIntDotDot() {
-        doTest("1..20",
-                """
+  @Test
+  fun testIntDotDot() {
+    doTest(
+      "1..20",
+      """
                 |INT32 ('1')
                 |DOT_DOT ('..')
                 |INT32 ('20')
                 """.trimMargin()
-        )
-    }
+    )
+  }
 
-    @Test
-    fun testIdent() {
-        doTest("``value.with odd#name``",
-                "IDENT ('``value.with odd#name``')")
-    }
+  @Test
+  fun testIdent() {
+    doTest(
+      "``value.with odd#name``",
+      "IDENT ('``value.with odd#name``')"
+    )
+  }
 
-    @Test
-    fun testUnfinishedIdent() {
-        doTest("``value\n",
-            """
+  @Test
+  fun testUnfinishedIdent() {
+    doTest(
+      "``value\n",
+      """
             |RESERVED_SYMBOLIC_SEQUENCE ('`')
             |RESERVED_SYMBOLIC_SEQUENCE ('`')
             |IDENT ('value')
             |NEW_LINE ('\n')
             """.trimMargin()
-        )
-    }
+    )
+  }
 
 
-    @Test
-    fun testEndOfLineComment() {
-        doTest("//hello world!\n//hello second world!",
-                """
+  @Test
+  fun testEndOfLineComment() {
+    doTest(
+      "//hello world!\n//hello second world!",
+      """
                 |LINE_COMMENT ('//hello world!')
                 |NEW_LINE ('\n')
                 |LINE_COMMENT ('//hello second world!')
                 """.trimMargin()
-        )
-    }
+    )
+  }
 
-    @Test
-    fun testUnfinishedString() {
-        doTest("(* \"\"\"hello\"\"\" *)\n" +
-                "        let str = \"STRING\n",
-                "BLOCK_COMMENT ('(* \"\"\"hello\"\"\" *)')\n" +
-                        """
+  @Test
+  fun testUnfinishedString() {
+    doTest(
+      "(* \"\"\"hello\"\"\" *)\n" +
+        "        let str = \"STRING\n",
+      "BLOCK_COMMENT ('(* \"\"\"hello\"\"\" *)')\n" +
+        """
                         |NEW_LINE ('\n')
                         |WHITESPACE ('        ')
                         |LET ('let')
@@ -317,13 +335,14 @@ class FSharpLexerTest : RiderFrontendLexerTest("fs") {
                         |WHITESPACE (' ')
                         |UNFINISHED_STRING ('"STRING\n')
                         """.trimMargin()
-        )
-    }
+    )
+  }
 
-    @Test
-    fun testCodeQuotation() {
-        doTest("<@ 1 + 1 @>.ToString() <@@ 1 + 1 @@>.ToString()",
-                """
+  @Test
+  fun testCodeQuotation() {
+    doTest(
+      "<@ 1 + 1 @>.ToString() <@@ 1 + 1 @@>.ToString()",
+      """
                 |LQUOTE_TYPED ('<@')
                 |WHITESPACE (' ')
                 |INT32 ('1')
@@ -352,35 +371,38 @@ class FSharpLexerTest : RiderFrontendLexerTest("fs") {
                 |LPAREN ('(')
                 |RPAREN (')')
                 """.trimMargin()
-        )
-    }
+    )
+  }
 
-    @Test
-    fun testBadOperator() {
-        doTest(".?:%? .?$%?",
-                """
+  @Test
+  fun testBadOperator() {
+    doTest(
+      ".?:%? .?$%?",
+      """
                 |BAD_SYMBOLIC_OP ('.?:%?')
                 |WHITESPACE (' ')
                 |BAD_SYMBOLIC_OP ('.?$%?')
                 """.trimMargin()
-        )
-    }
+    )
+  }
 
-    @Test
-    fun testAttribute() {
-        doTest("[<SomeAttribute>]",
-                """
+  @Test
+  fun testAttribute() {
+    doTest(
+      "[<SomeAttribute>]",
+      """
                 |LBRACK_LESS ('[<')
                 |IDENT ('SomeAttribute')
                 |GREATER_RBRACK ('>]')
                 """.trimMargin()
-        )
-    }
+    )
+  }
 
-    @Test
-    fun testTypeApp() {
-        doTest("let typeApp = typeof<Map<Map<Map<Map<_,_>[],Map<_,_[]>>,_>,_>>.FullName",
-                """
+  @Test
+  fun testTypeApp() {
+    doTest(
+      "let typeApp = typeof<Map<Map<Map<Map<_,_>[],Map<_,_[]>>,_>,_>>.FullName",
+      """
                 |LET ('let')
                 |WHITESPACE (' ')
                 |IDENT ('typeApp')
@@ -423,13 +445,14 @@ class FSharpLexerTest : RiderFrontendLexerTest("fs") {
                 |DOT ('.')
                 |IDENT ('FullName')
                 """.trimMargin()
-        )
-    }
+    )
+  }
 
-    @Test
-    fun testCorrectTypeApp() {
-        doTest("[typeof<int>] [typeof<int >]",
-                """
+  @Test
+  fun testCorrectTypeApp() {
+    doTest(
+      "[typeof<int>] [typeof<int >]",
+      """
                 |LBRACK ('[')
                 |IDENT ('typeof')
                 |LESS ('<')
@@ -445,13 +468,14 @@ class FSharpLexerTest : RiderFrontendLexerTest("fs") {
                 |GREATER ('>')
                 |RBRACK (']')
                 """.trimMargin()
-        )
-    }
+    )
+  }
 
-    @Test
-    fun testIncorrectTypeApp() {
-        doTest("C<M<int >] >>> C<M<int >] > >>",
-                """
+  @Test
+  fun testIncorrectTypeApp() {
+    doTest(
+      "C<M<int >] >>> C<M<int >] > >>",
+      """
                 |IDENT ('C')
                 |LESS ('<')
                 |IDENT ('M')
@@ -478,16 +502,17 @@ class FSharpLexerTest : RiderFrontendLexerTest("fs") {
                 |WHITESPACE (' ')
                 |SYMBOLIC_OP ('>>')
                 """.trimMargin()
-        )
-    }
+    )
+  }
 
-    @Test
-    fun testGenericDeclaration() {
-        doTest("""
+  @Test
+  fun testGenericDeclaration() {
+    doTest(
+      """
             |type U<'a> = Choice1 of 'a
             |type 'a F = | F of 'a
             """.trimMargin(),
-                """
+      """
                 |TYPE ('type')
                 |WHITESPACE (' ')
                 |IDENT ('U')
@@ -523,17 +548,18 @@ class FSharpLexerTest : RiderFrontendLexerTest("fs") {
                 |QUOTE (''')
                 |IDENT ('a')
                 """.trimMargin()
-        )
-    }
+    )
+  }
 
-    @Test
-    fun testIfDirective() {
-        doTest("""
+  @Test
+  fun testIfDirective() {
+    doTest(
+      """
             |#if
             |#if (symbol || symbol) && symbol
             |#ifs symbol <- symbol
             """.trimMargin(),
-                """
+      """
                     |PP_IF_SECTION ('#if')
                     |NEW_LINE ('\n')
                     |PP_IF_SECTION ('#if')
@@ -559,17 +585,18 @@ class FSharpLexerTest : RiderFrontendLexerTest("fs") {
                     |WHITESPACE (' ')
                     |IDENT ('symbol')
                     """.trimMargin()
-        )
-    }
+    )
+  }
 
-    @Test
-    fun testElseDirective() {
-        doTest("""
+  @Test
+  fun testElseDirective() {
+    doTest(
+      """
             |#else (symbol || symbol) && symbol
             |#else
             |#elses symbol
             """.trimMargin(),
-                """
+      """
                 |PP_ELSE_SECTION ('#else')
                 |WHITESPACE (' ')
                 |PP_LPAR ('(')
@@ -591,17 +618,18 @@ class FSharpLexerTest : RiderFrontendLexerTest("fs") {
                 |WHITESPACE (' ')
                 |PP_CONDITIONAL_SYMBOL ('symbol')
                 """.trimMargin()
-        )
-    }
+    )
+  }
 
-    @Test
-    fun testEndIfDirective() {
-        doTest("""
+  @Test
+  fun testEndIfDirective() {
+    doTest(
+      """
             |#endif
             |#endif (symbol || symbol) && symbol
             |#endifs symbol
             """.trimMargin(),
-                """
+      """
                 |PP_ENDIF ('#endif')
                 |NEW_LINE ('\n')
                 |PP_ENDIF ('#endif')
@@ -623,12 +651,13 @@ class FSharpLexerTest : RiderFrontendLexerTest("fs") {
                 |WHITESPACE (' ')
                 |PP_CONDITIONAL_SYMBOL ('symbol')
                 """.trimMargin()
-        )
-    }
+    )
+  }
 
-    @Test
-    fun testLightDirective() {
-        doTest("""
+  @Test
+  fun testLightDirective() {
+    doTest(
+      """
             |#light
             |#light "on"
             |#light "off"
@@ -637,7 +666,7 @@ class FSharpLexerTest : RiderFrontendLexerTest("fs") {
             |#indent "off"
             |let app : #light -> light = Constr >> Constr
             """.trimMargin(),
-                """
+      """
                 |PP_LIGHT ('#light')
                 |NEW_LINE ('\n')
                 |PP_LIGHT ('#light')
@@ -678,12 +707,13 @@ class FSharpLexerTest : RiderFrontendLexerTest("fs") {
                 |WHITESPACE (' ')
                 |IDENT ('Constr')
                 """.trimMargin()
-        )
-    }
+    )
+  }
 
-    @Test
-    fun testLineDirective() {
-        doTest("""
+  @Test
+  fun testLineDirective() {
+    doTest(
+      """
             |#line
             |#line "string"
             |#line @"verbatim string"
@@ -694,7 +724,7 @@ class FSharpLexerTest : RiderFrontendLexerTest("fs") {
             |# 44 "string"
             |# 44 @"verbatim string"
             """.trimMargin(),
-                """
+      """
                 |PP_LINE ('#line')
                 |NEW_LINE ('\n')
                 |PP_LINE ('#line')
@@ -725,19 +755,20 @@ class FSharpLexerTest : RiderFrontendLexerTest("fs") {
                 |WHITESPACE (' ')
                 |VERBATIM_STRING ('@"verbatim string"')
                 """.trimMargin()
-        )
-    }
+    )
+  }
 
-    @Test
-    fun testBadCommentInDirective() {
-        doTest("""
+  @Test
+  fun testBadCommentInDirective() {
+    doTest(
+      """
             |#if asdfasdf /*asdfasdfasdfasdfasdfasdf*/ asdfasdf
             |sadfsadf
             |#else
             |sadfasdf
             |#endif
             """.trimMargin(),
-                """
+      """
                 |PP_IF_SECTION ('#if')
                 |WHITESPACE (' ')
                 |PP_CONDITIONAL_SYMBOL ('asdfasdf')
@@ -758,48 +789,52 @@ class FSharpLexerTest : RiderFrontendLexerTest("fs") {
                 |NEW_LINE ('\n')
                 |PP_ENDIF ('#endif')
                 """.trimMargin()
-        )
-    }
+    )
+  }
 
-    @Test
-    fun testEscapeCharacterInString() {
-        doTest(""""\\" ()""",
-                """
+  @Test
+  fun testEscapeCharacterInString() {
+    doTest(
+      """"\\" ()""",
+      """
                 |STRING ('"\\"')
                 |WHITESPACE (' ')
                 |LPAREN ('(')
                 |RPAREN (')')
                 """.trimMargin()
-        )
-    }
+    )
+  }
 
-    @Test
-    fun testEscapeCharacterInTripleQuotedString() {
-        doTest("""""${'"'}\""${'"'} ()""",
-                """
+  @Test
+  fun testEscapeCharacterInTripleQuotedString() {
+    doTest(
+      """""${'"'}\""${'"'} ()""",
+      """
                 |TRIPLE_QUOTED_STRING ('""${'"'}\""${'"'}')
                 |WHITESPACE (' ')
                 |LPAREN ('(')
                 |RPAREN (')')
                 """.trimMargin()
-        )
-    }
+    )
+  }
 
-    @Test
-    fun testEscapeCharacterInVerbatimString() {
-        doTest("""@"\" ()""",
-                """
+  @Test
+  fun testEscapeCharacterInVerbatimString() {
+    doTest(
+      """@"\" ()""",
+      """
                 |VERBATIM_STRING ('@"\"')
                 |WHITESPACE (' ')
                 |LPAREN ('(')
                 |RPAREN (')')
                 """.trimMargin()
-        )
-    }
+    )
+  }
 
-    @Test
-    fun testInteractiveDirective() {
-        doTest("""
+  @Test
+  fun testInteractiveDirective() {
+    doTest(
+      """
             |#r "file.dll";;
             |#I "path";;
             |#load "file.fs" "file.fs";;
@@ -807,7 +842,7 @@ class FSharpLexerTest : RiderFrontendLexerTest("fs") {
             |#help;;
             |#quit;;
             """.trimMargin(),
-                """
+      """
                 |PP_REFERENCE ('#r')
                 |WHITESPACE (' ')
                 |STRING ('"file.dll"')
@@ -838,26 +873,28 @@ class FSharpLexerTest : RiderFrontendLexerTest("fs") {
                 |PP_QUIT ('#quit')
                 |SEMICOLON_SEMICOLON (';;')
                 """.trimMargin()
-        )
-    }
+    )
+  }
 
-    @Test
-    fun testHelpQuitDirective() {
-        doTest("""
+  @Test
+  fun testHelpQuitDirective() {
+    doTest(
+      """
             |#help
             |#quit
             """.trimMargin(),
-                """
+      """
                 |PP_HELP ('#help')
                 |NEW_LINE ('\n')
                 |PP_QUIT ('#quit')
                 """.trimMargin()
-        )
-    }
+    )
+  }
 
-    @Test
-    fun testLoadDirective() {
-        doTest("""
+  @Test
+  fun testLoadDirective() {
+    doTest(
+      """
             |#l
             |#l "string"
             |#l @"verbatim string"
@@ -865,7 +902,7 @@ class FSharpLexerTest : RiderFrontendLexerTest("fs") {
             |#load "string"
             |#load @"verbatim string"
             """.trimMargin(),
-                """
+      """
                 |PP_LOAD ('#l')
                 |NEW_LINE ('\n')
                 |PP_LOAD ('#l')
@@ -886,12 +923,13 @@ class FSharpLexerTest : RiderFrontendLexerTest("fs") {
                 |WHITESPACE (' ')
                 |VERBATIM_STRING ('@"verbatim string"')
                 """.trimMargin()
-        )
-    }
+    )
+  }
 
-    @Test
-    fun testReferenceDirective() {
-        doTest("""
+  @Test
+  fun testReferenceDirective() {
+    doTest(
+      """
             |#r
             |#r "string"
             |#r @"verbatim string"
@@ -899,7 +937,7 @@ class FSharpLexerTest : RiderFrontendLexerTest("fs") {
             |#reference "string"
             |#reference @"verbatim string"
             """.trimMargin(),
-                """
+      """
                 |PP_REFERENCE ('#r')
                 |NEW_LINE ('\n')
                 |PP_REFERENCE ('#r')
@@ -920,17 +958,18 @@ class FSharpLexerTest : RiderFrontendLexerTest("fs") {
                 |WHITESPACE (' ')
                 |VERBATIM_STRING ('@"verbatim string"')
                 """.trimMargin()
-        )
-    }
+    )
+  }
 
-    @Test
-    fun testTimeDirective() {
-        doTest("""
+  @Test
+  fun testTimeDirective() {
+    doTest(
+      """
             |#time
             |#time "string"
             |#time @"verbatim string"
             """.trimMargin(),
-                """
+      """
                 |PP_TIME ('#time')
                 |NEW_LINE ('\n')
                 |PP_TIME ('#time')
@@ -941,17 +980,18 @@ class FSharpLexerTest : RiderFrontendLexerTest("fs") {
                 |WHITESPACE (' ')
                 |VERBATIM_STRING ('@"verbatim string"')
                 """.trimMargin()
-        )
-    }
+    )
+  }
 
-    @Test
-    fun testIDirective() {
-        doTest("""
+  @Test
+  fun testIDirective() {
+    doTest(
+      """
             |#I
             |#I "string"
             |#I @"verbatim string"
             """.trimMargin(),
-                """
+      """
                 |PP_I ('#I')
                 |NEW_LINE ('\n')
                 |PP_I ('#I')
@@ -962,25 +1002,27 @@ class FSharpLexerTest : RiderFrontendLexerTest("fs") {
                 |WHITESPACE (' ')
                 |VERBATIM_STRING ('@"verbatim string"')
                 """.trimMargin()
-        )
-    }
+    )
+  }
 
-    @Test
-    fun testSpaceDirective() {
-        doTest(" #r \"on\"",
-                """
+  @Test
+  fun testSpaceDirective() {
+    doTest(
+      " #r \"on\"",
+      """
                 |WHITESPACE (' ')
                 |PP_REFERENCE ('#r')
                 |WHITESPACE (' ')
                 |STRING ('"on"')
                 """.trimMargin()
-        )
-    }
+    )
+  }
 
-    @Test
-    fun testFlexibleType() {
-        doTest("let app : #r\nlet app1 : #if_",
-                """
+  @Test
+  fun testFlexibleType() {
+    doTest(
+      "let app : #r\nlet app1 : #if_",
+      """
                 |LET ('let')
                 |WHITESPACE (' ')
                 |IDENT ('app')
@@ -999,60 +1041,65 @@ class FSharpLexerTest : RiderFrontendLexerTest("fs") {
                 |PP_DIRECTIVE ('#if')
                 |UNDERSCORE ('_')
                 """.trimMargin()
-        )
-    }
+    )
+  }
 
-    @Test
-    fun testCharInString() {
-        doTest(""""string 'c'" ()""",
-                """
+  @Test
+  fun testCharInString() {
+    doTest(
+      """"string 'c'" ()""",
+      """
                 |STRING ('"string 'c'"')
                 |WHITESPACE (' ')
                 |LPAREN ('(')
                 |RPAREN (')')
                 """.trimMargin()
-        )
-    }
+    )
+  }
 
-    @Test
-    fun testCharVerbatimString() {
-        doTest("""@"string 'c'" ()""",
-                """
+  @Test
+  fun testCharVerbatimString() {
+    doTest(
+      """@"string 'c'" ()""",
+      """
                 |VERBATIM_STRING ('@"string 'c'"')
                 |WHITESPACE (' ')
                 |LPAREN ('(')
                 |RPAREN (')')
                 """.trimMargin()
-        )
-    }
+    )
+  }
 
-    @Test
-    fun testCharTripleQuoteString() {
-        doTest("""""${'"'}string 'c'""${'"'} ()""",
-                """
+  @Test
+  fun testCharTripleQuoteString() {
+    doTest(
+      """""${'"'}string 'c'""${'"'} ()""",
+      """
                 |TRIPLE_QUOTED_STRING ('""${'"'}string 'c'""${'"'}')
                 |WHITESPACE (' ')
                 |LPAREN ('(')
                 |RPAREN (')')
                 """.trimMargin()
-        )
-    }
+    )
+  }
 
-    @Test
-    fun testLeftArrow() {
-        doTest("ident<-ident",
-                """
+  @Test
+  fun testLeftArrow() {
+    doTest(
+      "ident<-ident",
+      """
                 |IDENT ('ident')
                 |LARROW ('<-')
                 |IDENT ('ident')
                 """.trimMargin()
-        )
-    }
+    )
+  }
 
-    @Test
-    fun testRightArrow() {
-        doTest("t< -> t< ->>",
-                """
+  @Test
+  fun testRightArrow() {
+    doTest(
+      "t< -> t< ->>",
+      """
                 |IDENT ('t')
                 |LESS ('<')
                 |WHITESPACE (' ')
@@ -1063,41 +1110,44 @@ class FSharpLexerTest : RiderFrontendLexerTest("fs") {
                 |WHITESPACE (' ')
                 |SYMBOLIC_OP ('->>')
                 """.trimMargin()
-        )
-    }
+    )
+  }
 
-    @Test
-    fun testBackslashInString() {
-        doTest("""
+  @Test
+  fun testBackslashInString() {
+    doTest(
+      """
         |"a\
           b\
 		c\
 
 	d"
         |""".trimMargin(),
-                """
+      """
                 |STRING ('"a\\n          b\\n		c\\n\n	d"')
                 |NEW_LINE ('\n')
                 """.trimMargin()
-        )
-    }
+    )
+  }
 
-    @Test
-    fun testCommentInTypeApp() {
-        doTest("typeof<int//>",
-                """
+  @Test
+  fun testCommentInTypeApp() {
+    doTest(
+      "typeof<int//>",
+      """
                 |IDENT ('typeof')
                 |LESS ('<')
                 |IDENT ('int')
                 |LINE_COMMENT ('//>')
                 """.trimMargin()
-        )
-    }
+    )
+  }
 
-    @Test
-    fun testBlockCommentInTypeApp() {
-        doTest("typeof<int(*comment*)> typeof<int<int(*comment*)>>",
-                """
+  @Test
+  fun testBlockCommentInTypeApp() {
+    doTest(
+      "typeof<int(*comment*)> typeof<int<int(*comment*)>>",
+      """
                 |IDENT ('typeof')
                 |LESS ('<')
                 |IDENT ('int')
@@ -1113,18 +1163,19 @@ class FSharpLexerTest : RiderFrontendLexerTest("fs") {
                 |GREATER ('>')
                 |GREATER ('>')
                 """.trimMargin()
-        )
-    }
+    )
+  }
 
-    @Test
-    fun testValidIdentifiers() {
-        doTest("``s<>,.;':\"`~!@#\$%^&*()_+-=``","IDENT ('``s<>,.;':\"`~!@#\$%^&*()_+-=``')")
-    }
+  @Test
+  fun testValidIdentifiers() {
+    doTest("``s<>,.;':\"`~!@#\$%^&*()_+-=``", "IDENT ('``s<>,.;':\"`~!@#\$%^&*()_+-=``')")
+  }
 
-    @Test
-    fun testSmashingGreaterBarRBrack() {
-        doTest("let t = [|typeof<string>|]",
-                """
+  @Test
+  fun testSmashingGreaterBarRBrack() {
+    doTest(
+      "let t = [|typeof<string>|]",
+      """
                 |LET ('let')
                 |WHITESPACE (' ')
                 |IDENT ('t')
@@ -1138,13 +1189,14 @@ class FSharpLexerTest : RiderFrontendLexerTest("fs") {
                 |GREATER ('>')
                 |BAR_RBRACK ('|]')
                 """.trimMargin()
-        )
-    }
+    )
+  }
 
-    @Test
-    fun testAnonymousRecords() {
-        doTest("f<{| C : int |}>x",
-                """
+  @Test
+  fun testAnonymousRecords() {
+    doTest(
+      "f<{| C : int |}>x",
+      """
                 |IDENT ('f')
                 |LESS ('<')
                 |LBRACE_BAR ('{|')
@@ -1159,13 +1211,14 @@ class FSharpLexerTest : RiderFrontendLexerTest("fs") {
                 |GREATER ('>')
                 |IDENT ('x')
                 """.trimMargin()
-        )
-    }
+    )
+  }
 
-    @Test
-    fun testAttributeInsideGeneric() {
-        doTest("[<MeasureAnnotatedAbbreviation>] type bool<[<Measure>] 'm> = bool",
-                """
+  @Test
+  fun testAttributeInsideGeneric() {
+    doTest(
+      "[<MeasureAnnotatedAbbreviation>] type bool<[<Measure>] 'm> = bool",
+      """
                 |LBRACK_LESS ('[<')
                 |IDENT ('MeasureAnnotatedAbbreviation')
                 |GREATER_RBRACK ('>]')
@@ -1186,23 +1239,24 @@ class FSharpLexerTest : RiderFrontendLexerTest("fs") {
                 |WHITESPACE (' ')
                 |IDENT ('bool')
                 """.trimMargin()
-        )
-    }
+    )
+  }
 
-    @Test
-    fun testCharQuote() {
-        doTest("'''", "CHARACTER_LITERAL (''''')")
-    }
+  @Test
+  fun testCharQuote() {
+    doTest("'''", "CHARACTER_LITERAL (''''')")
+  }
 
-    @Test
-    fun `testStrings - Interpolated - Regular 01 - No interpolation`() {
-        doTest("$\"\"", "REGULAR_INTERPOLATED_STRING ('\$\"\"')")
-    }
+  @Test
+  fun `testStrings - Interpolated - Regular 01 - No interpolation`() {
+    doTest("$\"\"", "REGULAR_INTERPOLATED_STRING ('\$\"\"')")
+  }
 
-    @Test
-    fun `testStrings - Interpolated - Regular 02`() {
-        doTest("$\"{1} hello {2 + 3}\"",
-            """REGULAR_INTERPOLATED_STRING_START ('${'$'}"{')
+  @Test
+  fun `testStrings - Interpolated - Regular 02`() {
+    doTest(
+      "$\"{1} hello {2 + 3}\"",
+      """REGULAR_INTERPOLATED_STRING_START ('${'$'}"{')
             |INT32 ('1')
             |REGULAR_INTERPOLATED_STRING_MIDDLE ('} hello {')
             |INT32 ('2')
@@ -1210,13 +1264,15 @@ class FSharpLexerTest : RiderFrontendLexerTest("fs") {
             |PLUS ('+')
             |WHITESPACE (' ')
             |INT32 ('3')
-            |REGULAR_INTERPOLATED_STRING_END ('}"')""".trimMargin())
-    }
+            |REGULAR_INTERPOLATED_STRING_END ('}"')""".trimMargin()
+    )
+  }
 
-    @Test
-    fun `testStrings - Interpolated - Regular 03 - Record`() {
-        doTest("$\"{ {F=1} }\"",
-            """REGULAR_INTERPOLATED_STRING_START ('$"{')
+  @Test
+  fun `testStrings - Interpolated - Regular 03 - Record`() {
+    doTest(
+      "$\"{ {F=1} }\"",
+      """REGULAR_INTERPOLATED_STRING_START ('$"{')
             |WHITESPACE (' ')
             |LBRACE ('{')
             |IDENT ('F')
@@ -1225,26 +1281,28 @@ class FSharpLexerTest : RiderFrontendLexerTest("fs") {
             |RBRACE ('}')
             |WHITESPACE (' ')
             |REGULAR_INTERPOLATED_STRING_END ('}"')""".trimMargin()
-        )
-    }
+    )
+  }
 
-    @Test
-    fun `testStrings - Interpolated - Triple quote - Nested 01`() {
-        doTest("$\"\"\"{\$\"{1}\"}\"\"\"",
-            """TRIPLE_QUOTE_INTERPOLATED_STRING_START ('${'$'}""${'"'}{')
+  @Test
+  fun `testStrings - Interpolated - Triple quote - Nested 01`() {
+    doTest(
+      "$\"\"\"{\$\"{1}\"}\"\"\"",
+      """TRIPLE_QUOTE_INTERPOLATED_STRING_START ('${'$'}""${'"'}{')
             |REGULAR_INTERPOLATED_STRING_START ('${'$'}"{')
             |INT32 ('1')
             |REGULAR_INTERPOLATED_STRING_END ('}"')
-            |TRIPLE_QUOTED_STRING_END ('}""${'"'}')""".trimMargin());
-    }
+            |TRIPLE_QUOTED_STRING_END ('}""${'"'}')""".trimMargin()
+    );
+  }
 
-    @Test
-    fun `testStrings - Interpolated - Triple quote 01`() {
-        doTest("$\"\"\" \"}} \"\"\"", """TRIPLE_QUOTED_STRING ('${'$'}""${'"'} "}} ""${'"'}')""");
-    }
+  @Test
+  fun `testStrings - Interpolated - Triple quote 01`() {
+    doTest("$\"\"\" \"}} \"\"\"", """TRIPLE_QUOTED_STRING ('${'$'}""${'"'} "}} ""${'"'}')""");
+  }
 
-    @Test
-    fun `testStrings - Interpolated - Triple quote 02`() {
-        doTest("$\"\"\" \"\"}} \"\"\"", """TRIPLE_QUOTED_STRING ('${'$'}""${'"'} ""}} ""${'"'}')""");
-    }
+  @Test
+  fun `testStrings - Interpolated - Triple quote 02`() {
+    doTest("$\"\"\" \"\"}} \"\"\"", """TRIPLE_QUOTED_STRING ('${'$'}""${'"'} ""}} ""${'"'}')""");
+  }
 }

--- a/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/markup/FSharpHoverDocTest.kt
+++ b/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/markup/FSharpHoverDocTest.kt
@@ -11,55 +11,55 @@ import org.testng.annotations.Test
 
 @TestEnvironment(solution = "CoreConsoleApp", coreVersion = CoreVersion.DOT_NET_6)
 class FSharpHoverDocTest : DocumentationTestBase() {
-    @Test
-    fun `test hover docs for EntryPoint`() = doTest("Program.fs", "Program.fs")
+  @Test
+  fun `test hover docs for EntryPoint`() = doTest("Program.fs", "Program.fs")
 
-    @Test
-    fun `test hover docs for a function definition`() = doTest("Program.fs", "Program.fs")
+  @Test
+  fun `test hover docs for a function definition`() = doTest("Program.fs", "Program.fs")
 
-    @Test
-    fun `test hover docs for a parameter`() = doTest("Program.fs", "Program.fs")
+  @Test
+  fun `test hover docs for a parameter`() = doTest("Program.fs", "Program.fs")
 
-    @Test
-    fun `test hover docs for a submodule`() = doTest("Program.fs", "Program.fs")
+  @Test
+  fun `test hover docs for a submodule`() = doTest("Program.fs", "Program.fs")
 
-    @Test
-    fun `test xml doc with symbol reference`() = doTest("Program.fs", "Program.fs")
+  @Test
+  fun `test xml doc with symbol reference`() = doTest("Program.fs", "Program.fs")
 
-    @Test
-    fun `test empty xml doc`() = doTest("Program.fs", "Program.fs")
+  @Test
+  fun `test empty xml doc`() = doTest("Program.fs", "Program.fs")
 
-    @Test
-    @TestEnvironment(solution = "ConsoleAppTwoTargetFrameworks")
-    fun `test multiple frameworks`() = doTest("Program.fs", "Program.fs")
+  @Test
+  @TestEnvironment(solution = "ConsoleAppTwoTargetFrameworks")
+  fun `test multiple frameworks`() = doTest("Program.fs", "Program.fs")
 
-    @Test
-    @TestEnvironment(
-        solution = "SwaggerProviderCSharp",
-        toolset = ToolsetVersion.TOOLSET_17_CORE,
-        coreVersion = CoreVersion.DOT_NET_6
-    )
-    fun `provided method in csharp`() = doTest("CSharpLibrary.cs", "CSharpLibrary.cs")
+  @Test
+  @TestEnvironment(
+    solution = "SwaggerProviderCSharp",
+    toolset = ToolsetVersion.TOOLSET_17_CORE,
+    coreVersion = CoreVersion.DOT_NET_6
+  )
+  fun `provided method in csharp`() = doTest("CSharpLibrary.cs", "CSharpLibrary.cs")
 
-    @Test
-    @TestEnvironment(
-        solution = "SwaggerProviderCSharp",
-        toolset = ToolsetVersion.TOOLSET_17_CORE,
-        coreVersion = CoreVersion.DOT_NET_6
-    )
-    fun `provided abbreviation in csharp`() = doTestWithTypeProviders("OpenAPI Provider for")
+  @Test
+  @TestEnvironment(
+    solution = "SwaggerProviderCSharp",
+    toolset = ToolsetVersion.TOOLSET_17_CORE,
+    coreVersion = CoreVersion.DOT_NET_6
+  )
+  fun `provided abbreviation in csharp`() = doTestWithTypeProviders("OpenAPI Provider for")
 
-    @Test
-    fun `test xml doc parsing error`() {
-        withCultureInfo(project, "en-US") {
-            doTest("Program.fs", "Program.fs")
-        }
+  @Test
+  fun `test xml doc parsing error`() {
+    withCultureInfo(project, "en-US") {
+      doTest("Program.fs", "Program.fs")
     }
+  }
 
-    private fun doTestWithTypeProviders(summary: String){
-        doTestWithMarkupModel("CSharpLibrary.cs", "CSharpLibrary.cs") {
-            waitForDaemon()
-            generateBackendHoverDoc().shouldContains(summary)
-        }
+  private fun doTestWithTypeProviders(summary: String) {
+    doTestWithMarkupModel("CSharpLibrary.cs", "CSharpLibrary.cs") {
+      waitForDaemon()
+      generateBackendHoverDoc().shouldContains(summary)
     }
+  }
 }

--- a/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/projectModel/FSharpMoveProviderExtensionTest.kt
+++ b/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/projectModel/FSharpMoveProviderExtensionTest.kt
@@ -20,141 +20,141 @@ import org.testng.annotations.Test
 @Test
 class FSharpMoveProviderExtensionTest : ProjectModelBaseTest() {
 
-    override fun getSolutionDirectoryName() = error("Specify solution per test")
+  override fun getSolutionDirectoryName() = error("Specify solution per test")
 
-    @Test
-    @TestEnvironment(solution = "MoveProviderSolution1", toolset = ToolsetVersion.TOOLSET_16_CORE)
-    fun testAllowPaste01_Mix() {
-        doTest { provider ->
-            val compileBeforeFile = findFile("Project", "CompileBeforeFile.fs")
-            val compileFile = findFile("Project", "CompileFile.fs")
-            val targetFile = findFileView("Project", "TargetFile.fs")
+  @Test
+  @TestEnvironment(solution = "MoveProviderSolution1", toolset = ToolsetVersion.TOOLSET_16_CORE)
+  fun testAllowPaste01_Mix() {
+    doTest { provider ->
+      val compileBeforeFile = findFile("Project", "CompileBeforeFile.fs")
+      val compileFile = findFile("Project", "CompileFile.fs")
+      val targetFile = findFileView("Project", "TargetFile.fs")
 
-            Assert.assertTrue(
-                    provider.allowPaste(listOf(compileFile, compileBeforeFile), targetFile, ActionOrderType.None)
-            )
-            Assert.assertFalse(
-                    provider.allowPaste(listOf(compileFile, compileBeforeFile), targetFile, ActionOrderType.Before)
-            )
-            Assert.assertFalse(
-                    provider.allowPaste(listOf(compileFile, compileBeforeFile), targetFile, ActionOrderType.After)
-            )
-        }
+      Assert.assertTrue(
+        provider.allowPaste(listOf(compileFile, compileBeforeFile), targetFile, ActionOrderType.None)
+      )
+      Assert.assertFalse(
+        provider.allowPaste(listOf(compileFile, compileBeforeFile), targetFile, ActionOrderType.Before)
+      )
+      Assert.assertFalse(
+        provider.allowPaste(listOf(compileFile, compileBeforeFile), targetFile, ActionOrderType.After)
+      )
     }
+  }
 
-    @Test
-    @TestEnvironment(solution = "MoveProviderSolution2", toolset = ToolsetVersion.TOOLSET_16_CORE)
-    fun testAllowPaste02_DifferentFiles() {
-        doTest { provider ->
-            val files = arrayListOf(
-                    findFileView("TargetProject", "File1.fs"),
-                    findFileView("TargetProject", "File2.fs"),
-                    findFileView("TargetProject", "File3.fs"),
-                    findFileView("TargetProject", "File4.fs"),
-                    findFileView("TargetProject", "File5.fs"),
-                    findFileView("TargetProject", "File6.fs")
-            )
+  @Test
+  @TestEnvironment(solution = "MoveProviderSolution2", toolset = ToolsetVersion.TOOLSET_16_CORE)
+  fun testAllowPaste02_DifferentFiles() {
+    doTest { provider ->
+      val files = arrayListOf(
+        findFileView("TargetProject", "File1.fs"),
+        findFileView("TargetProject", "File2.fs"),
+        findFileView("TargetProject", "File3.fs"),
+        findFileView("TargetProject", "File4.fs"),
+        findFileView("TargetProject", "File5.fs"),
+        findFileView("TargetProject", "File6.fs")
+      )
 
-            // Compile case
-            val compileFile = listOf(findFile("SourceProject", "CompileFile.fs"))
-            Assert.assertFalse(provider.allowPaste(compileFile, files[0], ActionOrderType.Before))
-            Assert.assertFalse(provider.allowPaste(compileFile, files[0], ActionOrderType.After))
-            Assert.assertFalse(provider.allowPaste(compileFile, files[1], ActionOrderType.Before))
-            Assert.assertTrue(provider.allowPaste(compileFile, files[1], ActionOrderType.After))
-            Assert.assertTrue(provider.allowPaste(compileFile, files[2], ActionOrderType.Before))
-            Assert.assertTrue(provider.allowPaste(compileFile, files[2], ActionOrderType.After))
-            Assert.assertTrue(provider.allowPaste(compileFile, files[3], ActionOrderType.Before))
-            Assert.assertTrue(provider.allowPaste(compileFile, files[3], ActionOrderType.After))
-            Assert.assertTrue(provider.allowPaste(compileFile, files[4], ActionOrderType.Before))
-            Assert.assertFalse(provider.allowPaste(compileFile, files[4], ActionOrderType.After))
-            Assert.assertFalse(provider.allowPaste(compileFile, files[5], ActionOrderType.Before))
-            Assert.assertFalse(provider.allowPaste(compileFile, files[5], ActionOrderType.After))
+      // Compile case
+      val compileFile = listOf(findFile("SourceProject", "CompileFile.fs"))
+      Assert.assertFalse(provider.allowPaste(compileFile, files[0], ActionOrderType.Before))
+      Assert.assertFalse(provider.allowPaste(compileFile, files[0], ActionOrderType.After))
+      Assert.assertFalse(provider.allowPaste(compileFile, files[1], ActionOrderType.Before))
+      Assert.assertTrue(provider.allowPaste(compileFile, files[1], ActionOrderType.After))
+      Assert.assertTrue(provider.allowPaste(compileFile, files[2], ActionOrderType.Before))
+      Assert.assertTrue(provider.allowPaste(compileFile, files[2], ActionOrderType.After))
+      Assert.assertTrue(provider.allowPaste(compileFile, files[3], ActionOrderType.Before))
+      Assert.assertTrue(provider.allowPaste(compileFile, files[3], ActionOrderType.After))
+      Assert.assertTrue(provider.allowPaste(compileFile, files[4], ActionOrderType.Before))
+      Assert.assertFalse(provider.allowPaste(compileFile, files[4], ActionOrderType.After))
+      Assert.assertFalse(provider.allowPaste(compileFile, files[5], ActionOrderType.Before))
+      Assert.assertFalse(provider.allowPaste(compileFile, files[5], ActionOrderType.After))
 
-            // CompileBefore case
-            val compileBeforeFile = listOf(findFile("SourceProject", "CompileBeforeFile.fs"))
-            Assert.assertTrue(provider.allowPaste(compileBeforeFile, files[0], ActionOrderType.Before))
-            Assert.assertTrue(provider.allowPaste(compileBeforeFile, files[0], ActionOrderType.After))
-            Assert.assertTrue(provider.allowPaste(compileBeforeFile, files[1], ActionOrderType.Before))
-            Assert.assertTrue(provider.allowPaste(compileBeforeFile, files[1], ActionOrderType.After))
-            Assert.assertTrue(provider.allowPaste(compileBeforeFile, files[2], ActionOrderType.Before))
-            Assert.assertFalse(provider.allowPaste(compileBeforeFile, files[2], ActionOrderType.After))
-            Assert.assertFalse(provider.allowPaste(compileBeforeFile, files[3], ActionOrderType.Before))
-            Assert.assertFalse(provider.allowPaste(compileBeforeFile, files[3], ActionOrderType.After))
-            Assert.assertFalse(provider.allowPaste(compileBeforeFile, files[4], ActionOrderType.Before))
-            Assert.assertFalse(provider.allowPaste(compileBeforeFile, files[4], ActionOrderType.After))
-            Assert.assertFalse(provider.allowPaste(compileBeforeFile, files[5], ActionOrderType.Before))
-            Assert.assertFalse(provider.allowPaste(compileBeforeFile, files[5], ActionOrderType.After))
+      // CompileBefore case
+      val compileBeforeFile = listOf(findFile("SourceProject", "CompileBeforeFile.fs"))
+      Assert.assertTrue(provider.allowPaste(compileBeforeFile, files[0], ActionOrderType.Before))
+      Assert.assertTrue(provider.allowPaste(compileBeforeFile, files[0], ActionOrderType.After))
+      Assert.assertTrue(provider.allowPaste(compileBeforeFile, files[1], ActionOrderType.Before))
+      Assert.assertTrue(provider.allowPaste(compileBeforeFile, files[1], ActionOrderType.After))
+      Assert.assertTrue(provider.allowPaste(compileBeforeFile, files[2], ActionOrderType.Before))
+      Assert.assertFalse(provider.allowPaste(compileBeforeFile, files[2], ActionOrderType.After))
+      Assert.assertFalse(provider.allowPaste(compileBeforeFile, files[3], ActionOrderType.Before))
+      Assert.assertFalse(provider.allowPaste(compileBeforeFile, files[3], ActionOrderType.After))
+      Assert.assertFalse(provider.allowPaste(compileBeforeFile, files[4], ActionOrderType.Before))
+      Assert.assertFalse(provider.allowPaste(compileBeforeFile, files[4], ActionOrderType.After))
+      Assert.assertFalse(provider.allowPaste(compileBeforeFile, files[5], ActionOrderType.Before))
+      Assert.assertFalse(provider.allowPaste(compileBeforeFile, files[5], ActionOrderType.After))
 
-            // CompileAfter
-            val compileAfterFile = listOf(findFile("SourceProject", "CompileAfterFile.fs"))
-            Assert.assertFalse(provider.allowPaste(compileAfterFile, files[0], ActionOrderType.Before))
-            Assert.assertFalse(provider.allowPaste(compileAfterFile, files[0], ActionOrderType.After))
-            Assert.assertFalse(provider.allowPaste(compileAfterFile, files[1], ActionOrderType.Before))
-            Assert.assertFalse(provider.allowPaste(compileAfterFile, files[1], ActionOrderType.After))
-            Assert.assertFalse(provider.allowPaste(compileAfterFile, files[2], ActionOrderType.Before))
-            Assert.assertFalse(provider.allowPaste(compileAfterFile, files[2], ActionOrderType.After))
-            Assert.assertFalse(provider.allowPaste(compileAfterFile, files[3], ActionOrderType.Before))
-            Assert.assertTrue(provider.allowPaste(compileAfterFile, files[3], ActionOrderType.After))
-            Assert.assertTrue(provider.allowPaste(compileAfterFile, files[4], ActionOrderType.Before))
-            Assert.assertTrue(provider.allowPaste(compileAfterFile, files[4], ActionOrderType.After))
-            Assert.assertTrue(provider.allowPaste(compileAfterFile, files[5], ActionOrderType.Before))
-            Assert.assertTrue(provider.allowPaste(compileAfterFile, files[5], ActionOrderType.After))
-        }
+      // CompileAfter
+      val compileAfterFile = listOf(findFile("SourceProject", "CompileAfterFile.fs"))
+      Assert.assertFalse(provider.allowPaste(compileAfterFile, files[0], ActionOrderType.Before))
+      Assert.assertFalse(provider.allowPaste(compileAfterFile, files[0], ActionOrderType.After))
+      Assert.assertFalse(provider.allowPaste(compileAfterFile, files[1], ActionOrderType.Before))
+      Assert.assertFalse(provider.allowPaste(compileAfterFile, files[1], ActionOrderType.After))
+      Assert.assertFalse(provider.allowPaste(compileAfterFile, files[2], ActionOrderType.Before))
+      Assert.assertFalse(provider.allowPaste(compileAfterFile, files[2], ActionOrderType.After))
+      Assert.assertFalse(provider.allowPaste(compileAfterFile, files[3], ActionOrderType.Before))
+      Assert.assertTrue(provider.allowPaste(compileAfterFile, files[3], ActionOrderType.After))
+      Assert.assertTrue(provider.allowPaste(compileAfterFile, files[4], ActionOrderType.Before))
+      Assert.assertTrue(provider.allowPaste(compileAfterFile, files[4], ActionOrderType.After))
+      Assert.assertTrue(provider.allowPaste(compileAfterFile, files[5], ActionOrderType.Before))
+      Assert.assertTrue(provider.allowPaste(compileAfterFile, files[5], ActionOrderType.After))
     }
+  }
 
-    @Test
-    @TestEnvironment(solution = "MoveProviderSolution3", toolset = ToolsetVersion.TOOLSET_16_CORE)
-    fun testAllowPaste03_DifferentFilesInFolders() {
-        doTest { provider ->
-            val rootFile = findFileView("TargetProject", "File3.fs")
-            val folder1 = findFileView("TargetProject", "Folder1")
-            val folder2 = findFileView("TargetProject", "Folder2")
+  @Test
+  @TestEnvironment(solution = "MoveProviderSolution3", toolset = ToolsetVersion.TOOLSET_16_CORE)
+  fun testAllowPaste03_DifferentFilesInFolders() {
+    doTest { provider ->
+      val rootFile = findFileView("TargetProject", "File3.fs")
+      val folder1 = findFileView("TargetProject", "Folder1")
+      val folder2 = findFileView("TargetProject", "Folder2")
 
-            // Compile case
-            val compileFile = listOf(findFile("SourceProject", "CompileFile.fs"))
-            Assert.assertFalse(provider.allowPaste(compileFile, folder1, ActionOrderType.Before))
-            Assert.assertTrue(provider.allowPaste(compileFile, folder1, ActionOrderType.After))
-            Assert.assertTrue(provider.allowPaste(compileFile, rootFile, ActionOrderType.Before))
-            Assert.assertTrue(provider.allowPaste(compileFile, rootFile, ActionOrderType.After))
-            Assert.assertTrue(provider.allowPaste(compileFile, folder2, ActionOrderType.Before))
-            Assert.assertFalse(provider.allowPaste(compileFile, folder2, ActionOrderType.After))
+      // Compile case
+      val compileFile = listOf(findFile("SourceProject", "CompileFile.fs"))
+      Assert.assertFalse(provider.allowPaste(compileFile, folder1, ActionOrderType.Before))
+      Assert.assertTrue(provider.allowPaste(compileFile, folder1, ActionOrderType.After))
+      Assert.assertTrue(provider.allowPaste(compileFile, rootFile, ActionOrderType.Before))
+      Assert.assertTrue(provider.allowPaste(compileFile, rootFile, ActionOrderType.After))
+      Assert.assertTrue(provider.allowPaste(compileFile, folder2, ActionOrderType.Before))
+      Assert.assertFalse(provider.allowPaste(compileFile, folder2, ActionOrderType.After))
 
-            // CompileBefore case
-            val compileBeforeFile = listOf(findFile("SourceProject", "CompileBeforeFile.fs"))
-            Assert.assertTrue(provider.allowPaste(compileBeforeFile, folder1, ActionOrderType.Before))
-            Assert.assertFalse(provider.allowPaste(compileBeforeFile, folder1, ActionOrderType.After))
-            Assert.assertFalse(provider.allowPaste(compileBeforeFile, rootFile, ActionOrderType.Before))
-            Assert.assertFalse(provider.allowPaste(compileBeforeFile, rootFile, ActionOrderType.After))
-            Assert.assertFalse(provider.allowPaste(compileBeforeFile, folder2, ActionOrderType.Before))
-            Assert.assertFalse(provider.allowPaste(compileBeforeFile, folder2, ActionOrderType.After))
+      // CompileBefore case
+      val compileBeforeFile = listOf(findFile("SourceProject", "CompileBeforeFile.fs"))
+      Assert.assertTrue(provider.allowPaste(compileBeforeFile, folder1, ActionOrderType.Before))
+      Assert.assertFalse(provider.allowPaste(compileBeforeFile, folder1, ActionOrderType.After))
+      Assert.assertFalse(provider.allowPaste(compileBeforeFile, rootFile, ActionOrderType.Before))
+      Assert.assertFalse(provider.allowPaste(compileBeforeFile, rootFile, ActionOrderType.After))
+      Assert.assertFalse(provider.allowPaste(compileBeforeFile, folder2, ActionOrderType.Before))
+      Assert.assertFalse(provider.allowPaste(compileBeforeFile, folder2, ActionOrderType.After))
 
-            // CompileAfter
-            val compileAfterFile = listOf(findFile("SourceProject", "CompileAfterFile.fs"))
-            Assert.assertFalse(provider.allowPaste(compileAfterFile, folder1, ActionOrderType.Before))
-            Assert.assertFalse(provider.allowPaste(compileAfterFile, folder1, ActionOrderType.After))
-            Assert.assertFalse(provider.allowPaste(compileAfterFile, rootFile, ActionOrderType.Before))
-            Assert.assertFalse(provider.allowPaste(compileAfterFile, rootFile, ActionOrderType.After))
-            Assert.assertFalse(provider.allowPaste(compileAfterFile, folder2, ActionOrderType.Before))
-            Assert.assertTrue(provider.allowPaste(compileAfterFile, folder2, ActionOrderType.After))
-        }
+      // CompileAfter
+      val compileAfterFile = listOf(findFile("SourceProject", "CompileAfterFile.fs"))
+      Assert.assertFalse(provider.allowPaste(compileAfterFile, folder1, ActionOrderType.Before))
+      Assert.assertFalse(provider.allowPaste(compileAfterFile, folder1, ActionOrderType.After))
+      Assert.assertFalse(provider.allowPaste(compileAfterFile, rootFile, ActionOrderType.Before))
+      Assert.assertFalse(provider.allowPaste(compileAfterFile, rootFile, ActionOrderType.After))
+      Assert.assertFalse(provider.allowPaste(compileAfterFile, folder2, ActionOrderType.Before))
+      Assert.assertTrue(provider.allowPaste(compileAfterFile, folder2, ActionOrderType.After))
     }
+  }
 
-    private fun doTest(action: (FSharpMoveProviderExtension) -> Unit) {
-        prepareProjectView(project)
-        executeWithGold(testGoldFile) {
-            it.append(dumpSolutionExplorerTree(project))
-        }
-        action(FSharpMoveProviderExtension(project))
+  private fun doTest(action: (FSharpMoveProviderExtension) -> Unit) {
+    prepareProjectView(project)
+    executeWithGold(testGoldFile) {
+      it.append(dumpSolutionExplorerTree(project))
     }
+    action(FSharpMoveProviderExtension(project))
+  }
 
-    private fun findFile(vararg localPath: String): ProjectModelEntity {
-        val path = arrayOf(project.solutionName, *localPath)
-        return createDataContextFor(project, path)
-                .getProjectModelEntity(false)
-                .shouldNotBeNull("Can not find item '${path.joinToString("/")}'")
-    }
+  private fun findFile(vararg localPath: String): ProjectModelEntity {
+    val path = arrayOf(project.solutionName, *localPath)
+    return createDataContextFor(project, path)
+      .getProjectModelEntity(false)
+      .shouldNotBeNull("Can not find item '${path.joinToString("/")}'")
+  }
 
-    private fun findFileView(vararg path: String): ProjectEntityView {
-        return ProjectEntityView(project, findFile(*path))
-    }
+  private fun findFileView(vararg path: String): ProjectEntityView {
+    return ProjectEntityView(project, findFile(*path))
+  }
 }

--- a/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/projectModel/FSharpProjectModelTest.kt
+++ b/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/projectModel/FSharpProjectModelTest.kt
@@ -14,152 +14,188 @@ import java.io.File
 
 @Test
 class FSharpProjectModelTest : ProjectModelBaseTest() {
-    override fun getSolutionDirectoryName() = "EmptySolution"
-    override val restoreNuGetPackages = true
+  override fun getSolutionDirectoryName() = "EmptySolution"
+  override val restoreNuGetPackages = true
 
-    private fun moveItem(from: Array<Array<String>>, to: Array<String>, orderType: ActionOrderType? = null) {
-        // Wait for updating/refreshing items possibly queued by FSharpItemsContainerRefresher.
-        waitBackend(project) {
-            cutItem(project, from)
-            pasteItem(project, to, orderType = orderType)
+  private fun moveItem(from: Array<Array<String>>, to: Array<String>, orderType: ActionOrderType? = null) {
+    // Wait for updating/refreshing items possibly queued by FSharpItemsContainerRefresher.
+    waitBackend(project) {
+      cutItem(project, from)
+      pasteItem(project, to, orderType = orderType)
+    }
+  }
+
+  private fun moveItem(from: Array<String>, to: Array<String>, orderType: ActionOrderType? = null) {
+    moveItem(arrayOf(from), to, orderType)
+  }
+
+  @Suppress("SameParameterValue")
+  private fun renameItem(path: Array<String>, newName: String) {
+    // Wait for updating/refreshing items possibly queued by FSharpItemsContainerRefresher.
+    waitBackend(project) {
+      renameItem(project, path, newName)
+    }
+  }
+
+  private fun TestProjectModelContext.dump2(
+    caption: String,
+    checkSlnFile: Boolean,
+    compareProjFile: Boolean,
+    action: () -> Unit
+  ) {
+    dump(caption, checkSlnFile, compareProjFile, action)
+    treeOutput.append(project.fcsHost.dumpSingleProjectMapping.sync(Unit))
+  }
+
+  @Test
+  @TestEnvironment(
+    solution = "FSharpProjectTree",
+    toolset = ToolsetVersion.TOOLSET_16_CORE,
+    coreVersion = CoreVersion.DOT_NET_5
+  )
+  fun testFSharpProjectStructure() {
+    doTestDumpProjectsView {
+      dump2("Init", false, false) {
+      }
+      dump2(
+        "1. Move file 'Folder(1)/File1.fs' inside other part of the same folder after 'Folder(2)/File4.fs'",
+        false,
+        true
+      ) {
+        moveItem(
+          arrayOf("FSharpProjectTree", "ClassLibrary1", "Folder?1", "File1.fs"),
+          arrayOf("FSharpProjectTree", "ClassLibrary1", "Folder?2", "File4.fs")
+        )
+      }
+      dump2(
+        "2. Move file 'Folder(2)/File3.fs' inside other part of the same folder before 'Folder(1)/File2.fs'",
+        false,
+        true
+      ) {
+        moveItem(
+          arrayOf("FSharpProjectTree", "ClassLibrary1", "Folder?2", "File3.fs"),
+          arrayOf("FSharpProjectTree", "ClassLibrary1", "Folder?1", "File2.fs"), ActionOrderType.Before
+        )
+      }
+      dump2("3. Move file 'Folder(2)/File1.fs' before folder 'Folder(2)'", false, true) {
+        moveItem(
+          arrayOf("FSharpProjectTree", "ClassLibrary1", "Folder?2", "File1.fs"),
+          arrayOf("FSharpProjectTree", "ClassLibrary1", "Folder?2"), ActionOrderType.Before
+        )
+      }
+      dump2("4. Move file 'File3.fs' and 'File1.fs' in folder 'Folder(2)/Sub(1)' before 'Class1.fs'", false, true) {
+        moveItem(
+          arrayOf(
+            arrayOf("FSharpProjectTree", "ClassLibrary1", "File3.fs"),
+            arrayOf("FSharpProjectTree", "ClassLibrary1", "File1.fs")
+          ),
+          arrayOf("FSharpProjectTree", "ClassLibrary1", "Folder?2", "Sub?1", "Class1.fs"), ActionOrderType.Before
+        )
+      }
+      dump2("5. Move 'Folder/Sub/File3.fs' to project folder before EmptyFolder", false, true) {
+        moveItem(
+          arrayOf("FSharpProjectTree", "ClassLibrary1", "Folder?2", "Sub?1", "File3.fs"),
+          arrayOf("FSharpProjectTree", "ClassLibrary1", "EmptyFolder"), ActionOrderType.Before
+        )
+      }
+      dump2("6. Move 'Folder/Sub/File3.fs' to project folder after EmptyFolder", false, true) {
+        moveItem(
+          arrayOf("FSharpProjectTree", "ClassLibrary1", "File3.fs"),
+          arrayOf("FSharpProjectTree", "ClassLibrary1", "EmptyFolder"), ActionOrderType.After
+        )
+      }
+      dump2("7. Move file 'Class2.fs' in folder 'Folder(2)' before 'Sub(2)'", false, true) {
+        moveItem(
+          arrayOf("FSharpProjectTree", "ClassLibrary1", "Folder?2", "Sub?2", "Class2.fs"),
+          arrayOf("FSharpProjectTree", "ClassLibrary1", "Folder?2", "Sub?2"), ActionOrderType.Before
+        )
+      }
+      dump2("8. Move file 'Folder(1)/File2.fs' before folder 'Folder(1)/File3.fs'", false, true) {
+        moveItem(
+          arrayOf("FSharpProjectTree", "ClassLibrary1", "Folder?1", "File2.fs"),
+          arrayOf("FSharpProjectTree", "ClassLibrary1", "Folder?1", "File3.fs"), ActionOrderType.Before
+        )
+      }
+      dump2("9. Move file 'Folder/File2.fs' before 'Folder(1)'", false, true) {
+        moveItem(
+          arrayOf("FSharpProjectTree", "ClassLibrary1", "Folder?1", "File2.fs"),
+          arrayOf("FSharpProjectTree", "ClassLibrary1", "Folder?1"), ActionOrderType.Before
+        )
+      }
+      dump2("10. Rename file 'File3.fs' to 'Foo.fs'", false, true) {
+        renameItem(
+          arrayOf("FSharpProjectTree", "ClassLibrary1", "File3.fs"), "Foo.fs"
+        )
+      }
+      dump2("11. Move file 'Foo.fs' to 'EmptyFolder(1)'", false, true) {
+        moveItem(
+          arrayOf("FSharpProjectTree", "ClassLibrary1", "Foo.fs"),
+          arrayOf("FSharpProjectTree", "ClassLibrary1", "EmptyFolder?1")
+        )
+      }
+      dump2("12. Move file 'EmptyFolder/Foo.fs' before 'EmptyFolder(1)'", false, true) {
+        moveItem(
+          arrayOf("FSharpProjectTree", "ClassLibrary1", "EmptyFolder?1", "Foo.fs"),
+          arrayOf("FSharpProjectTree", "ClassLibrary1", "EmptyFolder?1"), ActionOrderType.Before
+        )
+      }
+      dump2("13. Move file 'File1.fs' and 'Class1.fs' in folder 'Folder(2)' before 'Sub(1)'", false, true) {
+        moveItem(
+          arrayOf(
+            arrayOf("FSharpProjectTree", "ClassLibrary1", "Folder?2", "Sub?1", "File1.fs"),
+            arrayOf("FSharpProjectTree", "ClassLibrary1", "Folder?2", "Sub?1", "Class1.fs")
+          ),
+          arrayOf("FSharpProjectTree", "ClassLibrary1", "Folder?2", "Sub?1"), ActionOrderType.Before
+        )
+      }
+    }
+  }
+
+  @Test
+  @Issues(Issue("RIDER-69084"), Issue("RIDER-69562"))
+  @TestEnvironment(coreVersion = CoreVersion.LATEST_STABLE, toolset = ToolsetVersion.TOOLSET_17_CORE)
+  fun testFSharpDirectoryManipulation() {
+    doTestDumpProjectsView {
+      dump2("1. Create project", checkSlnFile = false, compareProjFile = true) {
+        addProject(project, arrayOf("Solution"), "ClassLibrary", ProjectTemplateIds.currentCore.fsharp_classLibrary)
+      }
+      dump2("2. Create folder 'NewFolder'", checkSlnFile = false, compareProjFile = true) {
+        addNewFolder(arrayOf("Solution", "ClassLibrary"), "NewFolder")
+      }
+      dump2("3. Create subfolder 'NewFolder/NewSub'", checkSlnFile = false, compareProjFile = true) {
+        addNewFolder(arrayOf("Solution", "ClassLibrary", "NewFolder"), "NewSub")
+      }
+      dump2("4. Move folder 'NewFolder/NewSub' to project root", checkSlnFile = false, compareProjFile = true) {
+        moveItem(
+          arrayOf("Solution", "ClassLibrary", "NewFolder", "NewSub"),
+          arrayOf("Solution", "ClassLibrary")
+        )
+      }
+      dump2("5. Delete folder 'NewSub'", checkSlnFile = false, compareProjFile = true) {
+        deleteElement(arrayOf("Solution", "ClassLibrary", "NewSub"))
+      }
+    }
+  }
+
+  @Test
+  @TestEnvironment(
+    solution = "FsprojWithTwoFiles",
+    toolset = ToolsetVersion.TOOLSET_16_CORE,
+    coreVersion = CoreVersion.DOT_NET_5
+  )
+  fun testManualFsprojChange() {
+    doTestDumpProjectsView {
+      dump2("Init", false, false) { }
+
+      dump2("Move File1 and File2 lines", false, true) {
+        val fsprojFile = File(activeSolutionDirectory, "ClassLibrary1/ClassLibrary1.fsproj")
+        changeFileContent(project, fsprojFile) { content ->
+          content
+            .replace("<Compile Include=\"File2.fs\" />", "<Compile Include=\"File2.fs.tmp\" />")
+            .replace("<Compile Include=\"File1.fs\" />", "<Compile Include=\"File2.fs\" />")
+            .replace("<Compile Include=\"File2.fs.tmp\" />", "<Compile Include=\"File1.fs\" />")
         }
+      }
     }
-
-    private fun moveItem(from: Array<String>, to: Array<String>, orderType: ActionOrderType? = null) {
-        moveItem(arrayOf(from), to, orderType)
-    }
-
-    @Suppress("SameParameterValue")
-    private fun renameItem(path: Array<String>, newName: String) {
-        // Wait for updating/refreshing items possibly queued by FSharpItemsContainerRefresher.
-        waitBackend(project) {
-            renameItem(project, path, newName)
-        }
-    }
-
-    private fun TestProjectModelContext.dump2(caption: String, checkSlnFile: Boolean, compareProjFile: Boolean, action: () -> Unit) {
-        dump(caption, checkSlnFile, compareProjFile, action)
-        treeOutput.append(project.fcsHost.dumpSingleProjectMapping.sync(Unit))
-    }
-
-    @Test
-    @TestEnvironment(solution = "FSharpProjectTree", toolset = ToolsetVersion.TOOLSET_16_CORE, coreVersion = CoreVersion.DOT_NET_5)
-    fun testFSharpProjectStructure() {
-        doTestDumpProjectsView {
-            dump2("Init", false, false) {
-            }
-            dump2("1. Move file 'Folder(1)/File1.fs' inside other part of the same folder after 'Folder(2)/File4.fs'", false, true) {
-                moveItem(
-                        arrayOf("FSharpProjectTree", "ClassLibrary1", "Folder?1", "File1.fs"),
-                        arrayOf("FSharpProjectTree", "ClassLibrary1", "Folder?2", "File4.fs"))
-            }
-            dump2("2. Move file 'Folder(2)/File3.fs' inside other part of the same folder before 'Folder(1)/File2.fs'", false, true) {
-                moveItem(
-                        arrayOf("FSharpProjectTree", "ClassLibrary1", "Folder?2", "File3.fs"),
-                        arrayOf("FSharpProjectTree", "ClassLibrary1", "Folder?1", "File2.fs"), ActionOrderType.Before)
-            }
-            dump2("3. Move file 'Folder(2)/File1.fs' before folder 'Folder(2)'", false, true) {
-                moveItem(
-                        arrayOf("FSharpProjectTree", "ClassLibrary1", "Folder?2", "File1.fs"),
-                        arrayOf("FSharpProjectTree", "ClassLibrary1", "Folder?2"), ActionOrderType.Before)
-            }
-            dump2("4. Move file 'File3.fs' and 'File1.fs' in folder 'Folder(2)/Sub(1)' before 'Class1.fs'", false, true) {
-                moveItem(
-                        arrayOf(
-                                arrayOf("FSharpProjectTree", "ClassLibrary1", "File3.fs"),
-                                arrayOf("FSharpProjectTree", "ClassLibrary1", "File1.fs")),
-                        arrayOf("FSharpProjectTree", "ClassLibrary1", "Folder?2", "Sub?1", "Class1.fs"), ActionOrderType.Before)
-            }
-            dump2("5. Move 'Folder/Sub/File3.fs' to project folder before EmptyFolder", false, true) {
-                moveItem(
-                        arrayOf("FSharpProjectTree", "ClassLibrary1", "Folder?2", "Sub?1", "File3.fs"),
-                        arrayOf("FSharpProjectTree", "ClassLibrary1", "EmptyFolder"), ActionOrderType.Before)
-            }
-            dump2("6. Move 'Folder/Sub/File3.fs' to project folder after EmptyFolder", false, true) {
-                moveItem(
-                        arrayOf("FSharpProjectTree", "ClassLibrary1", "File3.fs"),
-                        arrayOf("FSharpProjectTree", "ClassLibrary1", "EmptyFolder"), ActionOrderType.After)
-            }
-            dump2("7. Move file 'Class2.fs' in folder 'Folder(2)' before 'Sub(2)'", false, true) {
-                moveItem(
-                        arrayOf("FSharpProjectTree", "ClassLibrary1", "Folder?2", "Sub?2", "Class2.fs"),
-                        arrayOf("FSharpProjectTree", "ClassLibrary1", "Folder?2", "Sub?2"), ActionOrderType.Before)
-            }
-            dump2("8. Move file 'Folder(1)/File2.fs' before folder 'Folder(1)/File3.fs'", false, true) {
-                moveItem(
-                        arrayOf("FSharpProjectTree", "ClassLibrary1", "Folder?1", "File2.fs"),
-                        arrayOf("FSharpProjectTree", "ClassLibrary1", "Folder?1", "File3.fs"), ActionOrderType.Before)
-            }
-            dump2("9. Move file 'Folder/File2.fs' before 'Folder(1)'", false, true) {
-                moveItem(
-                        arrayOf("FSharpProjectTree", "ClassLibrary1", "Folder?1", "File2.fs"),
-                        arrayOf("FSharpProjectTree", "ClassLibrary1", "Folder?1"), ActionOrderType.Before)
-            }
-            dump2("10. Rename file 'File3.fs' to 'Foo.fs'", false, true) {
-                renameItem(
-                        arrayOf("FSharpProjectTree", "ClassLibrary1", "File3.fs"), "Foo.fs")
-            }
-            dump2("11. Move file 'Foo.fs' to 'EmptyFolder(1)'", false, true) {
-                moveItem(
-                        arrayOf("FSharpProjectTree", "ClassLibrary1", "Foo.fs"),
-                        arrayOf("FSharpProjectTree", "ClassLibrary1", "EmptyFolder?1"))
-            }
-            dump2("12. Move file 'EmptyFolder/Foo.fs' before 'EmptyFolder(1)'", false, true) {
-                moveItem(
-                        arrayOf("FSharpProjectTree", "ClassLibrary1", "EmptyFolder?1", "Foo.fs"),
-                        arrayOf("FSharpProjectTree", "ClassLibrary1", "EmptyFolder?1"), ActionOrderType.Before)
-            }
-            dump2("13. Move file 'File1.fs' and 'Class1.fs' in folder 'Folder(2)' before 'Sub(1)'", false, true) {
-                moveItem(
-                        arrayOf(
-                                arrayOf("FSharpProjectTree", "ClassLibrary1", "Folder?2", "Sub?1", "File1.fs"),
-                                arrayOf("FSharpProjectTree", "ClassLibrary1", "Folder?2", "Sub?1", "Class1.fs")),
-                        arrayOf("FSharpProjectTree", "ClassLibrary1", "Folder?2", "Sub?1"), ActionOrderType.Before)
-            }
-        }
-    }
-
-    @Test
-    @Issues(Issue("RIDER-69084"), Issue("RIDER-69562"))
-    @TestEnvironment(coreVersion = CoreVersion.LATEST_STABLE, toolset = ToolsetVersion.TOOLSET_17_CORE)
-    fun testFSharpDirectoryManipulation() {
-        doTestDumpProjectsView {
-            dump2("1. Create project", checkSlnFile = false, compareProjFile = true) {
-                addProject(project, arrayOf("Solution"), "ClassLibrary", ProjectTemplateIds.currentCore.fsharp_classLibrary)
-            }
-            dump2("2. Create folder 'NewFolder'", checkSlnFile = false, compareProjFile = true) {
-                addNewFolder(arrayOf("Solution", "ClassLibrary"), "NewFolder")
-            }
-            dump2("3. Create subfolder 'NewFolder/NewSub'", checkSlnFile = false, compareProjFile = true) {
-                addNewFolder(arrayOf("Solution", "ClassLibrary", "NewFolder"), "NewSub")
-            }
-            dump2("4. Move folder 'NewFolder/NewSub' to project root", checkSlnFile = false, compareProjFile = true) {
-                moveItem(
-                    arrayOf("Solution", "ClassLibrary", "NewFolder", "NewSub"),
-                    arrayOf("Solution", "ClassLibrary")
-                )
-            }
-            dump2("5. Delete folder 'NewSub'", checkSlnFile = false, compareProjFile = true) {
-                deleteElement(arrayOf("Solution", "ClassLibrary", "NewSub"))
-            }
-        }
-    }
-
-    @Test
-    @TestEnvironment(solution = "FsprojWithTwoFiles", toolset = ToolsetVersion.TOOLSET_16_CORE, coreVersion = CoreVersion.DOT_NET_5)
-    fun testManualFsprojChange() {
-        doTestDumpProjectsView {
-            dump2("Init", false, false) { }
-
-            dump2("Move File1 and File2 lines", false, true) {
-                val fsprojFile = File(activeSolutionDirectory, "ClassLibrary1/ClassLibrary1.fsproj")
-                changeFileContent(project, fsprojFile) { content ->
-                    content
-                        .replace("<Compile Include=\"File2.fs\" />", "<Compile Include=\"File2.fs.tmp\" />")
-                        .replace("<Compile Include=\"File1.fs\" />", "<Compile Include=\"File2.fs\" />")
-                        .replace("<Compile Include=\"File2.fs.tmp\" />", "<Compile Include=\"File1.fs\" />")
-                }
-            }
-        }
-    }
+  }
 }

--- a/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/projectModel/FcsModuleReaderTest.kt
+++ b/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/projectModel/FcsModuleReaderTest.kt
@@ -32,237 +32,237 @@ import java.time.Duration
 @Test
 @TestEnvironment(coreVersion = CoreVersion.DEFAULT)
 class FcsModuleReaderTest : ProjectModelBaseTest() {
-    companion object {
-        private var launchCounter = 0
+  companion object {
+    private var launchCounter = 0
+  }
+
+  override fun getSolutionDirectoryName() = "EmptySolution"
+  override val restoreNuGetPackages = true
+
+  @AfterMethod(alwaysRun = true)
+  fun tearDownTestCase() {
+    launchCounter = 0
+  }
+
+  private fun EditorImpl.assertReferencedFcsProjectNames(
+    editorImpl: EditorImpl,
+    expectedReferencedProjects: List<String>
+  ) {
+    val project = project!!
+    val workspaceModel = WorkspaceModel.getInstance(project)
+    val fcsHost = project.fcsHost
+
+    val fileProjectModelEntity = workspaceModel.getProjectModelEntity(editorImpl.getProjectModelId())
+    val projectProjectModelId = fileProjectModelEntity?.containingProjectEntity()?.getId(project)!!
+    val referencedProjects = fcsHost.dumpFcsRefrencedProjects.syncFromBackend(projectProjectModelId, project)!!
+    assert(expectedReferencedProjects == referencedProjects)
+  }
+
+  private fun openFsFileDumpModuleReader(
+    printStream: PrintStream,
+    caption: String,
+    hasErrors: Boolean,
+    expectedReferencedProjects: List<String>
+  ) {
+    val project = project
+    withOpenedEditor(project, "FSharpProject/Library.fs") {
+      waitForDaemon()
+      assert(markupAdapter.hasErrors == hasErrors)
+      assertReferencedFcsProjectNames(this, expectedReferencedProjects)
+      dumpModuleReader(printStream, caption, project)
+    }
+    waitForDaemonCloseAllOpenEditors(project)
+  }
+
+  private fun dumpModuleReader(
+    printStream: PrintStream,
+    caption: String,
+    project: Project
+  ) {
+    printStream.appendLine("===================")
+    printStream.println(caption)
+    printStream.println()
+    printStream.println(project.fcsHost.dumpFcsModuleReader.syncFromBackend(Unit, project))
+  }
+
+  // Copied from EditorTestBase
+  private fun waitForEditorSwitch(targetFileName: String, hostTimeout: Duration = Duration.ofSeconds(20)) {
+    frameworkLogger.info("Waiting for editor switch")
+    val instanceEx = FileEditorManagerEx.getInstanceEx(project)
+
+    pumpMessages(hostTimeout) {
+      val name = instanceEx.selectedEditor?.file?.name
+      name == targetFileName
     }
 
-    override fun getSolutionDirectoryName() = "EmptySolution"
-    override val restoreNuGetPackages = true
+    val name = instanceEx.selectedEditor?.file?.name
 
-    @AfterMethod(alwaysRun = true)
-    fun tearDownTestCase() {
-        launchCounter = 0
+    assert(name == targetFileName) { "Editor should be switched. Current editor: $name" }
+    frameworkLogger.info("Editor switched to $targetFileName")
+  }
+
+
+  @TestEnvironment(solution = "ProjectReferencesCSharp")
+  fun testUnloadReloadCSharp() {
+    executeWithGold(testGoldFile) {
+      withNonFSharpProjectReferences {
+        assertAllProjectsWereLoaded(project)
+        dumpModuleReader(it, "Init", project)
+
+        openFsFileDumpModuleReader(it, "1. Open F# file", true, emptyList())
+
+        addReference(project, arrayOf("ProjectReferencesCSharp", "FSharpProject"), "<CSharpProject>")
+        dumpModuleReader(it, "2. Add reference", project)
+
+        openFsFileDumpModuleReader(it, "3. Open F# file", false, listOf("CSharpProject"))
+
+        unloadProject(arrayOf("ProjectReferencesCSharp", "CSharpProject"))
+        dumpModuleReader(it, "4. Unload C# project", project)
+
+        openFsFileDumpModuleReader(it, "5. Open F# file", true, emptyList())
+
+        reloadProject(arrayOf("ProjectReferencesCSharp", "CSharpProject"))
+        dumpModuleReader(it, "6. Reload C# project", project)
+
+        openFsFileDumpModuleReader(it, "7. Open F# file", false, listOf("CSharpProject"))
+      }
     }
+  }
 
-    private fun EditorImpl.assertReferencedFcsProjectNames(
-        editorImpl: EditorImpl,
-        expectedReferencedProjects: List<String>
-    ) {
-        val project = project!!
-        val workspaceModel = WorkspaceModel.getInstance(project)
-        val fcsHost = project.fcsHost
+  @TestEnvironment(solution = "ProjectReferencesCSharp")
+  fun testTypeInsideClassUnloadReload() {
+    executeWithGold(testGoldFile) {
+      withNonFSharpProjectReferences {
+        assertAllProjectsWereLoaded(project)
+        openFsFileDumpModuleReader(it, "Init", true, emptyList())
 
-        val fileProjectModelEntity = workspaceModel.getProjectModelEntity(editorImpl.getProjectModelId())
-        val projectProjectModelId = fileProjectModelEntity?.containingProjectEntity()?.getId(project)!!
-        val referencedProjects = fcsHost.dumpFcsRefrencedProjects.syncFromBackend(projectProjectModelId, project)!!
-        assert(expectedReferencedProjects == referencedProjects)
-    }
+        addReference(project, arrayOf("ProjectReferencesCSharp", "FSharpProject"), "<CSharpProject>")
+        dumpModuleReader(it, "1. Add reference", project)
 
-    private fun openFsFileDumpModuleReader(
-        printStream: PrintStream,
-        caption: String,
-        hasErrors: Boolean,
-        expectedReferencedProjects: List<String>
-    ) {
-        val project = project
-        withOpenedEditor(project, "FSharpProject/Library.fs") {
-            waitForDaemon()
-            assert(markupAdapter.hasErrors == hasErrors)
-            assertReferencedFcsProjectNames(this, expectedReferencedProjects)
-            dumpModuleReader(printStream, caption, project)
+        openFsFileDumpModuleReader(it, "2. Open F# file", false, listOf("CSharpProject"))
+
+        withOpenedEditor(project, "CSharpProject/Class1.cs") {
+          typeFromOffset(" ", 75)
+          waitForDaemon()
         }
+
         waitForDaemonCloseAllOpenEditors(project)
-    }
+        dumpModuleReader(it, "3. Type inside C# file", project)
 
-    private fun dumpModuleReader(
-        printStream: PrintStream,
-        caption: String,
-        project: Project
-    ) {
-        printStream.appendLine("===================")
-        printStream.println(caption)
-        printStream.println()
-        printStream.println(project.fcsHost.dumpFcsModuleReader.syncFromBackend(Unit, project))
-    }
+        openFsFileDumpModuleReader(it, "4. Open F# file", false, listOf("CSharpProject"))
 
-    // Copied from EditorTestBase
-    private fun waitForEditorSwitch(targetFileName: String, hostTimeout: Duration = Duration.ofSeconds(20)) {
-        frameworkLogger.info("Waiting for editor switch")
-        val instanceEx = FileEditorManagerEx.getInstanceEx(project)
+        unloadProject(arrayOf("ProjectReferencesCSharp", "CSharpProject"))
+        dumpModuleReader(it, "5. Unload C# project", project)
 
-        pumpMessages(hostTimeout) {
-            val name = instanceEx.selectedEditor?.file?.name
-            name == targetFileName
+        openFsFileDumpModuleReader(it, "6. Open F# file", true, emptyList())
+
+        reloadProject(arrayOf("ProjectReferencesCSharp", "CSharpProject"))
+        dumpModuleReader(it, "7. Reload C# project", project)
+
+        openFsFileDumpModuleReader(it, "8. Open F# file", false, listOf("CSharpProject"))
+
+        withOpenedEditor(project, "CSharpProject/Class1.cs") {
+          typeFromOffset(" ", 75)
         }
 
-        val name = instanceEx.selectedEditor?.file?.name
+        waitForDaemonCloseAllOpenEditors(project)
+        dumpModuleReader(it, "9. Type inside C# file", project)
 
-        assert(name == targetFileName) { "Editor should be switched. Current editor: $name" }
-        frameworkLogger.info("Editor switched to $targetFileName")
+        unloadProject(arrayOf("ProjectReferencesCSharp", "CSharpProject"))
+        dumpModuleReader(it, "10. Unload C# project", project)
+
+        openFsFileDumpModuleReader(it, "11. Open F# file", true, emptyList())
+
+        reloadProject(arrayOf("ProjectReferencesCSharp", "CSharpProject"))
+        dumpModuleReader(it, "12. Reload C# project", project)
+
+        openFsFileDumpModuleReader(it, "13. Open F# file", false, listOf("CSharpProject"))
+      }
     }
+  }
 
+  @TestEnvironment(solution = "ProjectReferencesCSharp")
+  fun testTypeOutsideClassUnloadReload() {
+    executeWithGold(testGoldFile) {
+      withNonFSharpProjectReferences {
+        assertAllProjectsWereLoaded(project)
+        openFsFileDumpModuleReader(it, "Init", true, emptyList())
 
-    @TestEnvironment(solution = "ProjectReferencesCSharp")
-    fun testUnloadReloadCSharp() {
-        executeWithGold(testGoldFile) {
-            withNonFSharpProjectReferences {
-                assertAllProjectsWereLoaded(project)
-                dumpModuleReader(it, "Init", project)
+        addReference(project, arrayOf("ProjectReferencesCSharp", "FSharpProject"), "<CSharpProject>")
+        dumpModuleReader(it, "1. Add reference", project)
 
-                openFsFileDumpModuleReader(it, "1. Open F# file", true, emptyList())
+        openFsFileDumpModuleReader(it, "2. Open F# file", false, listOf("CSharpProject"))
 
-                addReference(project, arrayOf("ProjectReferencesCSharp", "FSharpProject"), "<CSharpProject>")
-                dumpModuleReader(it, "2. Add reference", project)
-
-                openFsFileDumpModuleReader(it, "3. Open F# file", false, listOf("CSharpProject"))
-
-                unloadProject(arrayOf("ProjectReferencesCSharp", "CSharpProject"))
-                dumpModuleReader(it, "4. Unload C# project", project)
-
-                openFsFileDumpModuleReader(it, "5. Open F# file", true, emptyList())
-
-                reloadProject(arrayOf("ProjectReferencesCSharp", "CSharpProject"))
-                dumpModuleReader(it, "6. Reload C# project", project)
-
-                openFsFileDumpModuleReader(it, "7. Open F# file", false, listOf("CSharpProject"))
-            }
+        withOpenedEditor(project, "CSharpProject/Class1.cs") {
+          typeFromOffset(" ", 129)
         }
+
+        waitForDaemonCloseAllOpenEditors(project)
+        dumpModuleReader(it, "3. Type inside C# file", project)
+
+        openFsFileDumpModuleReader(it, "4. Open F# file", false, listOf("CSharpProject"))
+      }
     }
+  }
 
-    @TestEnvironment(solution = "ProjectReferencesCSharp")
-    fun testTypeInsideClassUnloadReload() {
-        executeWithGold(testGoldFile) {
-            withNonFSharpProjectReferences {
-                assertAllProjectsWereLoaded(project)
-                openFsFileDumpModuleReader(it, "Init", true, emptyList())
 
-                addReference(project, arrayOf("ProjectReferencesCSharp", "FSharpProject"), "<CSharpProject>")
-                dumpModuleReader(it, "1. Add reference", project)
+  @TestEnvironment(solution = "ProjectReferencesCSharp2")
+  fun testLoadReferenced() {
+    executeWithGold(testGoldFile) {
+      withNonFSharpProjectReferences {
+        assertAllProjectsWereLoaded(project)
+        openFsFileDumpModuleReader(it, "Init", false, listOf("CSharpProject"))
 
-                openFsFileDumpModuleReader(it, "2. Open F# file", false, listOf("CSharpProject"))
+        unloadProject(arrayOf("ProjectReferencesCSharp2", "CSharpProject"))
+        waitForDaemonCloseAllOpenEditors(project)
+        dumpModuleReader(it, "2. Unload C# project", project)
 
-                withOpenedEditor(project, "CSharpProject/Class1.cs") {
-                    typeFromOffset(" ", 75)
-                    waitForDaemon()
-                }
-
-                waitForDaemonCloseAllOpenEditors(project)
-                dumpModuleReader(it, "3. Type inside C# file", project)
-
-                openFsFileDumpModuleReader(it, "4. Open F# file", false, listOf("CSharpProject"))
-
-                unloadProject(arrayOf("ProjectReferencesCSharp", "CSharpProject"))
-                dumpModuleReader(it, "5. Unload C# project", project)
-
-                openFsFileDumpModuleReader(it, "6. Open F# file", true, emptyList())
-
-                reloadProject(arrayOf("ProjectReferencesCSharp", "CSharpProject"))
-                dumpModuleReader(it, "7. Reload C# project", project)
-
-                openFsFileDumpModuleReader(it, "8. Open F# file", false, listOf("CSharpProject"))
-
-                withOpenedEditor(project, "CSharpProject/Class1.cs") {
-                    typeFromOffset(" ", 75)
-                }
-
-                waitForDaemonCloseAllOpenEditors(project)
-                dumpModuleReader(it, "9. Type inside C# file", project)
-
-                unloadProject(arrayOf("ProjectReferencesCSharp", "CSharpProject"))
-                dumpModuleReader(it, "10. Unload C# project", project)
-
-                openFsFileDumpModuleReader(it, "11. Open F# file", true, emptyList())
-
-                reloadProject(arrayOf("ProjectReferencesCSharp", "CSharpProject"))
-                dumpModuleReader(it, "12. Reload C# project", project)
-
-                openFsFileDumpModuleReader(it, "13. Open F# file", false, listOf("CSharpProject"))
-            }
-        }
+        waitForDaemonCloseAllOpenEditors(project)
+        openFsFileDumpModuleReader(it, "3. Open F#", true, emptyList())
+      }
     }
+  }
 
-    @TestEnvironment(solution = "ProjectReferencesCSharp")
-    fun testTypeOutsideClassUnloadReload() {
-        executeWithGold(testGoldFile) {
-            withNonFSharpProjectReferences {
-                assertAllProjectsWereLoaded(project)
-                openFsFileDumpModuleReader(it, "Init", true, emptyList())
-
-                addReference(project, arrayOf("ProjectReferencesCSharp", "FSharpProject"), "<CSharpProject>")
-                dumpModuleReader(it, "1. Add reference", project)
-
-                openFsFileDumpModuleReader(it, "2. Open F# file", false, listOf("CSharpProject"))
-
-                withOpenedEditor(project, "CSharpProject/Class1.cs") {
-                    typeFromOffset(" ", 129)
-                }
-
-                waitForDaemonCloseAllOpenEditors(project)
-                dumpModuleReader(it, "3. Type inside C# file", project)
-
-                openFsFileDumpModuleReader(it, "4. Open F# file", false, listOf("CSharpProject"))
-            }
-        }
+  @TestEnvironment(solution = "ProjectReferencesCSharp2")
+  fun testGotoUsagesFromCSharp() {
+    withNonFSharpProjectReferences {
+      assertAllProjectsWereLoaded(project)
+      withOpenedEditor(project, "CSharpProject/Class1.cs", "Class1.cs") {
+        callAction(IdeActions.ACTION_GOTO_DECLARATION)
+        waitForEditorSwitch("Library.fs")
+      }
     }
+  }
 
-
-    @TestEnvironment(solution = "ProjectReferencesCSharp2")
-    fun testLoadReferenced() {
-        executeWithGold(testGoldFile) {
-            withNonFSharpProjectReferences {
-                assertAllProjectsWereLoaded(project)
-                openFsFileDumpModuleReader(it, "Init", false, listOf("CSharpProject"))
-
-                unloadProject(arrayOf("ProjectReferencesCSharp2", "CSharpProject"))
-                waitForDaemonCloseAllOpenEditors(project)
-                dumpModuleReader(it, "2. Unload C# project", project)
-
-                waitForDaemonCloseAllOpenEditors(project)
-                openFsFileDumpModuleReader(it, "3. Open F#", true, emptyList())
-            }
-        }
+  @TestEnvironment(solution = "ProjectReferencesCSharp3")
+  fun testGotoUsagesFromCSharpChangeCSharp() {
+    withNonFSharpProjectReferences {
+      assertAllProjectsWereLoaded(project)
+      withOpenedEditor(project, "CSharpProject/Class1.cs", "Class1.cs") {
+        typeWithLatency("1")
+        callAction(IdeActions.ACTION_GOTO_DECLARATION)
+        waitForEditorSwitch("Library.fs")
+      }
     }
+  }
 
-    @TestEnvironment(solution = "ProjectReferencesCSharp2")
-    fun testGotoUsagesFromCSharp() {
-        withNonFSharpProjectReferences {
-            assertAllProjectsWereLoaded(project)
-            withOpenedEditor(project, "CSharpProject/Class1.cs", "Class1.cs") {
-                callAction(IdeActions.ACTION_GOTO_DECLARATION)
-                waitForEditorSwitch("Library.fs")
-            }
-        }
+  @TestEnvironment(solution = "ProjectReferencesCSharp3")
+  fun testGotoUsagesFromCSharpChangeCSharp2() {
+    withNonFSharpProjectReferences {
+      assertAllProjectsWereLoaded(project)
+
+      withOpenedEditor(project, "FSharpProject/Library.fs") {
+        waitForDaemon()
+      }
+
+      waitForDaemonCloseAllOpenEditors(project)
+
+      withOpenedEditor(project, "CSharpProject/Class1.cs", "Class1.cs") {
+        typeWithLatency("1")
+        waitForNextDaemon()
+        callAction(IdeActions.ACTION_GOTO_DECLARATION)
+        waitForEditorSwitch("Library.fs")
+      }
     }
-
-    @TestEnvironment(solution = "ProjectReferencesCSharp3")
-    fun testGotoUsagesFromCSharpChangeCSharp() {
-        withNonFSharpProjectReferences {
-            assertAllProjectsWereLoaded(project)
-            withOpenedEditor(project, "CSharpProject/Class1.cs", "Class1.cs") {
-                typeWithLatency("1")
-                callAction(IdeActions.ACTION_GOTO_DECLARATION)
-                waitForEditorSwitch("Library.fs")
-            }
-        }
-    }
-
-    @TestEnvironment(solution = "ProjectReferencesCSharp3")
-    fun testGotoUsagesFromCSharpChangeCSharp2() {
-        withNonFSharpProjectReferences {
-            assertAllProjectsWereLoaded(project)
-
-            withOpenedEditor(project, "FSharpProject/Library.fs") {
-                waitForDaemon()
-            }
-
-            waitForDaemonCloseAllOpenEditors(project)
-
-            withOpenedEditor(project, "CSharpProject/Class1.cs", "Class1.cs") {
-                typeWithLatency("1")
-                waitForNextDaemon()
-                callAction(IdeActions.ACTION_GOTO_DECLARATION)
-                waitForEditorSwitch("Library.fs")
-            }
-        }
-    }
+  }
 }

--- a/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/projectModel/ReferencesOrderTest.kt
+++ b/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/projectModel/ReferencesOrderTest.kt
@@ -4,20 +4,20 @@ import com.jetbrains.rider.plugins.fsharp.test.fcsHost
 import com.jetbrains.rider.test.annotations.TestEnvironment
 import com.jetbrains.rider.test.base.BaseTestWithSolution
 import com.jetbrains.rider.test.enums.CoreVersion
- import com.jetbrains.rider.test.enums.ToolsetVersion
+import com.jetbrains.rider.test.enums.ToolsetVersion
 import org.testng.annotations.Test
 
 @Test
 @TestEnvironment(toolset = ToolsetVersion.TOOLSET_17_CORE, coreVersion = CoreVersion.DOT_NET_6)
 class ReferencesOrder : BaseTestWithSolution() {
-    override fun getSolutionDirectoryName() = "ReferencesOrder"
+  override fun getSolutionDirectoryName() = "ReferencesOrder"
 
-    override val waitForCaches = true
-    override val restoreNuGetPackages = true
+  override val waitForCaches = true
+  override val restoreNuGetPackages = true
 
-    @Test()
-    fun testReferencesOrder() {
-        val references = project.fcsHost.dumpSingleProjectLocalReferences.sync(Unit)
-        assert(references == listOf("Library1.dll", "Library2.dll"))
-    }
+  @Test()
+  fun testReferencesOrder() {
+    val references = project.fcsHost.dumpSingleProjectLocalReferences.sync(Unit)
+    assert(references == listOf("Library1.dll", "Library2.dll"))
+  }
 }

--- a/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/templates/core31/ProjectTemplates.Core31.kt
+++ b/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/templates/core31/ProjectTemplates.Core31.kt
@@ -13,46 +13,50 @@ import com.jetbrains.rider.test.scriptingApi.TemplateIdWithVersion
 
 
 @Suppress("unused")
-@TestEnvironment(coreVersion = CoreVersion.DOT_NET_CORE_3_1,
-    toolset = ToolsetVersion.TOOLSET_16_CORE,
-    platform = [PlatformType.WINDOWS_X64, PlatformType.MAC_OS_ALL])
+@TestEnvironment(
+  coreVersion = CoreVersion.DOT_NET_CORE_3_1,
+  toolset = ToolsetVersion.TOOLSET_16_CORE,
+  platform = [PlatformType.WINDOWS_X64, PlatformType.MAC_OS_ALL]
+)
 object Core31 {
-    class ClassLibProjectTemplateTest : ClassLibProjectTemplateTestBase() {
-        override val templateId: TemplateIdWithVersion
-            get() = ProjectTemplateIds.currentCore.fsharp_classLibrary
-        override val expectedNumOfAnalyzedFiles: Int = 1
-        override val expectedNumOfSkippedFiles: Int = 0
-        override val targetFramework: String = "netcoreapp3.1"
-        init {
-            addMute(Mute("RIDER-79065: No SWEA for F#"), ::swea)
-        }
-    }
+  class ClassLibProjectTemplateTest : ClassLibProjectTemplateTestBase() {
+    override val templateId: TemplateIdWithVersion
+      get() = ProjectTemplateIds.currentCore.fsharp_classLibrary
+    override val expectedNumOfAnalyzedFiles: Int = 1
+    override val expectedNumOfSkippedFiles: Int = 0
+    override val targetFramework: String = "netcoreapp3.1"
 
-    class ConsoleAppProjectTemplateTest : ConsoleAppProjectTemplateTestBase() {
-        override val templateId: TemplateIdWithVersion
-            get() = ProjectTemplateIds.currentCore.fsharp_consoleApplication
-        override val expectedNumOfAnalyzedFiles: Int = 0
-        override val expectedNumOfSkippedFiles: Int = 3
-        override val breakpointLine: Int = 7
-        override val expectedOutput: String = "Hello World from F#!"
-        override val debugFileName: String = "Program.fs"
-        init {
-            addMute(Mute("RIDER-79065: No SWEA for F#"), ::swea)
-        }
+    init {
+      addMute(Mute("RIDER-79065: No SWEA for F#"), ::swea)
     }
+  }
 
-    class XUnitProjectTemplateTest : XUnitProjectTemplateTestBase() {
-        override val templateId: TemplateIdWithVersion
-            get() = ProjectTemplateIds.currentCore.fsharp_xUnit
-        override val expectedNumOfAnalyzedFiles: Int = 1
-        override val expectedNumOfSkippedFiles: Int = 0
-        override val sessionElements: Int = 3
-        override val debugFileName: String = "Tests.fs"
-        override val breakpointLine: Int = 8
+  class ConsoleAppProjectTemplateTest : ConsoleAppProjectTemplateTestBase() {
+    override val templateId: TemplateIdWithVersion
+      get() = ProjectTemplateIds.currentCore.fsharp_consoleApplication
+    override val expectedNumOfAnalyzedFiles: Int = 0
+    override val expectedNumOfSkippedFiles: Int = 3
+    override val breakpointLine: Int = 7
+    override val expectedOutput: String = "Hello World from F#!"
+    override val debugFileName: String = "Program.fs"
 
-        init {
-            addMute(Mute("No run configuration"), ::runConfiguration)
-            addMute(Mute("RIDER-79065: No SWEA for F#"), ::swea)
-        }
+    init {
+      addMute(Mute("RIDER-79065: No SWEA for F#"), ::swea)
     }
+  }
+
+  class XUnitProjectTemplateTest : XUnitProjectTemplateTestBase() {
+    override val templateId: TemplateIdWithVersion
+      get() = ProjectTemplateIds.currentCore.fsharp_xUnit
+    override val expectedNumOfAnalyzedFiles: Int = 1
+    override val expectedNumOfSkippedFiles: Int = 0
+    override val sessionElements: Int = 3
+    override val debugFileName: String = "Tests.fs"
+    override val breakpointLine: Int = 8
+
+    init {
+      addMute(Mute("No run configuration"), ::runConfiguration)
+      addMute(Mute("RIDER-79065: No SWEA for F#"), ::swea)
+    }
+  }
 }

--- a/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/templates/net60/ProjectTemplates.Net60.kt
+++ b/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/templates/net60/ProjectTemplates.Net60.kt
@@ -15,42 +15,44 @@ import com.jetbrains.rider.test.scriptingApi.TemplateIdWithVersion
 @Mute("Unable to load project and obtain project information from MsBuild.", [PlatformType.LINUX_ARM64])
 @TestEnvironment(coreVersion = CoreVersion.DOT_NET_6, toolset = ToolsetVersion.TOOLSET_17_CORE)
 object Net60 {
-    class ClassLibProjectTemplateTest : ClassLibProjectTemplateTestBase() {
-        override val templateId: TemplateIdWithVersion
-            get() = ProjectTemplateIds.currentCore.fsharp_classLibrary
-        override val expectedNumOfAnalyzedFiles: Int = 1
-        override val expectedNumOfSkippedFiles: Int = 0
-        override val targetFramework: String = "net6.0"
-        init {
-            addMute(Mute("RIDER-79065: No SWEA for F#"), ::swea)
-        }
-    }
+  class ClassLibProjectTemplateTest : ClassLibProjectTemplateTestBase() {
+    override val templateId: TemplateIdWithVersion
+      get() = ProjectTemplateIds.currentCore.fsharp_classLibrary
+    override val expectedNumOfAnalyzedFiles: Int = 1
+    override val expectedNumOfSkippedFiles: Int = 0
+    override val targetFramework: String = "net6.0"
 
-    class ConsoleAppProjectTemplateTest : ConsoleAppProjectTemplateTestBase() {
-        override val templateId: TemplateIdWithVersion
-            get() = ProjectTemplateIds.currentCore.fsharp_consoleApplication
-        override val expectedNumOfAnalyzedFiles: Int = 3
-        override val expectedNumOfSkippedFiles: Int = 0
-        override val breakpointLine: Int = 2
-        override val expectedOutput: String = "Hello from F#"
-        override val debugFileName: String = "Program.fs"
-        init {
-            addMute(Mute("RIDER-79065: No SWEA for F#"), ::swea)
-        }
+    init {
+      addMute(Mute("RIDER-79065: No SWEA for F#"), ::swea)
     }
+  }
 
-    class XUnitProjectTemplateTest : XUnitProjectTemplateTestBase() {
-        override val templateId: TemplateIdWithVersion
-            get() = ProjectTemplateIds.currentCore.fsharp_xUnit
-        override val expectedNumOfAnalyzedFiles: Int = 1
-        override val expectedNumOfSkippedFiles: Int = 0
-        override val sessionElements: Int = 3
-        override val debugFileName: String = "Tests.fs"
-        override val breakpointLine: Int = 8
+  class ConsoleAppProjectTemplateTest : ConsoleAppProjectTemplateTestBase() {
+    override val templateId: TemplateIdWithVersion
+      get() = ProjectTemplateIds.currentCore.fsharp_consoleApplication
+    override val expectedNumOfAnalyzedFiles: Int = 3
+    override val expectedNumOfSkippedFiles: Int = 0
+    override val breakpointLine: Int = 2
+    override val expectedOutput: String = "Hello from F#"
+    override val debugFileName: String = "Program.fs"
 
-        init {
-            addMute(Mute("No run configuration"), ::runConfiguration)
-            addMute(Mute("RIDER-79065: No SWEA for F#"), ::swea)
-        }
+    init {
+      addMute(Mute("RIDER-79065: No SWEA for F#"), ::swea)
     }
+  }
+
+  class XUnitProjectTemplateTest : XUnitProjectTemplateTestBase() {
+    override val templateId: TemplateIdWithVersion
+      get() = ProjectTemplateIds.currentCore.fsharp_xUnit
+    override val expectedNumOfAnalyzedFiles: Int = 1
+    override val expectedNumOfSkippedFiles: Int = 0
+    override val sessionElements: Int = 3
+    override val debugFileName: String = "Tests.fs"
+    override val breakpointLine: Int = 8
+
+    init {
+      addMute(Mute("No run configuration"), ::runConfiguration)
+      addMute(Mute("RIDER-79065: No SWEA for F#"), ::swea)
+    }
+  }
 }

--- a/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/templates/net70/ProjectTemplates.Net70.kt
+++ b/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/templates/net70/ProjectTemplates.Net70.kt
@@ -15,43 +15,45 @@ import com.jetbrains.rider.test.scriptingApi.TemplateIdWithVersion
 @Mute("Unable to load project and obtain project information from MsBuild.", [PlatformType.LINUX_ARM64])
 @TestEnvironment(coreVersion = CoreVersion.DOT_NET_7, toolset = ToolsetVersion.TOOLSET_17_CORE)
 object Net70 {
-    class ClassLibProjectTemplateTest : ClassLibProjectTemplateTestBase() {
-        override val templateId: TemplateIdWithVersion
-            get() = ProjectTemplateIds.currentCore.fsharp_classLibrary
-        override val expectedNumOfAnalyzedFiles: Int = 1
-        override val expectedNumOfSkippedFiles: Int = 0
-        override val targetFramework: String = "net7.0"
-        override val flakyFiles: Array<String> = emptyArray()
-        init {
-            addMute(Mute("RIDER-79065: No SWEA for F#"), ::swea)
-        }
-    }
+  class ClassLibProjectTemplateTest : ClassLibProjectTemplateTestBase() {
+    override val templateId: TemplateIdWithVersion
+      get() = ProjectTemplateIds.currentCore.fsharp_classLibrary
+    override val expectedNumOfAnalyzedFiles: Int = 1
+    override val expectedNumOfSkippedFiles: Int = 0
+    override val targetFramework: String = "net7.0"
+    override val flakyFiles: Array<String> = emptyArray()
 
-    class ConsoleAppProjectTemplateTest : ConsoleAppProjectTemplateTestBase() {
-        override val templateId: TemplateIdWithVersion
-            get() = ProjectTemplateIds.currentCore.fsharp_consoleApplication
-        override val expectedNumOfAnalyzedFiles: Int = 3
-        override val expectedNumOfSkippedFiles: Int = 0
-        override val breakpointLine: Int = 2
-        override val expectedOutput: String = "Hello from F#"
-        override val debugFileName: String = "Program.fs"
-        init {
-            addMute(Mute("RIDER-79065: No SWEA for F#"), ::swea)
-        }
+    init {
+      addMute(Mute("RIDER-79065: No SWEA for F#"), ::swea)
     }
+  }
 
-    class XUnitProjectTemplateTest : XUnitProjectTemplateTestBase() {
-        override val templateId: TemplateIdWithVersion
-            get() = ProjectTemplateIds.currentCore.fsharp_xUnit
-        override val expectedNumOfAnalyzedFiles: Int = 1
-        override val expectedNumOfSkippedFiles: Int = 0
-        override val sessionElements: Int = 3
-        override val debugFileName: String = "Tests.fs"
-        override val breakpointLine: Int = 8
+  class ConsoleAppProjectTemplateTest : ConsoleAppProjectTemplateTestBase() {
+    override val templateId: TemplateIdWithVersion
+      get() = ProjectTemplateIds.currentCore.fsharp_consoleApplication
+    override val expectedNumOfAnalyzedFiles: Int = 3
+    override val expectedNumOfSkippedFiles: Int = 0
+    override val breakpointLine: Int = 2
+    override val expectedOutput: String = "Hello from F#"
+    override val debugFileName: String = "Program.fs"
 
-        init {
-            addMute(Mute("No run configuration"), ::runConfiguration)
-            addMute(Mute("RIDER-79065: No SWEA for F#"), ::swea)
-        }
+    init {
+      addMute(Mute("RIDER-79065: No SWEA for F#"), ::swea)
     }
+  }
+
+  class XUnitProjectTemplateTest : XUnitProjectTemplateTestBase() {
+    override val templateId: TemplateIdWithVersion
+      get() = ProjectTemplateIds.currentCore.fsharp_xUnit
+    override val expectedNumOfAnalyzedFiles: Int = 1
+    override val expectedNumOfSkippedFiles: Int = 0
+    override val sessionElements: Int = 3
+    override val debugFileName: String = "Tests.fs"
+    override val breakpointLine: Int = 8
+
+    init {
+      addMute(Mute("No run configuration"), ::runConfiguration)
+      addMute(Mute("RIDER-79065: No SWEA for F#"), ::swea)
+    }
+  }
 }

--- a/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/typeProviders/GenerativeTypeProvidersTest.kt
+++ b/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/typeProviders/GenerativeTypeProvidersTest.kt
@@ -19,48 +19,48 @@ import java.time.Duration
 @Test
 @TestEnvironment(toolset = ToolsetVersion.TOOLSET_16, coreVersion = CoreVersion.DOT_NET_CORE_3_1)
 class GenerativeTypeProvidersTest : BaseTestWithSolution() {
-    override fun getSolutionDirectoryName() = "TypeProviderLibrary"
+  override fun getSolutionDirectoryName() = "TypeProviderLibrary"
 
-    @Test
-    fun `generative type providers cross-project analysis`() {
-        val generativeProviderProjectPath =
-            "${project.solutionDirectoryPath}/GenerativeTypeProvider/GenerativeTypeProvider.fsproj"
+  @Test
+  fun `generative type providers cross-project analysis`() {
+    val generativeProviderProjectPath =
+      "${project.solutionDirectoryPath}/GenerativeTypeProvider/GenerativeTypeProvider.fsproj"
 
-        withOpenedEditor(project, "GenerativeTypeLibrary/Library.fs") {
-            waitForDaemon()
-            markupAdapter.hasErrors.shouldBeTrue()
+    withOpenedEditor(project, "GenerativeTypeLibrary/Library.fs") {
+      waitForDaemon()
+      markupAdapter.hasErrors.shouldBeTrue()
 
-            buildSelectedProjectsWithReSharperBuild(listOf(generativeProviderProjectPath))
+      buildSelectedProjectsWithReSharperBuild(listOf(generativeProviderProjectPath))
 
-            waitForNextDaemon(Duration.ofSeconds(5))
-            markupAdapter.hasErrors.shouldBeFalse()
-        }
-
-        unloadProject(arrayOf("TypeProviderLibrary", "GenerativeTypeProvider"))
-        reloadProject(arrayOf("TypeProviderLibrary", "GenerativeTypeProvider"))
-
-        withOpenedEditor(project, "GenerativeTypeLibrary/Library.fs") {
-            waitForDaemon()
-            markupAdapter.hasErrors.shouldBeFalse()
-        }
+      waitForNextDaemon(Duration.ofSeconds(5))
+      markupAdapter.hasErrors.shouldBeFalse()
     }
 
-    @Test
-    fun `change abbreviation`() {
-        executeWithGold(testGoldFile) {
-            withOpenedEditor(project, "GenerativeTypeProvider/Library.fs") {
-                waitForDaemon()
+    unloadProject(arrayOf("TypeProviderLibrary", "GenerativeTypeProvider"))
+    reloadProject(arrayOf("TypeProviderLibrary", "GenerativeTypeProvider"))
 
-                it.println("Before:\n")
-                dumpTypeProviders(it)
-
-                // change abbreviation from "SimpleGenerativeTypeAbbr" to "SimpleGenerativeTypeAbbr1"
-                typeFromOffset("1", 103)
-                waitForDaemon()
-
-                it.println("\n\nAfter:\n")
-                dumpTypeProviders(it)
-            }
-        }
+    withOpenedEditor(project, "GenerativeTypeLibrary/Library.fs") {
+      waitForDaemon()
+      markupAdapter.hasErrors.shouldBeFalse()
     }
+  }
+
+  @Test
+  fun `change abbreviation`() {
+    executeWithGold(testGoldFile) {
+      withOpenedEditor(project, "GenerativeTypeProvider/Library.fs") {
+        waitForDaemon()
+
+        it.println("Before:\n")
+        dumpTypeProviders(it)
+
+        // change abbreviation from "SimpleGenerativeTypeAbbr" to "SimpleGenerativeTypeAbbr1"
+        typeFromOffset("1", 103)
+        waitForDaemon()
+
+        it.println("\n\nAfter:\n")
+        dumpTypeProviders(it)
+      }
+    }
+  }
 }

--- a/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/typeProviders/TypeProvidersCSharpTest.kt
+++ b/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/typeProviders/TypeProvidersCSharpTest.kt
@@ -16,100 +16,101 @@ import java.io.File
 @Test
 @TestEnvironment(toolset = ToolsetVersion.TOOLSET_16)
 class TypeProvidersCSharpTest : BaseTestWithSolution() {
-    override fun getSolutionDirectoryName() = "YamlProviderCSharp"
-    override val restoreNuGetPackages = true
+  override fun getSolutionDirectoryName() = "YamlProviderCSharp"
+  override val restoreNuGetPackages = true
 
-    @Test
-    fun resolveTest() {
-        withOpenedEditor(project, "CSharpLibrary/CSharpLibrary.cs") {
-            waitForDaemon()
-            executeWithGold(testGoldFile) {
-                dumpSevereHighlighters(it)
-            }
-        }
-
-        unloadAllProjects()
-        reloadAllProjects(project)
-
-        withOpenedEditor(project, "CSharpLibrary/CSharpLibrary.cs") {
-            waitForDaemon()
-            executeWithGold(testGoldFile) {
-                dumpSevereHighlighters(it)
-            }
-        }
+  @Test
+  fun resolveTest() {
+    withOpenedEditor(project, "CSharpLibrary/CSharpLibrary.cs") {
+      waitForDaemon()
+      executeWithGold(testGoldFile) {
+        dumpSevereHighlighters(it)
+      }
     }
 
-    @Test
-    @TestEnvironment(
-        solution = "SwaggerProviderCSharp",
-        toolset = ToolsetVersion.TOOLSET_17_CORE,
-        coreVersion = CoreVersion.DOT_NET_6
-    )
-    fun changeStaticArg() {
-        withOpenedEditor(project, "CSharpLibrary/CSharpLibrary.cs") {
-            waitForDaemon()
-            markupAdapter.hasErrors.shouldBeFalse()
-        }
+    unloadAllProjects()
+    reloadAllProjects(project)
 
-        withOpenedEditor(project, "SwaggerProviderLibrary/Literals.fs") {
-            waitForDaemon()
-            // change schema path from "specification.json" to "specification1.json"
-            typeFromOffset("1", 86)
-        }
+    withOpenedEditor(project, "CSharpLibrary/CSharpLibrary.cs") {
+      waitForDaemon()
+      executeWithGold(testGoldFile) {
+        dumpSevereHighlighters(it)
+      }
+    }
+  }
 
-        withOpenedEditor(project, "CSharpLibrary/CSharpLibrary.cs") {
-            waitForNextDaemon()
-            executeWithGold(File(testGoldFile.path + "_before")) {
-                dumpSevereHighlighters(it)
-            }
-
-            // change method call from "ApiCoursesGet" to "ApiCoursesGet1"
-            typeFromOffset("1", 195)
-            waitForAllAnalysisFinished(project!!)
-
-            executeWithGold(File(testGoldFile.path + "_after")) {
-                dumpSevereHighlighters(it)
-            }
-        }
+  @Test
+  @TestEnvironment(
+    solution = "SwaggerProviderCSharp",
+    toolset = ToolsetVersion.TOOLSET_17_CORE,
+    coreVersion = CoreVersion.DOT_NET_6
+  )
+  fun changeStaticArg() {
+    withOpenedEditor(project, "CSharpLibrary/CSharpLibrary.cs") {
+      waitForDaemon()
+      markupAdapter.hasErrors.shouldBeFalse()
     }
 
-    @Test
-    fun `provided abbreviation rename`() {
-        withOpenedEditor("CSharpLibrary/CSharpLibrary.cs", "CSharpLibrary.cs") {
-            waitForDaemon()
-            defaultRefactoringRename("Renamed")
-            waitForNextDaemon()
-            markupAdapter.hasErrors.shouldBeFalse()
-            executeWithGold(File(testGoldFile.path + " - csharp")) {
-                dumpOpenedDocument(it, project!!)
-            }
-        }
-
-        withOpenedEditor("YamlProviderLibrary/Library.fs") {
-            waitForDaemon()
-            markupAdapter.hasErrors.shouldBeFalse()
-            executeWithGold(File(testGoldFile.path + " - fsharp")) {
-                dumpOpenedDocument(it, project!!)
-            }
-        }
+    withOpenedEditor(project, "SwaggerProviderLibrary/Literals.fs") {
+      waitForDaemon()
+      // change schema path from "specification.json" to "specification1.json"
+      typeFromOffset("1", 86)
     }
 
-    @Test
-    @TestEnvironment(solution = "YamlProviderCSharp", toolset = ToolsetVersion.TOOLSET_16)
-    fun `provided type abbreviation completion`() = doTestDumpLookupItems("CSharpLibrary/CSharpLibrary.cs", "CSharpLibrary.fs")
+    withOpenedEditor(project, "CSharpLibrary/CSharpLibrary.cs") {
+      waitForNextDaemon()
+      executeWithGold(File(testGoldFile.path + "_before")) {
+        dumpSevereHighlighters(it)
+      }
 
-    @Test
-    @TestEnvironment(solution = "YamlProviderCSharp", toolset = ToolsetVersion.TOOLSET_16)
-    fun `provided nested type completion`() = doTestDumpLookupItems("CSharpLibrary/CSharpLibrary.cs", "CSharpLibrary.fs")
+      // change method call from "ApiCoursesGet" to "ApiCoursesGet1"
+      typeFromOffset("1", 195)
+      waitForAllAnalysisFinished(project!!)
 
-    private fun doTestDumpLookupItems(relativePath: String, sourceFileName: String) {
-        withOpenedEditor(relativePath, sourceFileName) {
-            waitForDaemon()
-            callBasicCompletion()
-            waitForCompletion()
-            executeWithGold(testGoldFile) {
-                dumpActiveLookupItemsPresentations(it)
-            }
-        }
+      executeWithGold(File(testGoldFile.path + "_after")) {
+        dumpSevereHighlighters(it)
+      }
     }
+  }
+
+  @Test
+  fun `provided abbreviation rename`() {
+    withOpenedEditor("CSharpLibrary/CSharpLibrary.cs", "CSharpLibrary.cs") {
+      waitForDaemon()
+      defaultRefactoringRename("Renamed")
+      waitForNextDaemon()
+      markupAdapter.hasErrors.shouldBeFalse()
+      executeWithGold(File(testGoldFile.path + " - csharp")) {
+        dumpOpenedDocument(it, project!!)
+      }
+    }
+
+    withOpenedEditor("YamlProviderLibrary/Library.fs") {
+      waitForDaemon()
+      markupAdapter.hasErrors.shouldBeFalse()
+      executeWithGold(File(testGoldFile.path + " - fsharp")) {
+        dumpOpenedDocument(it, project!!)
+      }
+    }
+  }
+
+  @Test
+  @TestEnvironment(solution = "YamlProviderCSharp", toolset = ToolsetVersion.TOOLSET_16)
+  fun `provided type abbreviation completion`() =
+    doTestDumpLookupItems("CSharpLibrary/CSharpLibrary.cs", "CSharpLibrary.fs")
+
+  @Test
+  @TestEnvironment(solution = "YamlProviderCSharp", toolset = ToolsetVersion.TOOLSET_16)
+  fun `provided nested type completion`() = doTestDumpLookupItems("CSharpLibrary/CSharpLibrary.cs", "CSharpLibrary.fs")
+
+  private fun doTestDumpLookupItems(relativePath: String, sourceFileName: String) {
+    withOpenedEditor(relativePath, sourceFileName) {
+      waitForDaemon()
+      callBasicCompletion()
+      waitForCompletion()
+      executeWithGold(testGoldFile) {
+        dumpActiveLookupItemsPresentations(it)
+      }
+    }
+  }
 }

--- a/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/typeProviders/TypeProvidersFeaturesTest.kt
+++ b/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/typeProviders/TypeProvidersFeaturesTest.kt
@@ -14,74 +14,74 @@ import java.time.Duration
 
 @Test
 @TestEnvironment(
-    toolset = ToolsetVersion.TOOLSET_17_CORE,
-    coreVersion = CoreVersion.DOT_NET_6
+  toolset = ToolsetVersion.TOOLSET_17_CORE,
+  coreVersion = CoreVersion.DOT_NET_6
 )
 class TypeProvidersFeaturesTest : EditorTestBase() {
-    override fun getSolutionDirectoryName() = "SwaggerProviderCSharp"
-    override val restoreNuGetPackages = true
+  override fun getSolutionDirectoryName() = "SwaggerProviderCSharp"
+  override val restoreNuGetPackages = true
 
-    @Test
-    fun `signature file navigation`() = doNavigationTestWithMultipleDeclarations()
+  @Test
+  fun `signature file navigation`() = doNavigationTestWithMultipleDeclarations()
 
-    @Test
-    fun `provided member navigation`() = doNavigationTest("SwaggerProvider.fs")
+  @Test
+  fun `provided member navigation`() = doNavigationTest("SwaggerProvider.fs")
 
-    @Test
-    fun `provided abbreviation navigation`() = doNavigationTest("SwaggerProvider.fs")
+  @Test
+  fun `provided abbreviation navigation`() = doNavigationTest("SwaggerProvider.fs")
 
-    @Test
-    fun `navigate to decompiled`() {
-        withOpenedEditor("CSharpLibrary/CSharpLibrary.cs", "CSharpLibrary.cs") {
-            waitForDaemon()
-            callAction(IdeActions.ACTION_GOTO_SUPER)
-            waitForEditorSwitch("ProvidedApiClientBase.cs")
-        }
+  @Test
+  fun `navigate to decompiled`() {
+    withOpenedEditor("CSharpLibrary/CSharpLibrary.cs", "CSharpLibrary.cs") {
+      waitForDaemon()
+      callAction(IdeActions.ACTION_GOTO_SUPER)
+      waitForEditorSwitch("ProvidedApiClientBase.cs")
     }
+  }
 
-    @Test
-    fun `provided nested type navigation`() = doNavigationTest("SwaggerProvider.fs")
+  @Test
+  fun `provided nested type navigation`() = doNavigationTest("SwaggerProvider.fs")
 
-    @Test
-    fun `multiply different abbreviation type parts - before`() = doNavigationTestWithMultipleDeclarations()
+  @Test
+  fun `multiply different abbreviation type parts - before`() = doNavigationTestWithMultipleDeclarations()
 
-    @Test
-    fun `multiply different abbreviation type parts - after`() = doNavigationTestWithMultipleDeclarations()
+  @Test
+  fun `multiply different abbreviation type parts - after`() = doNavigationTestWithMultipleDeclarations()
 
-    @Test
-    fun `provided member rename disabled`() = doRenameUnavailableTest()
+  @Test
+  fun `provided member rename disabled`() = doRenameUnavailableTest()
 
-    @Test
-    fun `provided nested type rename disabled`() = doRenameUnavailableTest()
+  @Test
+  fun `provided nested type rename disabled`() = doRenameUnavailableTest()
 
-    private fun doNavigationTest(declarationFileName: String) {
-        withOpenedEditor("CSharpLibrary/CSharpLibrary.cs", "CSharpLibrary.cs") {
-            waitForDaemon()
-            gotoDeclaration {
-                waitForEditorSwitch(declarationFileName)
-                waitForDaemon()
-                executeWithGold(testGoldFile) {
-                    dumpOpenedDocument(it, project!!, true)
-                }
-            }
+  private fun doNavigationTest(declarationFileName: String) {
+    withOpenedEditor("CSharpLibrary/CSharpLibrary.cs", "CSharpLibrary.cs") {
+      waitForDaemon()
+      gotoDeclaration {
+        waitForEditorSwitch(declarationFileName)
+        waitForDaemon()
+        executeWithGold(testGoldFile) {
+          dumpOpenedDocument(it, project!!, true)
         }
+      }
     }
+  }
 
-    private fun doNavigationTestWithMultipleDeclarations() {
-        withOpenedEditor("CSharpLibrary/CSharpLibrary.cs", "CSharpLibrary.cs") {
-            waitForDaemon()
-            executeWithGold(testGoldFile) {
-                callActionAndHandlePopup(IdeActions.ACTION_GOTO_DECLARATION, it, true, Duration.ofSeconds(1)) {
-                    this.closeAll()
-                }
-            }
+  private fun doNavigationTestWithMultipleDeclarations() {
+    withOpenedEditor("CSharpLibrary/CSharpLibrary.cs", "CSharpLibrary.cs") {
+      waitForDaemon()
+      executeWithGold(testGoldFile) {
+        callActionAndHandlePopup(IdeActions.ACTION_GOTO_DECLARATION, it, true, Duration.ofSeconds(1)) {
+          this.closeAll()
         }
+      }
     }
+  }
 
-    private fun doRenameUnavailableTest() {
-        withOpenedEditor("CSharpLibrary/CSharpLibrary.cs", "CSharpLibrary.cs") {
-            waitForDaemon()
-            assertActionDisabled(project!!, dataContext, ActionPlaces.UNKNOWN, IdeActions.ACTION_RENAME)
-        }
+  private fun doRenameUnavailableTest() {
+    withOpenedEditor("CSharpLibrary/CSharpLibrary.cs", "CSharpLibrary.cs") {
+      waitForDaemon()
+      assertActionDisabled(project!!, dataContext, ActionPlaces.UNKNOWN, IdeActions.ACTION_RENAME)
     }
+  }
 }

--- a/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/typeProviders/TypeProvidersRuntimeTest.kt
+++ b/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/typeProviders/TypeProvidersRuntimeTest.kt
@@ -16,53 +16,54 @@ import org.testng.annotations.Test
 
 @Test
 class TypeProvidersRuntimeTest : BaseTestWithSolution() {
-    override fun getSolutionDirectoryName() = "CoreTypeProviderLibrary"
-    override val restoreNuGetPackages = true
+  override fun getSolutionDirectoryName() = "CoreTypeProviderLibrary"
+  override val restoreNuGetPackages = true
 
-    @Test
-    @TestEnvironment(
-        toolset = ToolsetVersion.TOOLSET_16,
-        coreVersion = CoreVersion.DOT_NET_CORE_3_1,
-        solution = "TypeProviderLibrary")
-    fun framework461() = doTest(".NET Framework 4.8")
+  @Test
+  @TestEnvironment(
+    toolset = ToolsetVersion.TOOLSET_16,
+    coreVersion = CoreVersion.DOT_NET_CORE_3_1,
+    solution = "TypeProviderLibrary"
+  )
+  fun framework461() = doTest(".NET Framework 4.8")
 
-    @Test(enabled = false)
-    @TestEnvironment(toolset = ToolsetVersion.TOOLSET_16_CORE, coreVersion = CoreVersion.DOT_NET_CORE_2_1)
-    fun core21() = doTest(".NET Core 3.1")
+  @Test(enabled = false)
+  @TestEnvironment(toolset = ToolsetVersion.TOOLSET_16_CORE, coreVersion = CoreVersion.DOT_NET_CORE_2_1)
+  fun core21() = doTest(".NET Core 3.1")
 
-    @Test
-    @TestEnvironment(toolset = ToolsetVersion.TOOLSET_16_CORE, coreVersion = CoreVersion.DOT_NET_CORE_3_1)
-    fun core31() = doTest(".NET Core 3.1")
+  @Test
+  @TestEnvironment(toolset = ToolsetVersion.TOOLSET_16_CORE, coreVersion = CoreVersion.DOT_NET_CORE_3_1)
+  fun core31() = doTest(".NET Core 3.1")
 
-    @Test
-    @TestEnvironment(toolset = ToolsetVersion.TOOLSET_16_CORE, coreVersion = CoreVersion.DOT_NET_5)
-    fun net5() = doTest(".NET 5")
+  @Test
+  @TestEnvironment(toolset = ToolsetVersion.TOOLSET_16_CORE, coreVersion = CoreVersion.DOT_NET_5)
+  fun net5() = doTest(".NET 5")
 
-    @Test
-    @TestEnvironment(toolset = ToolsetVersion.TOOLSET_17_CORE, coreVersion = CoreVersion.DOT_NET_6)
-    fun net6() = doTest(".NET 6")
+  @Test
+  @TestEnvironment(toolset = ToolsetVersion.TOOLSET_17_CORE, coreVersion = CoreVersion.DOT_NET_6)
+  fun net6() = doTest(".NET 6")
 
-    @Test
-    @TestEnvironment(toolset = ToolsetVersion.TOOLSET_17_CORE, coreVersion = CoreVersion.DOT_NET_7)
-    fun net7() = doTest(".NET 7")
+  @Test
+  @TestEnvironment(toolset = ToolsetVersion.TOOLSET_17_CORE, coreVersion = CoreVersion.DOT_NET_7)
+  fun net7() = doTest(".NET 7")
 
-    @Test(enabled = false)
-    @TestEnvironment(
-        toolset = ToolsetVersion.TOOLSET_16_CORE,
-        coreVersion = CoreVersion.DOT_NET_CORE_3_1,
-        solution = "FscTypeProviderLibrary"
-    )
-    fun fsc() = doTest(".NET Framework 4.8")
+  @Test(enabled = false)
+  @TestEnvironment(
+    toolset = ToolsetVersion.TOOLSET_16_CORE,
+    coreVersion = CoreVersion.DOT_NET_CORE_3_1,
+    solution = "FscTypeProviderLibrary"
+  )
+  fun fsc() = doTest(".NET Framework 4.8")
 
-    private fun doTest(expectedRuntime: String) {
-        withOpenedEditor(project, "TypeProviderLibrary/Library.fs") {
-            waitForDaemon()
-            this.project!!.fcsHost
-                    .typeProvidersRuntimeVersion.sync(Unit)
-                    .shouldNotBeNull()
-                    .startsWith(expectedRuntime)
-                    .shouldBeTrue()
-            markupAdapter.hasErrors.shouldBeFalse()
-        }
+  private fun doTest(expectedRuntime: String) {
+    withOpenedEditor(project, "TypeProviderLibrary/Library.fs") {
+      waitForDaemon()
+      this.project!!.fcsHost
+        .typeProvidersRuntimeVersion.sync(Unit)
+        .shouldNotBeNull()
+        .startsWith(expectedRuntime)
+        .shouldBeTrue()
+      markupAdapter.hasErrors.shouldBeFalse()
     }
+  }
 }

--- a/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/typeProviders/TypeProvidersSettingTest.kt
+++ b/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/typeProviders/TypeProvidersSettingTest.kt
@@ -21,38 +21,38 @@ import org.testng.annotations.Test
 @Test
 @TestEnvironment(toolset = ToolsetVersion.TOOLSET_16, coreVersion = CoreVersion.DOT_NET_CORE_3_1)
 class TypeProvidersSettingTest : BaseTestWithSolution() {
-    override fun getSolutionDirectoryName() = "TypeProviderLibrary"
-    override val restoreNuGetPackages = true
-    private val rdFcsHost get() = project.solution.rdFSharpModel.fsharpTestHost
+  override fun getSolutionDirectoryName() = "TypeProviderLibrary"
+  override val restoreNuGetPackages = true
+  private val rdFcsHost get() = project.solution.rdFSharpModel.fsharpTestHost
 
-    @Test
-    fun enableTypeProvidersSetting() {
-        val sourceFile = "TypeProviderLibrary2/Library.fs"
+  @Test
+  fun enableTypeProvidersSetting() {
+    val sourceFile = "TypeProviderLibrary2/Library.fs"
 
-        withOpenedEditor(project, sourceFile) {
-            waitForDaemon()
-            rdFcsHost.typeProvidersRuntimeVersion.sync(Unit).shouldNotBeNull()
-            markupAdapter.hasErrors.shouldBeFalse()
-        }
-
-        withDisabledOutOfProcessTypeProviders {
-            unloadAllProjects()
-            reloadAllProjects(project)
-
-            withOpenedEditor(project, sourceFile) {
-                waitForDaemon()
-                rdFcsHost.typeProvidersRuntimeVersion.sync(Unit).shouldBeNull()
-                markupAdapter.hasErrors.shouldBeFalse()
-            }
-        }
-
-        unloadAllProjects()
-        reloadAllProjects(project)
-
-        withOpenedEditor(project, sourceFile) {
-            waitForDaemon()
-            rdFcsHost.typeProvidersRuntimeVersion.sync(Unit).shouldNotBeNull()
-            markupAdapter.hasErrors.shouldBeFalse()
-        }
+    withOpenedEditor(project, sourceFile) {
+      waitForDaemon()
+      rdFcsHost.typeProvidersRuntimeVersion.sync(Unit).shouldNotBeNull()
+      markupAdapter.hasErrors.shouldBeFalse()
     }
+
+    withDisabledOutOfProcessTypeProviders {
+      unloadAllProjects()
+      reloadAllProjects(project)
+
+      withOpenedEditor(project, sourceFile) {
+        waitForDaemon()
+        rdFcsHost.typeProvidersRuntimeVersion.sync(Unit).shouldBeNull()
+        markupAdapter.hasErrors.shouldBeFalse()
+      }
+    }
+
+    unloadAllProjects()
+    reloadAllProjects(project)
+
+    withOpenedEditor(project, sourceFile) {
+      waitForDaemon()
+      rdFcsHost.typeProvidersRuntimeVersion.sync(Unit).shouldNotBeNull()
+      markupAdapter.hasErrors.shouldBeFalse()
+    }
+  }
 }

--- a/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/typeProviders/TypeProvidersTest.kt
+++ b/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/typeProviders/TypeProvidersTest.kt
@@ -13,39 +13,39 @@ import org.testng.annotations.Test
 @Test
 @TestEnvironment(toolset = ToolsetVersion.TOOLSET_16, coreVersion = CoreVersion.DOT_NET_CORE_3_1)
 class TypeProvidersTest : BaseTestWithSolution() {
-    override fun getSolutionDirectoryName() = "TypeProviderLibrary"
-    override val restoreNuGetPackages = true
+  override fun getSolutionDirectoryName() = "TypeProviderLibrary"
+  override val restoreNuGetPackages = true
 
-    @Test
-    fun swaggerProvider() = doTest("SwaggerProvider")
+  @Test
+  fun swaggerProvider() = doTest("SwaggerProvider")
 
-    @Test
-    fun simpleErasedProvider() = doTest("SimpleErasedProvider")
+  @Test
+  fun simpleErasedProvider() = doTest("SimpleErasedProvider")
 
-    @Test
-    fun simpleGenerativeProvider() = doTest("SimpleGenerativeProvider")
+  @Test
+  fun simpleGenerativeProvider() = doTest("SimpleGenerativeProvider")
 
-    @Test
-    fun providersErrors() = doTest("ProvidersErrors")
+  @Test
+  fun providersErrors() = doTest("ProvidersErrors")
 
-    @Test(description = "RIDER-60909")
-    @TestEnvironment(solution = "LegacyTypeProviderLibrary")
-    fun legacyTypeProviders() = doTest("LegacyTypeProviders")
+  @Test(description = "RIDER-60909")
+  @TestEnvironment(solution = "LegacyTypeProviderLibrary")
+  fun legacyTypeProviders() = doTest("LegacyTypeProviders")
 
-    @Test
-    @TestEnvironment(
-        solution = "CsvTypeProvider",
-        toolset = ToolsetVersion.TOOLSET_17_CORE,
-        coreVersion = CoreVersion.DOT_NET_6
-    )
-    fun `csvProvider - units of measure`() = doTest("Library")
+  @Test
+  @TestEnvironment(
+    solution = "CsvTypeProvider",
+    toolset = ToolsetVersion.TOOLSET_17_CORE,
+    coreVersion = CoreVersion.DOT_NET_6
+  )
+  fun `csvProvider - units of measure`() = doTest("Library")
 
-    private fun doTest(fileName: String) {
-        withOpenedEditor(project, "TypeProviderLibrary/$fileName.fs") {
-            waitForDaemon()
-            executeWithGold(testGoldFile) {
-                dumpSevereHighlighters(it)
-            }
-        }
+  private fun doTest(fileName: String) {
+    withOpenedEditor(project, "TypeProviderLibrary/$fileName.fs") {
+      waitForDaemon()
+      executeWithGold(testGoldFile) {
+        dumpSevereHighlighters(it)
+      }
     }
+  }
 }

--- a/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/typingAssist/FSharpTypingAssistTest.kt
+++ b/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/typingAssist/FSharpTypingAssistTest.kt
@@ -8,25 +8,25 @@ import org.testng.annotations.DataProvider
 import org.testng.annotations.Test
 
 @TestEnvironment(coreVersion = CoreVersion.LATEST_STABLE)
-class FSharpTypingAssistTest: TypingAssistTestBase() {
+class FSharpTypingAssistTest : TypingAssistTestBase() {
 
-    override fun getSolutionDirectoryName(): String = "CoreConsoleApp"
+  override fun getSolutionDirectoryName(): String = "CoreConsoleApp"
 
-    @DataProvider(name = "testTypingAssists")
-    fun testTypingAssists() = arrayOf(
-            arrayOf("closingBrace1", "{"),
-            arrayOf("parentheses1", "("),
-            arrayOf("quotes1", "\""),
-            arrayOf("singleQuote1", "'"),
-            arrayOf("closingAngleBracket1", "<"),
-            arrayOf("indentAfterEnter", "EditorEnter")
-    )
+  @DataProvider(name = "testTypingAssists")
+  fun testTypingAssists() = arrayOf(
+    arrayOf("closingBrace1", "{"),
+    arrayOf("parentheses1", "("),
+    arrayOf("quotes1", "\""),
+    arrayOf("singleQuote1", "'"),
+    arrayOf("closingAngleBracket1", "<"),
+    arrayOf("indentAfterEnter", "EditorEnter")
+  )
 
-    @Test(dataProvider = "testTypingAssists")
-    fun testTyping(caseName: String, input: String) {
-        dumpOpenedEditor("Program.fs", "Program.fs") {
-            typeOrCallAction(input)
-        }
+  @Test(dataProvider = "testTypingAssists")
+  fun testTyping(caseName: String, input: String) {
+    dumpOpenedEditor("Program.fs", "Program.fs") {
+      typeOrCallAction(input)
     }
+  }
 
 }


### PR DESCRIPTION
This brings the code format closer to what we have in the internal **dotnet-products** monorepo, and what we have in the [IntelliJ Community](https://github.com/JetBrains/intellij-community). So, it will be easier to exchange code snippets if the need arises.

Besides, I've added `.git-blame-ignore-revs` that's supposed to exclude this huge re-formatting commit from `git blame` and similar operations. [Read about it here](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view), see [an example of how the blame looks on GitHub here](https://github.com/JetBrains/resharper-fsharp/blame/d39c677d779c84ea9ee03996302db0198c6bbd60/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/breadcrumbs/breadcrumbs.kt).

**Note** that additional Git setup will be required for this file to be taken into account locally (it only gets auto-used by GitHub and some similar tools); see the instructions in the file itself. Sadly, it's impossible to share the Git settings together with the repository.