### PR TITLE
Generate overrides: add the newline before the typeRepr, not inside it

### DIFF
--- a/ReSharper.FSharp/src/FSharp.Psi.Services/src/Generate/GenerateProvider.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Services/src/Generate/GenerateProvider.fs
@@ -200,10 +200,8 @@ type FSharpOverridingMembersBuilder() =
         let currentIndent = typeRepr.Indent
         let desiredIndent = typeDecl.Indent + typeDecl.GetIndentSize()
 
-        addNodesBefore typeRepr.FirstChild [
-            NewLine(typeRepr.GetLineEnding())
-            Whitespace(currentIndent)
-        ] |> ignore
+        addNodeBefore typeRepr (NewLine(typeRepr.GetLineEnding()))
+        addNodeBefore typeRepr.FirstChild (Whitespace(desiredIndent))
 
         // to have good indents for begin/end keywords which might start out on different indents
         shiftNode (-currentIndent) typeRepr


### PR DESCRIPTION
Hey @auduchinok , here's the change you requested.
I'm still working on getting the tests green with this over in #512 

