### PR TITLE
Consider full range when closing NAMED_UNION_CASE_FIELDS_PAT.

### DIFF
--- a/ReSharper.FSharp/src/FSharp.Psi.Features/src/Parsing/FSharpImplTreeBuilder.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Features/src/Parsing/FSharpImplTreeBuilder.fs
@@ -308,7 +308,7 @@ type FSharpImplTreeBuilder(lexer, document, decls, lifetime, path, projectedOffs
     member x.ProcessMemberBinding(mark, SynBinding(_, _, _, _, attrLists, _, valData, headPat, returnInfo, expr, _, _, _), range, accessorsStart: pos option) : CompositeNodeType =
         let elType =
             match headPat with
-            | SynPat.LongIdent(LongIdentWithDots(lid, _), accessorId, typeParamsOpt, memberParams, _, range) ->
+            | SynPat.LongIdent(SynLongIdent(id = lid), accessorId, typeParamsOpt, memberParams, _, range) ->
                 match lid with
                 | [_] ->
                     match valData with
@@ -606,7 +606,7 @@ type FSharpImplTreeBuilder(lexer, document, decls, lifetime, path, projectedOffs
                 x.ProcessParam(pat, isLocal, markMember)
                 x.Done(range, mark, ElementType.FIELD_PAT)
 
-            x.Done(argsMark, ElementType.NAMED_UNION_CASE_FIELDS_PAT)
+            x.Done(argsRange, argsMark, ElementType.NAMED_UNION_CASE_FIELDS_PAT)
 
     member x.ProcessMemberParams(args: SynArgPats, isLocal, markMember) =
         match args with

--- a/ReSharper.FSharp/test/data/parsing/Pattern - Named args 01.fs.gold
+++ b/ReSharper.FSharp/test/data/parsing/Pattern - Named args 01.fs.gold
@@ -21,7 +21,7 @@ IFSharpImplFile
                 ITopReferencePat
                   IExpressionReferenceName
                     FSharpIdentifierToken(type:IDENTIFIER, text:namedFieldPat)
-            FSharpTokenType+RparenTokenElement(type:RPAREN, text:))
+              FSharpTokenType+RparenTokenElement(type:RPAREN, text:))
           FSharpTokenType+RparenTokenElement(type:RPAREN, text:))
         Whitespace(type:WHITE_SPACE, text: ) spaces:" "
         FSharpTokenType+EqualsTokenElement(type:EQUALS, text:=)

--- a/ReSharper.FSharp/test/data/parsing/Pattern - Named args 02 - Multiple.fs.gold
+++ b/ReSharper.FSharp/test/data/parsing/Pattern - Named args 02 - Multiple.fs.gold
@@ -35,7 +35,7 @@ IFSharpImplFile
                 ITopReferencePat
                   IExpressionReferenceName
                     FSharpIdentifierToken(type:IDENTIFIER, text:namedFieldPat2)
-            FSharpTokenType+RparenTokenElement(type:RPAREN, text:))
+              FSharpTokenType+RparenTokenElement(type:RPAREN, text:))
           FSharpTokenType+RparenTokenElement(type:RPAREN, text:))
         Whitespace(type:WHITE_SPACE, text: ) spaces:" "
         FSharpTokenType+EqualsTokenElement(type:EQUALS, text:=)

--- a/ReSharper.FSharp/test/data/parsing/Pattern - Parameters owner 06 - NamedUnionCaseFieldsPat.fs
+++ b/ReSharper.FSharp/test/data/parsing/Pattern - Parameters owner 06 - NamedUnionCaseFieldsPat.fs
@@ -1,0 +1,7 @@
+match x with
+|
+    Foo
+        ( y = 8 
+                )
+                    ->
+                        ()

--- a/ReSharper.FSharp/test/data/parsing/Pattern - Parameters owner 06 - NamedUnionCaseFieldsPat.fs.gold
+++ b/ReSharper.FSharp/test/data/parsing/Pattern - Parameters owner 06 - NamedUnionCaseFieldsPat.fs.gold
@@ -1,0 +1,47 @@
+Language: PsiLanguageType:F#
+IFSharpImplFile
+  IAnonModuleDeclaration
+    IExpressionStatement
+      IChameleonExpression
+        IMatchExpr
+          FSharpTokenType+MatchTokenElement(type:MATCH, text:match)
+          Whitespace(type:WHITE_SPACE, text: ) spaces:" "
+          IReferenceExpr
+            FSharpIdentifierToken(type:IDENTIFIER, text:x)
+          Whitespace(type:WHITE_SPACE, text: ) spaces:" "
+          FSharpTokenType+WithTokenElement(type:WITH, text:with)
+          NewLine(type:NEW_LINE, text:\n) spaces:"\n"
+          IMatchClause
+            FSharpTokenType+BarTokenElement(type:BAR, text:|)
+            NewLine(type:NEW_LINE, text:\n) spaces:"\n"
+            Whitespace(type:WHITE_SPACE, text:    ) spaces:"    "
+            IParametersOwnerPat
+              IExpressionReferenceName
+                FSharpIdentifierToken(type:IDENTIFIER, text:Foo)
+              NewLine(type:NEW_LINE, text:\n) spaces:"\n"
+              Whitespace(type:WHITE_SPACE, text:        ) spaces:"        "
+              INamedUnionCaseFieldsPat
+                FSharpTokenType+LparenTokenElement(type:LPAREN, text:()
+                Whitespace(type:WHITE_SPACE, text: ) spaces:" "
+                IFieldPat
+                  IExpressionReferenceName
+                    FSharpIdentifierToken(type:IDENTIFIER, text:y)
+                  Whitespace(type:WHITE_SPACE, text: ) spaces:" "
+                  FSharpTokenType+EqualsTokenElement(type:EQUALS, text:=)
+                  Whitespace(type:WHITE_SPACE, text: ) spaces:" "
+                  ILiteralPat
+                    FSharpToken(type:INT32, text:8)
+                Whitespace(type:WHITE_SPACE, text: ) spaces:" "
+                NewLine(type:NEW_LINE, text:\n) spaces:"\n"
+                Whitespace(type:WHITE_SPACE, text:                ) spaces:"                "
+                FSharpTokenType+RparenTokenElement(type:RPAREN, text:))
+            NewLine(type:NEW_LINE, text:\n) spaces:"\n"
+            Whitespace(type:WHITE_SPACE, text:                    ) spaces:"                    "
+            FSharpTokenType+RarrowTokenElement(type:RARROW, text:->)
+            NewLine(type:NEW_LINE, text:\n) spaces:"\n"
+            Whitespace(type:WHITE_SPACE, text:                        ) spaces:"                        "
+            IUnitExpr
+              FSharpTokenType+LparenTokenElement(type:LPAREN, text:()
+              FSharpTokenType+RparenTokenElement(type:RPAREN, text:))
+    NewLine(type:NEW_LINE, text:\n) spaces:"\n"
+

--- a/ReSharper.FSharp/test/src/FSharp.Tests/Parsing/FSharpParserTest.fs
+++ b/ReSharper.FSharp/test/src/FSharp.Tests/Parsing/FSharpParserTest.fs
@@ -651,6 +651,7 @@ type FSharpParserTest() =
     [<Test>] member x.``Pattern - Parameters owner 03 - Tuple``() = x.DoNamedTest()
     [<Test>] member x.``Pattern - Parameters owner 04 - Parens``() = x.DoNamedTest()
     [<Test>] member x.``Pattern - Parameters owner 05 - Parens``() = x.DoNamedTest()
+    [<Test>] member x.``Pattern - Parameters owner 06 - NamedUnionCaseFieldsPat``() = x.DoNamedTest()
 
     [<Test>] member x.``Pattern - IsInst 01``() = x.DoNamedTest()
     [<Test>] member x.``Pattern - IsInst 02 - Function``() = x.DoNamedTest()


### PR DESCRIPTION
Should include the right paren in INamedUnionCaseFieldsPat.