### PR TITLE
Language injections: fix backslash escaping at the end of the string part

### DIFF
--- a/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/psi/FSharpStringElementManipulator.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/psi/FSharpStringElementManipulator.kt
@@ -12,7 +12,7 @@ class FSharpStringElementManipulator : ElementManipulator<FSharpStringLiteralExp
 
   private fun escapeRegularString(str: String): String {
     val buffer = StringBuilder()
-    val strLength = str.length
+    val lastCharIndex = str.length - 1
     var isEscaped = false
     str.forEachIndexed { i, ch ->
       when (ch) {
@@ -22,7 +22,7 @@ class FSharpStringElementManipulator : ElementManipulator<FSharpStringLiteralExp
         '\n' -> buffer.append('\n')
         '\u000c' -> buffer.append("\\f")
         '\r' -> buffer.append("\\r")
-        '\\' -> buffer.append(if (!isEscaped && i == strLength - 1) "\\\\" else "\\")
+        '\\' -> buffer.append(if (!isEscaped && i == lastCharIndex) "\\\\" else "\\")
         else -> if (!StringUtil.isPrintableUnicode(ch)) {
           val hexCode: CharSequence = StringUtil.toUpperCase(Integer.toHexString(ch.code))
           buffer.append("\\u")

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/psi/FSharpStringElementManipulator.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/psi/FSharpStringElementManipulator.kt
@@ -12,7 +12,9 @@ class FSharpStringElementManipulator : ElementManipulator<FSharpStringLiteralExp
 
   private fun escapeRegularString(str: String): String {
     val buffer = StringBuilder()
-    for (ch in str) {
+    val strLength = str.length
+    var isEscaped = false
+    str.forEachIndexed { i, ch ->
       when (ch) {
         '"' -> buffer.append("\\\"")
         '\b' -> buffer.append("\\b")
@@ -20,7 +22,7 @@ class FSharpStringElementManipulator : ElementManipulator<FSharpStringLiteralExp
         '\n' -> buffer.append('\n')
         '\u000c' -> buffer.append("\\f")
         '\r' -> buffer.append("\\r")
-        '\\' -> buffer.append('\\')
+        '\\' -> buffer.append(if (!isEscaped && i == strLength - 1) "\\\\" else "\\")
         else -> if (!StringUtil.isPrintableUnicode(ch)) {
           val hexCode: CharSequence = StringUtil.toUpperCase(Integer.toHexString(ch.code))
           buffer.append("\\u")
@@ -33,6 +35,7 @@ class FSharpStringElementManipulator : ElementManipulator<FSharpStringLiteralExp
           buffer.append(ch)
         }
       }
+      isEscaped = ch == '\\' && !isEscaped
     }
     return buffer.toString()
   }
@@ -44,7 +47,7 @@ class FSharpStringElementManipulator : ElementManipulator<FSharpStringLiteralExp
     var newText = newContent
     val elementType = element.literalType
 
-    if (elementType.isRegular) newText = escapeRegularString(newContent)
+    if (elementType.isRegular) newText = escapeRegularString(newText)
 
     if (elementType.isInterpolated) newText =
       newText

--- a/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/markup/injections/InjectionEscapersTest.kt
+++ b/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/markup/injections/InjectionEscapersTest.kt
@@ -1,0 +1,72 @@
+package com.jetbrains.rider.plugins.fsharp.test.cases.markup.injections
+
+import com.intellij.codeInsight.daemon.impl.HighlightInfoType
+import com.intellij.codeInsight.intention.impl.QuickEditAction
+import com.intellij.lang.injection.InjectedLanguageManager
+import com.intellij.openapi.editor.impl.EditorImpl
+import com.intellij.openapi.fileEditor.OpenFileDescriptor
+import com.intellij.openapi.fileEditor.ex.FileEditorManagerEx
+import com.intellij.psi.impl.source.tree.injected.InjectedLanguageUtil
+import com.jetbrains.rider.editors.getPsiFile
+import com.jetbrains.rider.test.annotations.TestEnvironment
+import com.jetbrains.rider.test.base.BaseTestWithSolution
+import com.jetbrains.rider.test.env.enums.SdkVersion
+import com.jetbrains.rider.test.framework.executeWithGold
+import com.jetbrains.rider.test.scriptingApi.getHighlighters
+import com.jetbrains.rider.test.scriptingApi.typeFromOffset
+import com.jetbrains.rider.test.scriptingApi.withOpenedEditor
+import com.jetbrains.rider.test.waitForDaemon
+import org.testng.annotations.Test
+
+@Test
+@TestEnvironment(sdkVersion = SdkVersion.DOT_NET_6)
+class InjectionEscapersTest : BaseTestWithSolution() {
+  override fun getSolutionDirectoryName() = "CoreConsoleApp"
+
+  private fun doTest(action: (EditorImpl, EditorImpl) -> Unit) {
+    withOpenedEditor("Program.fs", "Program.fs") {
+      waitForDaemon()
+      val hostFile = getPsiFile()!!
+      val project = project!!
+      val offset = this.caretModel.offset
+      val injectedLanguageManager = InjectedLanguageManager.getInstance(project)
+      val fileEditorManager = FileEditorManagerEx.getInstanceEx(project)
+      val element = injectedLanguageManager.findInjectedElementAt(hostFile, offset)
+      val quickEditHandler = QuickEditAction().invokeImpl(project, this, hostFile)
+      val documentWindow = InjectedLanguageUtil.getDocumentWindow(element!!.containingFile)
+      val unescapedOffset = InjectedLanguageUtil.hostToInjectedUnescaped(documentWindow, offset);
+      val fragmentEditor =
+        fileEditorManager.openTextEditor(
+          OpenFileDescriptor(
+            project,
+            quickEditHandler.newFile.virtualFile,
+            unescapedOffset
+          ), true
+        ) as EditorImpl
+
+      try {
+        action(this, fragmentEditor)
+      } finally {
+        quickEditHandler.closeEditorForTest()
+      }
+    }
+  }
+
+  private fun doBackslashTest() = doTest { hostEditor, fragmentEditor ->
+    fragmentEditor.typeFromOffset("\\", fragmentEditor.caretModel.offset)
+    executeWithGold(testGoldFile) { printStream ->
+      printStream.print(
+        getHighlighters(project, hostEditor) {
+          it.severity === HighlightInfoType.INJECTED_FRAGMENT_SEVERITY
+        }
+      )
+    }
+  }
+
+  fun `backslash - simple`() = doBackslashTest()
+  fun `backslash at the end - regular`() = doBackslashTest()
+  fun `backslash at the end - verbatim`() = doBackslashTest()
+  fun `backslash at the end - triple quoted`() = doBackslashTest()
+  fun `backslash before hole - interpolated`() = doBackslashTest()
+  fun `escaped backslash at the end - regular`() = doBackslashTest()
+}

--- a/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/markup/injections/InjectionEscapersTest.kt
+++ b/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/markup/injections/InjectionEscapersTest.kt
@@ -34,7 +34,7 @@ class InjectionEscapersTest : BaseTestWithSolution() {
       val element = injectedLanguageManager.findInjectedElementAt(hostFile, offset)
       val quickEditHandler = QuickEditAction().invokeImpl(project, this, hostFile)
       val documentWindow = InjectedLanguageUtil.getDocumentWindow(element!!.containingFile)
-      val unescapedOffset = InjectedLanguageUtil.hostToInjectedUnescaped(documentWindow, offset);
+      val unescapedOffset = InjectedLanguageUtil.hostToInjectedUnescaped(documentWindow, offset)
       val fragmentEditor =
         fileEditorManager.openTextEditor(
           OpenFileDescriptor(

--- a/rider-fsharp/testData/markup/injections/InjectionEscapersTest/backslash - simple/gold/backslash - simple.gold
+++ b/rider-fsharp/testData/markup/injections/InjectionEscapersTest/backslash - simple/gold/backslash - simple.gold
@@ -1,0 +1,1 @@
+"<frontend:INJECTED_FRAGMENT>select * from \ table</frontend:INJECTED_FRAGMENT>"

--- a/rider-fsharp/testData/markup/injections/InjectionEscapersTest/backslash - simple/source/Program.fs
+++ b/rider-fsharp/testData/markup/injections/InjectionEscapersTest/backslash - simple/source/Program.fs
@@ -1,0 +1,1 @@
+"select * from <caret> table"

--- a/rider-fsharp/testData/markup/injections/InjectionEscapersTest/backslash at the end - regular/gold/backslash at the end - regular.gold
+++ b/rider-fsharp/testData/markup/injections/InjectionEscapersTest/backslash at the end - regular/gold/backslash at the end - regular.gold
@@ -1,0 +1,1 @@
+"<frontend:INJECTED_FRAGMENT>select * from table \\</frontend:INJECTED_FRAGMENT>"

--- a/rider-fsharp/testData/markup/injections/InjectionEscapersTest/backslash at the end - regular/source/Program.fs
+++ b/rider-fsharp/testData/markup/injections/InjectionEscapersTest/backslash at the end - regular/source/Program.fs
@@ -1,0 +1,1 @@
+"select * from table <caret>"

--- a/rider-fsharp/testData/markup/injections/InjectionEscapersTest/backslash at the end - triple quoted/gold/backslash at the end - triple quoted.gold
+++ b/rider-fsharp/testData/markup/injections/InjectionEscapersTest/backslash at the end - triple quoted/gold/backslash at the end - triple quoted.gold
@@ -1,0 +1,1 @@
+"""<frontend:INJECTED_FRAGMENT>select * from table \</frontend:INJECTED_FRAGMENT>"""

--- a/rider-fsharp/testData/markup/injections/InjectionEscapersTest/backslash at the end - triple quoted/source/Program.fs
+++ b/rider-fsharp/testData/markup/injections/InjectionEscapersTest/backslash at the end - triple quoted/source/Program.fs
@@ -1,0 +1,1 @@
+"""select * from table <caret>"""

--- a/rider-fsharp/testData/markup/injections/InjectionEscapersTest/backslash at the end - verbatim/gold/backslash at the end - verbatim.gold
+++ b/rider-fsharp/testData/markup/injections/InjectionEscapersTest/backslash at the end - verbatim/gold/backslash at the end - verbatim.gold
@@ -1,0 +1,1 @@
+@"<frontend:INJECTED_FRAGMENT>select * from table \</frontend:INJECTED_FRAGMENT>"

--- a/rider-fsharp/testData/markup/injections/InjectionEscapersTest/backslash at the end - verbatim/source/Program.fs
+++ b/rider-fsharp/testData/markup/injections/InjectionEscapersTest/backslash at the end - verbatim/source/Program.fs
@@ -1,0 +1,1 @@
+@"select * from table <caret>"

--- a/rider-fsharp/testData/markup/injections/InjectionEscapersTest/backslash before hole - interpolated/gold/backslash before hole - interpolated.gold
+++ b/rider-fsharp/testData/markup/injections/InjectionEscapersTest/backslash before hole - interpolated/gold/backslash before hole - interpolated.gold
@@ -1,0 +1,1 @@
+$"<frontend:INJECTED_FRAGMENT>select * from \\</frontend:INJECTED_FRAGMENT>{5}"

--- a/rider-fsharp/testData/markup/injections/InjectionEscapersTest/backslash before hole - interpolated/source/Program.fs
+++ b/rider-fsharp/testData/markup/injections/InjectionEscapersTest/backslash before hole - interpolated/source/Program.fs
@@ -1,0 +1,1 @@
+$"select * from <caret>{5}"

--- a/rider-fsharp/testData/markup/injections/InjectionEscapersTest/escaped backslash at the end - regular/gold/escaped backslash at the end - regular.gold
+++ b/rider-fsharp/testData/markup/injections/InjectionEscapersTest/escaped backslash at the end - regular/gold/escaped backslash at the end - regular.gold
@@ -1,0 +1,1 @@
+"<frontend:INJECTED_FRAGMENT>select * from table \\</frontend:INJECTED_FRAGMENT>"

--- a/rider-fsharp/testData/markup/injections/InjectionEscapersTest/escaped backslash at the end - regular/source/Program.fs
+++ b/rider-fsharp/testData/markup/injections/InjectionEscapersTest/escaped backslash at the end - regular/source/Program.fs
@@ -1,0 +1,1 @@
+"select * from table \\<caret>"


### PR DESCRIPTION
Currently, we don't escape backslashes at the end of the string part (regular or regular interpolated) that will lead to a parsing error in the corresponding F# string. 

Correct escaping examples:

![Language injections](https://github.com/JetBrains/resharper-fsharp/assets/26364714/dfb994f9-5103-43d6-b7ff-d784f17d47f8)


- [x] Tests
