### PR TITLE
LambdaAnalyzer: disable for active patterns

### DIFF
--- a/ReSharper.FSharp/src/FSharp.Psi.Daemon/src/Analyzers/LambdaAnalyzer.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Daemon/src/Analyzers/LambdaAnalyzer.fs
@@ -131,6 +131,7 @@ type LambdaAnalyzer() =
 
         match replacementExprSymbol with
         | ValueSome (:? FSharpEntity as entity) when (getAbbreviatedEntity entity).IsDelegate -> null
+        | ValueSome (:? FSharpActivePatternCase) -> null
         | _ ->
 
         let binaryExpr = BinaryAppExprNavigator.GetByRightArgument(lambda)

--- a/ReSharper.FSharp/test/data/features/daemon/lambdaAnalyzer/Not available.fs
+++ b/ReSharper.FSharp/test/data/features/daemon/lambdaAnalyzer/Not available.fs
@@ -38,3 +38,9 @@ fun None -> None
 fun A.b -> b
 fun b -> A.b
 fun A.b -> A.b
+
+let (|One|Other|) x =
+    match x with
+    | 1 -> One
+    | x -> x |> fun a -> Other a
+

--- a/ReSharper.FSharp/test/data/features/daemon/lambdaAnalyzer/Not available.fs.gold
+++ b/ReSharper.FSharp/test/data/features/daemon/lambdaAnalyzer/Not available.fs.gold
@@ -39,6 +39,12 @@ fun A.b -> b
 fun b -> A.b
 fun A.b -> A.b
 
+let (|One|Other|) x =
+    match x with
+    | 1 -> One
+    | x -> x |> fun a -> Other a
+
+
 ---------------------------------------------------------
 (0): ReSharper Dead Code: Redundant application
 (1): ReSharper Dead Code: Redundant application


### PR DESCRIPTION
fix for [RIDER-91110](https://youtrack.jetbrains.com/issue/RIDER-91110/Wrong-hint-to-remove-lambda-when-passing-active-pattern-case-in-a-function)