### PR TITLE
Fix overrides generation for "naked" single case unions

### DIFF
--- a/ReSharper.FSharp/src/FSharp.Psi.Services/src/Generate/GenerateProvider.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Services/src/Generate/GenerateProvider.fs
@@ -334,7 +334,7 @@ type FSharpOverridingMembersBuilder() =
             let factory = typeDecl.CreateElementFactory()
             let caseName = FSharpNamingService.mangleNameIfNecessary abbrRepr.AbbreviatedTypeOrUnionCase.SourceName
             let declGroup = factory.CreateModuleMember($"type U = | {caseName}")
-            let typeDeclaration = declGroup.FirstChild.As<IFSharpTypeDeclaration>()
+            let typeDeclaration = declGroup.TypeDeclarations[0] :?> IFSharpTypeDeclaration
             let repr = typeDeclaration.TypeRepresentation
             let nav = FSharpTypeDeclarationNavigator.GetByTypeRepresentation(abbrRepr)
             let newRepr = nav.SetTypeRepresentation(repr)

--- a/ReSharper.FSharp/src/FSharp.Psi.Services/src/Generate/GenerateProvider.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Services/src/Generate/GenerateProvider.fs
@@ -290,14 +290,10 @@ type FSharpOverridingMembersBuilder() =
                 normalizeReprEnd recordRepr.LeftBrace recordRepr.RightBrace
                 recordRepr.LeftBrace, recordRepr.RightBrace
 
-            | :? IUnionRepresentation as unionRepr ->
+            | :? IUnionRepresentation
+            | :? ITypeAbbreviationRepresentation as typeRepr ->
                 let diff = origTypeReprIndent - desiredIndent
-                if diff > 0 then shiftWithWhitespaceBefore -diff unionRepr
-                null, null
-
-            | :? ITypeAbbreviationRepresentation as abbrRepr ->
-                let diff = origTypeReprIndent - desiredIndent
-                if diff > 0 then shiftWithWhitespaceBefore -diff abbrRepr
+                if diff > 0 then shiftWithWhitespaceBefore -diff typeRepr
                 null, null
 
             | _ -> null, null

--- a/ReSharper.FSharp/src/FSharp.Psi.Services/src/Generate/GenerateProvider.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Services/src/Generate/GenerateProvider.fs
@@ -332,9 +332,10 @@ type FSharpOverridingMembersBuilder() =
             |> Option.iter EnumCaseLikeDeclarationUtil.addBarIfNeeded
         | :? ITypeAbbreviationRepresentation as abbrRepr when abbrRepr.CanBeUnionCase ->
             let factory = typeDecl.CreateElementFactory()
-            let declGroup = factory.CreateModuleMember($"type U = | {abbrRepr.AbbreviatedTypeOrUnionCase.DeclaredName}")
+            let caseName = FSharpNamingService.mangleNameIfNecessary abbrRepr.AbbreviatedTypeOrUnionCase.SourceName
+            let declGroup = factory.CreateModuleMember($"type U = | {caseName}")
             let typeDeclaration = declGroup.FirstChild.As<IFSharpTypeDeclaration>()
-            let repr = typeDeclaration.TypeRepresentation.As<IUnionRepresentation>()
+            let repr = typeDeclaration.TypeRepresentation
             let nav = FSharpTypeDeclarationNavigator.GetByTypeRepresentation(abbrRepr)
             let newRepr = nav.SetTypeRepresentation(repr)
             if context.Anchor == abbrRepr then context.Anchor <- newRepr

--- a/ReSharper.FSharp/src/FSharp.Psi.Services/src/Generate/GenerateProvider.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Services/src/Generate/GenerateProvider.fs
@@ -333,11 +333,10 @@ type FSharpOverridingMembersBuilder() =
         | :? ITypeAbbreviationRepresentation as abbrRepr when abbrRepr.CanBeUnionCase ->
             let factory = typeDecl.CreateElementFactory()
             let caseName = FSharpNamingService.mangleNameIfNecessary abbrRepr.AbbreviatedTypeOrUnionCase.SourceName
-            let declGroup = factory.CreateModuleMember($"type U = | {caseName}")
+            let declGroup = factory.CreateModuleMember($"type U = | {caseName}") :?> ITypeDeclarationGroup
             let typeDeclaration = declGroup.TypeDeclarations[0] :?> IFSharpTypeDeclaration
             let repr = typeDeclaration.TypeRepresentation
-            let nav = FSharpTypeDeclarationNavigator.GetByTypeRepresentation(abbrRepr)
-            let newRepr = nav.SetTypeRepresentation(repr)
+            let newRepr = typeDecl.SetTypeRepresentation(repr)
             if context.Anchor == abbrRepr then context.Anchor <- newRepr
         | _ -> ()
 

--- a/ReSharper.FSharp/test/data/features/generate/overrides/Repr - Union - No bar - Single 03.fs
+++ b/ReSharper.FSharp/test/data/features/generate/overrides/Repr - Union - No bar - Single 03.fs
@@ -1,0 +1,4 @@
+// ${KIND:Overrides}
+// ${SELECT0:ToString():System.String}
+
+type SingleCaseUnion = Case{caret}

--- a/ReSharper.FSharp/test/data/features/generate/overrides/Repr - Union - No bar - Single 03.fs.gold
+++ b/ReSharper.FSharp/test/data/features/generate/overrides/Repr - Union - No bar - Single 03.fs.gold
@@ -1,0 +1,13 @@
+﻿Provided elements:
+ 0: ToString():System.String
+ 1: Equals(System.Object):System.Boolean
+ 2: GetHashCode():System.Int32
+ 3: Finalize():System.Void
+
+// ${KIND:Overrides}
+// ${SELECT0:ToString():System.String}
+
+type SingleCaseUnion = 
+  | Case
+
+  override this.ToString() = {selstart}failwith "todo"{selend}

--- a/ReSharper.FSharp/test/data/features/generate/overrides/Repr - Union - No bar - Single 04.fs
+++ b/ReSharper.FSharp/test/data/features/generate/overrides/Repr - Union - No bar - Single 04.fs
@@ -1,0 +1,4 @@
+// ${KIND:Overrides}
+// ${SELECT0:ToString():System.String}
+
+type U = ``A{caret} B``

--- a/ReSharper.FSharp/test/data/features/generate/overrides/Repr - Union - No bar - Single 04.fs.gold
+++ b/ReSharper.FSharp/test/data/features/generate/overrides/Repr - Union - No bar - Single 04.fs.gold
@@ -1,0 +1,13 @@
+﻿Provided elements:
+ 0: ToString():System.String
+ 1: Equals(System.Object):System.Boolean
+ 2: GetHashCode():System.Int32
+ 3: Finalize():System.Void
+
+// ${KIND:Overrides}
+// ${SELECT0:ToString():System.String}
+
+type U = 
+  | ``A B``
+
+  override this.ToString() = {selstart}failwith "todo"{selend}

--- a/ReSharper.FSharp/test/src/FSharp.Tests/Generate/FSharpGenerateOverridesTest.fs
+++ b/ReSharper.FSharp/test/src/FSharp.Tests/Generate/FSharpGenerateOverridesTest.fs
@@ -105,6 +105,7 @@ type FSharpGenerateOverridesTest() =
     [<Test>] member x.``Repr - Union - No bar - Single 01``() = x.DoNamedTest()
     [<Test>] member x.``Repr - Union - No bar - Single 02``() = x.DoNamedTest()
     [<Test>] member x.``Repr - Union - No bar - Single 03``() = x.DoNamedTest()
+    [<Test>] member x.``Repr - Union - No bar - Single 04``() = x.DoNamedTest()
     [<Test>] member x.``Repr - Union 01``() = x.DoNamedTest()
     [<Test>] member x.``Repr - Union 02``() = x.DoNamedTest()
 

--- a/ReSharper.FSharp/test/src/FSharp.Tests/Generate/FSharpGenerateOverridesTest.fs
+++ b/ReSharper.FSharp/test/src/FSharp.Tests/Generate/FSharpGenerateOverridesTest.fs
@@ -104,6 +104,7 @@ type FSharpGenerateOverridesTest() =
     [<Test>] member x.``Repr - Union - No bar - Multiple 03``() = x.DoNamedTest()
     [<Test>] member x.``Repr - Union - No bar - Single 01``() = x.DoNamedTest()
     [<Test>] member x.``Repr - Union - No bar - Single 02``() = x.DoNamedTest()
+    [<Test>] member x.``Repr - Union - No bar - Single 03``() = x.DoNamedTest()
     [<Test>] member x.``Repr - Union 01``() = x.DoNamedTest()
     [<Test>] member x.``Repr - Union 02``() = x.DoNamedTest()
 


### PR DESCRIPTION
Single case unions like "type U = C" are interpreted as ITypeAbbreviationRepresentation.
So this PR adds the needed code to add a `|` in front and to fix the indentation.