### PR TITLE
Add new internal action to dump the PSI of an F# file

### DIFF
--- a/ReSharper.FSharp/src/FSharp.Psi.Features/src/Internal/FSharpInternalActionGroup.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Features/src/Internal/FSharpInternalActionGroup.fs
@@ -5,10 +5,12 @@ open JetBrains.Application.Diagnostics
 open JetBrains.Application.UI.ActionSystem.ActionsRevised.Menu
 open JetBrains.Application.UI.Actions.InternalMenu
 open JetBrains.Application.UI.ActionsRevised.Menu
+open JetBrains.DocumentModel.DataContext
 open JetBrains.ProjectModel
 open JetBrains.ProjectModel.DataContext
 open JetBrains.ReSharper.Plugins.FSharp.Checker
 open JetBrains.ReSharper.Psi
+open JetBrains.ReSharper.Psi.DataContext
 open JetBrains.ReSharper.Psi.ExtensionsAPI
 open JetBrains.ReSharper.Psi.Files
 open JetBrains.ReSharper.Psi.Tree
@@ -58,11 +60,11 @@ type DumpCurrentFileAction() =
             isNotNull (context.GetData(ProjectModelDataConstants.PROJECT))
 
         member this.Execute(context, _) =
-            let editorContext = context.GetData(JetBrains.DocumentModel.DataContext.DocumentModelDataConstants.EDITOR_CONTEXT)
+            let editorContext = context.GetData(DocumentModelDataConstants.EDITOR_CONTEXT)
             if isNull editorContext then () else
 
-            let sourceFile = context.GetData(JetBrains.ReSharper.Psi.DataContext.PsiDataConstants.SOURCE_FILE)
-            let file = if isNull sourceFile then null else sourceFile.GetPsiFile(editorContext.CaretOffset)
+            let sourceFile = context.GetData(PsiDataConstants.SOURCE_FILE)
+            let file = if isNull sourceFile then null else sourceFile.GetPrimaryPsiFile()
             
             if isNull file then () else
             Dumper.DumpToNotepad(fun writer ->

--- a/ReSharper.FSharp/src/FSharp.Psi.Features/src/Internal/FSharpInternalActionGroup.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Features/src/Internal/FSharpInternalActionGroup.fs
@@ -54,7 +54,7 @@ type DumpCurrentFileAction() =
 
     interface IExecutableAction with
         member this.Update(context, _, _) =
-            isNotNull (context.GetData(ProjectModelDataConstants.PROJECT))
+            isNotNull (context.GetData(DocumentModelDataConstants.EDITOR_CONTEXT))
 
         member this.Execute(context, _) =
             let editorContext = context.GetData(DocumentModelDataConstants.EDITOR_CONTEXT)

--- a/ReSharper.FSharp/src/FSharp.Psi.Features/src/Internal/FSharpInternalActionGroup.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Features/src/Internal/FSharpInternalActionGroup.fs
@@ -52,9 +52,6 @@ type DumpCurrentFcsProjectAction() =
 [<Action("FSharp_Internal_DumpCurrentFile", "Dump current file")>]
 type DumpCurrentFileAction() =
 
-    [<DefaultValue>]
-    val mutable myTextControl: JetBrains.TextControl.ITextControl
-
     interface IExecutableAction with
         member this.Update(context, _, _) =
             isNotNull (context.GetData(ProjectModelDataConstants.PROJECT))

--- a/ReSharper.FSharp/src/FSharp.Psi.Features/src/Internal/FSharpInternalActionGroup.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Features/src/Internal/FSharpInternalActionGroup.fs
@@ -5,10 +5,16 @@ open JetBrains.Application.Diagnostics
 open JetBrains.Application.UI.ActionSystem.ActionsRevised.Menu
 open JetBrains.Application.UI.Actions.InternalMenu
 open JetBrains.Application.UI.ActionsRevised.Menu
+open JetBrains.Diagnostics
+open JetBrains.IDE
 open JetBrains.ProjectModel
 open JetBrains.ProjectModel.DataContext
+open JetBrains.ReSharper.Plugins.FSharp.Psi
 open JetBrains.ReSharper.Plugins.FSharp.Checker
 open JetBrains.ReSharper.Psi
+open JetBrains.ReSharper.Psi.ExtensionsAPI
+open JetBrains.ReSharper.Psi.Tree
+open JetBrains.TextControl
 
 [<Action("FSharp_Internal_DumpFcsProjects", "Dump all FCS projects")>]
 type DumpFcsProjectsAction() =
@@ -42,12 +48,39 @@ type DumpCurrentFcsProjectAction() =
                     match fcsProjectProvider.GetFcsProject(psiModule) with
                     | Some fcsProject -> writer.WriteLine(fcsProject.TestDump(writer))
                     | _ -> ())
+            
+            
+[<Action("FSharp_Internal_DumpCurrentFcsFile", "Dump current FCS file")>]
+type DumpCurrentFcsFileAction() =
+
+    [<DefaultValue>]
+    val mutable myTextControl: JetBrains.TextControl.ITextControl
+
+    interface IExecutableAction with
+        member this.Update(context, _, _) =
+            isNotNull (context.GetData(ProjectModelDataConstants.PROJECT))
+
+        member this.Execute(context, _) =
+            let project = context.GetData(ProjectModelDataConstants.PROJECT)
+            let solution = project.GetSolution()
+            // Todo get path from currently viewed .fs file
+            let virtualFileSystemPath = VirtualFileSystemPath.TryParse(@"C:\Users\schae\src\resharper-fsharp\ReSharper.FSharp\test\data\parsing\_.fs", InteractionContext.SolutionContext)
+            if virtualFileSystemPath.FullPath <> System.String.Empty then
+                let textControl = solution.GetComponent<IEditorManager>().OpenFileAsync(virtualFileSystemPath, OpenFileOptions.DefaultActivate).Result.NotNull<ITextControl>("editorManager.OpenFileAsync(file, OpenFileOptions.DefaultActivate).Result")
+                let psiSourceFile = textControl.Document.GetPsiSourceFile(solution)
+                let psiFile = psiSourceFile.GetTheOnlyPsiFile<FSharpLanguage>()
+
+                Dumper.DumpToNotepad(fun writer ->
+                    let treeNode = psiFile :> ITreeNode
+                    writer.WriteLine("Language: {0}", psiFile.Language :> obj)
+                    DebugUtil.DumpPsi(writer, treeNode))
 
 
 [<ActionGroup(ActionGroupInsertStyles.Submenu ||| ActionGroupInsertStyles.Separated, Text = "F#")>]
 type FSharpInternalActionGroup(
         _dumpFcsProjectsAction: DumpFcsProjectsAction,
-        _dumpCurrentFcsProjectAction: DumpCurrentFcsProjectAction) =
+        _dumpCurrentFcsProjectAction: DumpCurrentFcsProjectAction,
+        _dumpCurrentFcsFileAction: DumpCurrentFcsFileAction) =
     interface IAction
     interface IInsertLast<IntoInternalMenu>
 

--- a/ReSharper.FSharp/src/FSharp.Psi.Features/src/Internal/FSharpInternalActionGroup.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Features/src/Internal/FSharpInternalActionGroup.fs
@@ -5,16 +5,13 @@ open JetBrains.Application.Diagnostics
 open JetBrains.Application.UI.ActionSystem.ActionsRevised.Menu
 open JetBrains.Application.UI.Actions.InternalMenu
 open JetBrains.Application.UI.ActionsRevised.Menu
-open JetBrains.Diagnostics
-open JetBrains.IDE
 open JetBrains.ProjectModel
 open JetBrains.ProjectModel.DataContext
-open JetBrains.ReSharper.Plugins.FSharp.Psi
 open JetBrains.ReSharper.Plugins.FSharp.Checker
 open JetBrains.ReSharper.Psi
 open JetBrains.ReSharper.Psi.ExtensionsAPI
+open JetBrains.ReSharper.Psi.Files
 open JetBrains.ReSharper.Psi.Tree
-open JetBrains.TextControl
 
 [<Action("FSharp_Internal_DumpFcsProjects", "Dump all FCS projects")>]
 type DumpFcsProjectsAction() =
@@ -61,19 +58,17 @@ type DumpCurrentFcsFileAction() =
             isNotNull (context.GetData(ProjectModelDataConstants.PROJECT))
 
         member this.Execute(context, _) =
-            let project = context.GetData(ProjectModelDataConstants.PROJECT)
-            let solution = project.GetSolution()
-            // Todo get path from currently viewed .fs file
-            let virtualFileSystemPath = VirtualFileSystemPath.TryParse(@"C:\Users\schae\src\resharper-fsharp\ReSharper.FSharp\test\data\parsing\_.fs", InteractionContext.SolutionContext)
-            if virtualFileSystemPath.FullPath <> System.String.Empty then
-                let textControl = solution.GetComponent<IEditorManager>().OpenFileAsync(virtualFileSystemPath, OpenFileOptions.DefaultActivate).Result.NotNull<ITextControl>("editorManager.OpenFileAsync(file, OpenFileOptions.DefaultActivate).Result")
-                let psiSourceFile = textControl.Document.GetPsiSourceFile(solution)
-                let psiFile = psiSourceFile.GetTheOnlyPsiFile<FSharpLanguage>()
-
-                Dumper.DumpToNotepad(fun writer ->
-                    let treeNode = psiFile :> ITreeNode
-                    writer.WriteLine("Language: {0}", psiFile.Language :> obj)
-                    DebugUtil.DumpPsi(writer, treeNode))
+            let editorContext = context.GetData(JetBrains.DocumentModel.DataContext.DocumentModelDataConstants.EDITOR_CONTEXT)
+            if isNull editorContext then
+                ()
+            else
+                let sourceFile = context.GetData(JetBrains.ReSharper.Psi.DataContext.PsiDataConstants.SOURCE_FILE)
+                let file = if isNull sourceFile then null else sourceFile.GetPsiFile(editorContext.CaretOffset)
+                if not (isNull file) then
+                    Dumper.DumpToNotepad(fun writer ->
+                            let treeNode = file :> ITreeNode
+                            writer.WriteLine("Language: {0}", file.Language :> obj)
+                            DebugUtil.DumpPsi(writer, treeNode))
 
 
 [<ActionGroup(ActionGroupInsertStyles.Submenu ||| ActionGroupInsertStyles.Separated, Text = "F#")>]

--- a/ReSharper.FSharp/src/FSharp.Psi.Features/src/Internal/FSharpInternalActionGroup.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Features/src/Internal/FSharpInternalActionGroup.fs
@@ -47,8 +47,8 @@ type DumpCurrentFcsProjectAction() =
                     | _ -> ())
             
             
-[<Action("FSharp_Internal_DumpCurrentFcsFile", "Dump current FCS file")>]
-type DumpCurrentFcsFileAction() =
+[<Action("FSharp_Internal_DumpCurrentFile", "Dump current file")>]
+type DumpCurrentFileAction() =
 
     [<DefaultValue>]
     val mutable myTextControl: JetBrains.TextControl.ITextControl
@@ -75,7 +75,7 @@ type DumpCurrentFcsFileAction() =
 type FSharpInternalActionGroup(
         _dumpFcsProjectsAction: DumpFcsProjectsAction,
         _dumpCurrentFcsProjectAction: DumpCurrentFcsProjectAction,
-        _dumpCurrentFcsFileAction: DumpCurrentFcsFileAction) =
+        _dumpCurrentFileAction: DumpCurrentFileAction) =
     interface IAction
     interface IInsertLast<IntoInternalMenu>
 

--- a/ReSharper.FSharp/src/FSharp.Psi.Features/src/Internal/FSharpInternalActionGroup.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Features/src/Internal/FSharpInternalActionGroup.fs
@@ -59,16 +59,16 @@ type DumpCurrentFcsFileAction() =
 
         member this.Execute(context, _) =
             let editorContext = context.GetData(JetBrains.DocumentModel.DataContext.DocumentModelDataConstants.EDITOR_CONTEXT)
-            if isNull editorContext then
-                ()
-            else
-                let sourceFile = context.GetData(JetBrains.ReSharper.Psi.DataContext.PsiDataConstants.SOURCE_FILE)
-                let file = if isNull sourceFile then null else sourceFile.GetPsiFile(editorContext.CaretOffset)
-                if not (isNull file) then
-                    Dumper.DumpToNotepad(fun writer ->
-                            let treeNode = file :> ITreeNode
-                            writer.WriteLine("Language: {0}", file.Language :> obj)
-                            DebugUtil.DumpPsi(writer, treeNode))
+            if isNull editorContext then () else
+
+            let sourceFile = context.GetData(JetBrains.ReSharper.Psi.DataContext.PsiDataConstants.SOURCE_FILE)
+            let file = if isNull sourceFile then null else sourceFile.GetPsiFile(editorContext.CaretOffset)
+            
+            if isNull file then () else
+            Dumper.DumpToNotepad(fun writer ->
+                let treeNode = file :> ITreeNode
+                writer.WriteLine("Language: {0}", file.Language :> obj)
+                DebugUtil.DumpPsi(writer, treeNode))
 
 
 [<ActionGroup(ActionGroupInsertStyles.Submenu ||| ActionGroupInsertStyles.Separated, Text = "F#")>]


### PR DESCRIPTION
Second part for #487: "Dump current FCS file"
I'm getting the same output as in the `FSharpParserTest._` test:

![Screenshot 2023-03-02 171419](https://user-images.githubusercontent.com/3221269/222490265-90e26b7b-8452-428b-8192-b89e1760eaef.png)

![Screenshot 2023-03-02 171145](https://user-images.githubusercontent.com/3221269/222489075-1cdeeb81-8356-4184-8231-478461b8d3ac.png)

As it also works for other file types, I'm not sure about the placement in the menu tree.