### PR TITLE
CodeStyle Settings page: support .editorconfig layer

### DIFF
--- a/ReSharper.FSharp/src/FSharp.Psi.Features/src/CodeStyle/FSharpCodeStylePage.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Features/src/CodeStyle/FSharpCodeStylePage.fs
@@ -7,6 +7,7 @@ open JetBrains.Application.UI.Options
 open JetBrains.ReSharper.Feature.Services.OptionPages.CodeStyle
 open JetBrains.ReSharper.Plugins.FSharp
 open JetBrains.ReSharper.Plugins.FSharp.Psi
+open JetBrains.ReSharper.Psi.EditorConfig
 open JetBrains.ReSharper.Resources.Resources.Icons
 
 [<CodePreviewPreparatorComponent>]
@@ -63,7 +64,8 @@ type FSharpCodeStylePageSchema(lifetime, smartContext, itemViewModelFactory, con
            x.GetItem(fun key -> key.NeverOutdentPipeOperators) |] :> _
 
 
-[<OptionsPage("FSharpCodeStylePage", "Formatting Style", typeof<PsiFeaturesUnsortedOptionsThemedIcons.Indent>)>]
+[<OptionsPage("FSharpCodeStylePage", "Formatting Style", typeof<PsiFeaturesUnsortedOptionsThemedIcons.Indent>,
+              FilterTags = [|ConfigFileUtils.EditorConfigName|])>]
 type FSharpCodeStylePage(lifetime, smartContext: OptionsSettingsSmartContext, env,
                          schema: FSharpCodeStylePageSchema, preview, componentContainer: IComponentContainer) =
     inherit CodeStylePage(lifetime, smartContext, env, schema, preview, componentContainer)

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/settings/FSharpCodeStyleSettingsProvider.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/settings/FSharpCodeStyleSettingsProvider.kt
@@ -15,4 +15,8 @@ abstract class FSharpCodeStyleSettingsProviderBase(private val lang: Language) :
   override fun getHelpTopic() = "Settings_Code_Style_FSHARP"
   override fun getConfigurableDisplayName() = lang.displayName
   override fun getPagesId() = mapOf("FSharpCodeStylePage" to "Formatting Style", "FantomasPage" to "Fantomas")
+  override fun filterPages(filterTag: String) =
+    if (filterTag == IRiderViewModelConfigurable.EditorConfigFilterTag)
+      mapOf("FSharpCodeStylePage" to "Formatting Style")
+    else super.filterPages(filterTag)
 }


### PR DESCRIPTION
Fix for [RIDER-91470](https://youtrack.jetbrains.com/issue/RIDER-91470/There-is-no-descriptor-for-an-options-page-ID-FSharpCodeStylePage)