### PR TITLE
Place generated override after any let binding in IObjectModelTypeRepresentation

### DIFF
--- a/ReSharper.FSharp/src/FSharp.Psi.Services/src/Generate/GenerateProvider.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Services/src/Generate/GenerateProvider.fs
@@ -336,6 +336,15 @@ type FSharpOverridingMembersBuilder() =
             objModelTypeRepr
 
         let (anchor: ITreeNode), indent =
+            let tryGetLastLet (typeMembersEnumerable: TreeNodeEnumerable<ITypeBodyMemberDeclaration>) =
+                let letBindings =
+                    typeMembersEnumerable
+                    |> Seq.takeWhile (fun x -> x :? ILetBindingsDeclaration)
+                    |> Seq.tryLast
+                match letBindings with
+                | Some b -> Some b
+                | None -> None
+
             match anchor with
             | :? IStructRepresentation as structRepr ->
                 structRepr.BeginKeyword :> _, structRepr.BeginKeyword.Indent + typeDecl.GetIndentSize()
@@ -348,6 +357,10 @@ type FSharpOverridingMembersBuilder() =
                         match repr.TypeMembersEnumerable |> Seq.tryHead with
                         | Some memberDecl -> memberDecl.Indent
                         | _ -> repr.BeginKeyword.Indent + typeDecl.GetIndentSize()
+                    let treeNode =
+                        match repr.TypeMembersEnumerable |> tryGetLastLet with
+                        | Some memberDecl -> memberDecl :> ITreeNode
+                        | _ -> treeNode
                     treeNode, indent
                 | _ ->
 

--- a/ReSharper.FSharp/test/data/features/generate/overrides/Anchor - Repr 13.fs.gold
+++ b/ReSharper.FSharp/test/data/features/generate/overrides/Anchor - Repr 13.fs.gold
@@ -11,7 +11,8 @@
 
 type C() = 
   class
-    override this.ToString() = {selstart}failwith "todo"{selend}
     // comment
     let f = 23
+
+    override this.ToString() = {selstart}failwith "todo"{selend}
   end

--- a/ReSharper.FSharp/test/data/features/generate/overrides/Anchor - Repr 19.fs.gold
+++ b/ReSharper.FSharp/test/data/features/generate/overrides/Anchor - Repr 19.fs.gold
@@ -10,9 +10,10 @@
 
 type C(y: int) = 
   class
-    override this.ToString() = {selstart}failwith "todo"{selend}
     // comment 1
     let x = y // comment 2
+
+    override this.ToString() = {selstart}failwith "todo"{selend}
 
   end
   // comment 3

--- a/ReSharper.FSharp/test/data/features/generate/overrides/Anchor - Repr 21.fs
+++ b/ReSharper.FSharp/test/data/features/generate/overrides/Anchor - Repr 21.fs
@@ -6,4 +6,6 @@
 type C() = class{caret}
              
              let f x = x
+
+             member _.Func(x) = x
            end

--- a/ReSharper.FSharp/test/data/features/generate/overrides/Anchor - Repr 21.fs.gold
+++ b/ReSharper.FSharp/test/data/features/generate/overrides/Anchor - Repr 21.fs.gold
@@ -11,7 +11,10 @@
 
 type C() = 
   class
-    override this.ToString() = {selstart}failwith "todo"{selend}
     
     let f x = x
+
+    override this.ToString() = {selstart}failwith "todo"{selend}
+
+    member _.Func(x) = x
   end

--- a/ReSharper.FSharp/test/data/features/generate/overrides/Anchor - Repr 23.fs
+++ b/ReSharper.FSharp/test/data/features/generate/overrides/Anchor - Repr 23.fs
@@ -1,0 +1,16 @@
+// ${KIND:Overrides}
+// ${SELECT0:ToString():System.String}
+
+// ${KIND:Overrides}
+
+module M
+
+type C(y: int) = class
+
+        do
+            let f{caret} x y = x + y
+            ()
+
+        let x = y
+
+    end

--- a/ReSharper.FSharp/test/data/features/generate/overrides/Anchor - Repr 23.fs.gold
+++ b/ReSharper.FSharp/test/data/features/generate/overrides/Anchor - Repr 23.fs.gold
@@ -1,0 +1,25 @@
+﻿Provided elements:
+ 0: ToString():System.String
+ 1: Equals(System.Object):System.Boolean
+ 2: GetHashCode():System.Int32
+ 3: Finalize():System.Void
+
+// ${KIND:Overrides}
+// ${SELECT0:ToString():System.String}
+
+// ${KIND:Overrides}
+
+module M
+
+type C(y: int) = 
+  class
+
+    do
+        let f x y = x + y
+        ()
+
+    let x = y
+
+    override this.ToString() = {selstart}failwith "todo"{selend}
+
+  end

--- a/ReSharper.FSharp/test/data/features/generate/overrides/Anchor - Repr 24.fs
+++ b/ReSharper.FSharp/test/data/features/generate/overrides/Anchor - Repr 24.fs
@@ -4,6 +4,7 @@
 // ${KIND:Overrides}
 
 type T() =
-  class
-    do (){caret}
+  class{caret}
+    do ()
+    member this.P = 1
   end

--- a/ReSharper.FSharp/test/data/features/generate/overrides/Anchor - Repr 24.fs.gold
+++ b/ReSharper.FSharp/test/data/features/generate/overrides/Anchor - Repr 24.fs.gold
@@ -14,4 +14,5 @@ type T() =
     do ()
 
     override this.ToString() = {selstart}failwith "todo"{selend}
+    member this.P = 1
   end

--- a/ReSharper.FSharp/test/src/FSharp.Tests/Generate/FSharpGenerateOverridesTest.fs
+++ b/ReSharper.FSharp/test/src/FSharp.Tests/Generate/FSharpGenerateOverridesTest.fs
@@ -49,6 +49,7 @@ type FSharpGenerateOverridesTest() =
     [<Test>] member x.``Anchor - Repr 21``() = x.DoNamedTest()
     [<Test>] member x.``Anchor - Repr 22``() = x.DoNamedTest()
     [<Test>] member x.``Anchor - Repr 23``() = x.DoNamedTest()
+    [<Test>] member x.``Anchor - Repr 24``() = x.DoNamedTest()
     [<Test>] member x.``Anchor - Repr - Member 01``() = x.DoNamedTest()
     [<Test>] member x.``Anchor - Repr - Member 02``() = x.DoNamedTest()
     [<Test>] member x.``Anchor - Repr - Member 03``() = x.DoNamedTest()

--- a/ReSharper.FSharp/test/src/FSharp.Tests/Generate/FSharpGenerateOverridesTest.fs
+++ b/ReSharper.FSharp/test/src/FSharp.Tests/Generate/FSharpGenerateOverridesTest.fs
@@ -48,6 +48,7 @@ type FSharpGenerateOverridesTest() =
     [<Test>] member x.``Anchor - Repr 20``() = x.DoNamedTest()
     [<Test>] member x.``Anchor - Repr 21``() = x.DoNamedTest()
     [<Test>] member x.``Anchor - Repr 22``() = x.DoNamedTest()
+    [<Test>] member x.``Anchor - Repr 23``() = x.DoNamedTest()
     [<Test>] member x.``Anchor - Repr - Member 01``() = x.DoNamedTest()
     [<Test>] member x.``Anchor - Repr - Member 02``() = x.DoNamedTest()
     [<Test>] member x.``Anchor - Repr - Member 03``() = x.DoNamedTest()


### PR DESCRIPTION
This moves the anchor to the last let binding in an IObjectModelTypeRepresentation if there is any.