### PR TITLE
Psi/Tree builder: support extern declarations in type members

### DIFF
--- a/ReSharper.FSharp/src/FSharp.Psi/src/FSharp.psi
+++ b/ReSharper.FSharp/src/FSharp.Psi/src/FSharp.psi
@@ -1174,6 +1174,7 @@ interface typeBodyMemberDeclaration:
   valFieldDeclaration |
   letBindingsDeclaration |
   overridableMemberDeclaration |
+  externDeclaration |
   doStatement;
 
 interface overridableMemberDeclaration:

--- a/ReSharper.FSharp/test/data/parsing/Type member - Let bindings - Extern 01.fs
+++ b/ReSharper.FSharp/test/data/parsing/Type member - Let bindings - Extern 01.fs
@@ -1,0 +1,3 @@
+type T() =
+    [<DllImport("user32.dll")>]
+    static extern uint32 M(nativeint hWnd)

--- a/ReSharper.FSharp/test/data/parsing/Type member - Let bindings - Extern 01.fs.gold
+++ b/ReSharper.FSharp/test/data/parsing/Type member - Let bindings - Extern 01.fs.gold
@@ -1,0 +1,46 @@
+﻿Language: PsiLanguageType:F#
+IFSharpImplFile
+  IAnonModuleDeclaration
+    ITypeDeclarationGroup
+      IFSharpTypeDeclaration
+        FSharpTokenType+TypeTokenElement(type:TYPE, text:type)
+        Whitespace(type:WHITE_SPACE, text: ) spaces:" "
+        FSharpIdentifierToken(type:IDENTIFIER, text:T)
+        IPrimaryConstructorDeclaration
+          IParametersPatternDeclaration
+            IUnitPat
+              FSharpTokenType+LparenTokenElement(type:LPAREN, text:()
+              FSharpTokenType+RparenTokenElement(type:RPAREN, text:))
+        Whitespace(type:WHITE_SPACE, text: ) spaces:" "
+        FSharpTokenType+EqualsTokenElement(type:EQUALS, text:=)
+        NewLine(type:NEW_LINE, text:\n) spaces:"\n"
+        Whitespace(type:WHITE_SPACE, text:    ) spaces:"    "
+        IExternDeclaration
+          IAttributeList
+            FSharpTokenType+LbrackLessTokenElement(type:LBRACK_LESS, text:[<)
+            IAttribute
+              ITypeReferenceName
+                FSharpIdentifierToken(type:IDENTIFIER, text:DllImport)
+              IChameleonExpression
+                IParenExpr
+                  FSharpTokenType+LparenTokenElement(type:LPAREN, text:()
+                  ILiteralExpr
+                    FSharpString(type:STRING, text:"user32.dll")
+                  FSharpTokenType+RparenTokenElement(type:RPAREN, text:))
+            FSharpTokenType+GreaterRbrackTokenElement(type:GREATER_RBRACK, text:>])
+          NewLine(type:NEW_LINE, text:\n) spaces:"\n"
+          Whitespace(type:WHITE_SPACE, text:    ) spaces:"    "
+          FSharpTokenType+StaticTokenElement(type:STATIC, text:static)
+          Whitespace(type:WHITE_SPACE, text: ) spaces:" "
+          FSharpTokenType+ExternTokenElement(type:EXTERN, text:extern)
+          Whitespace(type:WHITE_SPACE, text: ) spaces:" "
+          FSharpIdentifierToken(type:IDENTIFIER, text:uint32)
+          Whitespace(type:WHITE_SPACE, text: ) spaces:" "
+          FSharpIdentifierToken(type:IDENTIFIER, text:M)
+          FSharpTokenType+LparenTokenElement(type:LPAREN, text:()
+          FSharpIdentifierToken(type:IDENTIFIER, text:nativeint)
+          Whitespace(type:WHITE_SPACE, text: ) spaces:" "
+          FSharpIdentifierToken(type:IDENTIFIER, text:hWnd)
+          FSharpTokenType+RparenTokenElement(type:RPAREN, text:))
+    NewLine(type:NEW_LINE, text:\n) spaces:"\n"
+

--- a/ReSharper.FSharp/test/data/parsing/Type member - Let bindings - Multiple 01.fs
+++ b/ReSharper.FSharp/test/data/parsing/Type member - Let bindings - Multiple 01.fs
@@ -1,0 +1,7 @@
+type T() =
+    let a = 3
+
+    [<DllImport("user32.dll")>]
+    static extern uint32 M(nativeint hWnd)
+
+    do ()

--- a/ReSharper.FSharp/test/data/parsing/Type member - Let bindings - Multiple 01.fs.gold
+++ b/ReSharper.FSharp/test/data/parsing/Type member - Let bindings - Multiple 01.fs.gold
@@ -1,0 +1,72 @@
+﻿Language: PsiLanguageType:F#
+IFSharpImplFile
+  IAnonModuleDeclaration
+    ITypeDeclarationGroup
+      IFSharpTypeDeclaration
+        FSharpTokenType+TypeTokenElement(type:TYPE, text:type)
+        Whitespace(type:WHITE_SPACE, text: ) spaces:" "
+        FSharpIdentifierToken(type:IDENTIFIER, text:T)
+        IPrimaryConstructorDeclaration
+          IParametersPatternDeclaration
+            IUnitPat
+              FSharpTokenType+LparenTokenElement(type:LPAREN, text:()
+              FSharpTokenType+RparenTokenElement(type:RPAREN, text:))
+        Whitespace(type:WHITE_SPACE, text: ) spaces:" "
+        FSharpTokenType+EqualsTokenElement(type:EQUALS, text:=)
+        NewLine(type:NEW_LINE, text:\n) spaces:"\n"
+        Whitespace(type:WHITE_SPACE, text:    ) spaces:"    "
+        ILetBindingsDeclaration
+          ITopBinding
+            FSharpTokenType+LetTokenElement(type:LET, text:let)
+            Whitespace(type:WHITE_SPACE, text: ) spaces:" "
+            ITopReferencePat
+              IExpressionReferenceName
+                FSharpIdentifierToken(type:IDENTIFIER, text:a)
+            Whitespace(type:WHITE_SPACE, text: ) spaces:" "
+            FSharpTokenType+EqualsTokenElement(type:EQUALS, text:=)
+            Whitespace(type:WHITE_SPACE, text: ) spaces:" "
+            IChameleonExpression
+              ILiteralExpr
+                FSharpToken(type:INT32, text:3)
+        NewLine(type:NEW_LINE, text:\n) spaces:"\n"
+        NewLine(type:NEW_LINE, text:\n) spaces:"\n"
+        Whitespace(type:WHITE_SPACE, text:    ) spaces:"    "
+        IExternDeclaration
+          IAttributeList
+            FSharpTokenType+LbrackLessTokenElement(type:LBRACK_LESS, text:[<)
+            IAttribute
+              ITypeReferenceName
+                FSharpIdentifierToken(type:IDENTIFIER, text:DllImport)
+              IChameleonExpression
+                IParenExpr
+                  FSharpTokenType+LparenTokenElement(type:LPAREN, text:()
+                  ILiteralExpr
+                    FSharpString(type:STRING, text:"user32.dll")
+                  FSharpTokenType+RparenTokenElement(type:RPAREN, text:))
+            FSharpTokenType+GreaterRbrackTokenElement(type:GREATER_RBRACK, text:>])
+          NewLine(type:NEW_LINE, text:\n) spaces:"\n"
+          Whitespace(type:WHITE_SPACE, text:    ) spaces:"    "
+          FSharpTokenType+StaticTokenElement(type:STATIC, text:static)
+          Whitespace(type:WHITE_SPACE, text: ) spaces:" "
+          FSharpTokenType+ExternTokenElement(type:EXTERN, text:extern)
+          Whitespace(type:WHITE_SPACE, text: ) spaces:" "
+          FSharpIdentifierToken(type:IDENTIFIER, text:uint32)
+          Whitespace(type:WHITE_SPACE, text: ) spaces:" "
+          FSharpIdentifierToken(type:IDENTIFIER, text:M)
+          FSharpTokenType+LparenTokenElement(type:LPAREN, text:()
+          FSharpIdentifierToken(type:IDENTIFIER, text:nativeint)
+          Whitespace(type:WHITE_SPACE, text: ) spaces:" "
+          FSharpIdentifierToken(type:IDENTIFIER, text:hWnd)
+          FSharpTokenType+RparenTokenElement(type:RPAREN, text:))
+        NewLine(type:NEW_LINE, text:\n) spaces:"\n"
+        NewLine(type:NEW_LINE, text:\n) spaces:"\n"
+        Whitespace(type:WHITE_SPACE, text:    ) spaces:"    "
+        IDoStatement
+          FSharpTokenType+DoTokenElement(type:DO, text:do)
+          Whitespace(type:WHITE_SPACE, text: ) spaces:" "
+          IChameleonExpression
+            IUnitExpr
+              FSharpTokenType+LparenTokenElement(type:LPAREN, text:()
+              FSharpTokenType+RparenTokenElement(type:RPAREN, text:))
+    NewLine(type:NEW_LINE, text:\n) spaces:"\n"
+

--- a/ReSharper.FSharp/test/src/FSharp.Tests/Parsing/FSharpParserTest.fs
+++ b/ReSharper.FSharp/test/src/FSharp.Tests/Parsing/FSharpParserTest.fs
@@ -522,6 +522,8 @@ type FSharpParserTest() =
 
     [<Test>] member x.``Type member - Do 01``() = x.DoNamedTest()
 
+    [<Test>] member x.``Type member - Let bindings - Extern 01``() = x.DoNamedTest()
+    [<Test>] member x.``Type member - Let bindings - Multiple 01``() = x.DoNamedTest()
     [<Test>] member x.``Type member - Let bindings - XmlDoc 01``() = x.DoNamedTest()
     [<Test>] member x.``Type member - Let bindings - XmlDoc 02 - Attrs``() = x.DoNamedTest()
     [<Test>] member x.``Type member - Let bindings - XmlDoc 03 - Attrs``() = x.DoNamedTest()


### PR DESCRIPTION
Fix for [RIDER-88948](https://youtrack.jetbrains.com/issue/RIDER-88948/Highlighting-is-broken-in-F-file)