### PR TITLE
Quick fix for ValueNotContainedMutabilityAttributesDiffer

### DIFF
--- a/ReSharper.FSharp/src/FSharp.Psi.Daemon/src/Stages/FcsErrorsStageProcessBase.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Daemon/src/Stages/FcsErrorsStageProcessBase.fs
@@ -43,6 +43,7 @@ module FSharpErrors =
     let [<Literal>] MatchIncomplete = 25
     let [<Literal>] RuleNeverMatched = 26
     let [<Literal>] ValNotMutable = 27
+    let [<Literal>] ValueNotContainedMutability = 34
     let [<Literal>] VarBoundTwice = 38
     let [<Literal>] UndefinedName = 39
     let [<Literal>] ErrorFromAddingConstraint = 43
@@ -315,6 +316,12 @@ type FcsErrorsStageProcessBase(fsFile, daemonProcess) =
 
             ValueNotMutableError(refExpr) :> _
 
+        | ValueNotContainedMutability ->
+            if error.Message.EndsWith("The mutability attributes differ") then
+                createHighlightingFromNodeWithMessage ValueNotContainedMutabilityAttributesDifferError range error
+            else
+                createGenericHighlighting error range
+        
         | UnitTypeExpected ->
             createHighlightingFromMappedExpression getResultExpr UnitTypeExpectedWarning range error
 

--- a/ReSharper.FSharp/src/FSharp.Psi.Intentions/FSharp.Psi.Intentions.fsproj
+++ b/ReSharper.FSharp/src/FSharp.Psi.Intentions/FSharp.Psi.Intentions.fsproj
@@ -100,6 +100,7 @@
     <Compile Include="src\QuickFixes\UpdateRecordFieldTypeInSignatureFix.fs" />
     <Compile Include="src\QuickFixes\RemovePatternArgumentFix.fs" />
     <Compile Include="src\QuickFixes\AddSetterFix.fs" />
+    <Compile Include="src\QuickFixes\UpdateMutabilityInSignatureFix.fs" />
     <ErrorsGen Include="..\FSharp.Psi.Services\src\Daemon\Highlightings\Errors.xml">
       <Mode>QUICKFIX</Mode>
       <Namespace>JetBrains.ReSharper.Plugins.FSharp.Psi.Features.Daemon.QuickFixes</Namespace>

--- a/ReSharper.FSharp/src/FSharp.Psi.Intentions/src/QuickFixes/UpdateMutabilityInSignatureFix.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Intentions/src/QuickFixes/UpdateMutabilityInSignatureFix.fs
@@ -1,4 +1,4 @@
-﻿namespace JetBrains.ReSharper.Plugins.FSharp.Psi.Features.Daemon.QuickFixes
+namespace JetBrains.ReSharper.Plugins.FSharp.Psi.Features.Daemon.QuickFixes
 
 open JetBrains.ReSharper.Plugins.FSharp.Psi.Tree
 open JetBrains.ReSharper.Plugins.FSharp.Psi.Features.Daemon.Highlightings
@@ -53,7 +53,7 @@ type UpdateMutabilityInSignatureFix(error: ValueNotContainedMutabilityAttributes
     override x.IsAvailable _ =
         match tryFindImplementationBindingInfo error.Pat with
         | None -> false
-        |Some (topLevelBinding, declaredElement) ->
+        | Some (topLevelBinding, declaredElement) ->
             match tryFindBindingSignature error.Pat.DeclaredName declaredElement with
             | None -> false
             | Some bindingSignature -> topLevelBinding.IsMutable <> bindingSignature.IsMutable
@@ -64,7 +64,7 @@ type UpdateMutabilityInSignatureFix(error: ValueNotContainedMutabilityAttributes
 
         match tryFindImplementationBindingInfo error.Pat with
         | None -> ()
-        |Some (topLevelBinding, declaredElement) ->
+        | Some (topLevelBinding, declaredElement) ->
             match tryFindBindingSignature error.Pat.DeclaredName declaredElement with
             | None -> ()
             | Some bindingSignature ->

--- a/ReSharper.FSharp/src/FSharp.Psi.Intentions/src/QuickFixes/UpdateMutabilityInSignatureFix.fs
+++ b/ReSharper.FSharp/src/FSharp.Psi.Intentions/src/QuickFixes/UpdateMutabilityInSignatureFix.fs
@@ -1,0 +1,71 @@
+﻿namespace JetBrains.ReSharper.Plugins.FSharp.Psi.Features.Daemon.QuickFixes
+
+open JetBrains.ReSharper.Plugins.FSharp.Psi.Tree
+open JetBrains.ReSharper.Plugins.FSharp.Psi.Features.Daemon.Highlightings
+open JetBrains.ReSharper.Psi.ExtensionsAPI
+open JetBrains.ReSharper.Resources.Shell
+open JetBrains.ReSharper.Plugins.FSharp.Psi
+
+type UpdateMutabilityInSignatureFix(error: ValueNotContainedMutabilityAttributesDifferError) =
+    inherit FSharpQuickFixBase()
+
+    let tryFindBindingSignature (implementationDeclaredName: string) (declaredElement: IFSharpMember) =
+        let parentDeclarations = declaredElement.ContainingType.GetDeclarations()
+
+        // Find the parent signature counter part
+        let signatureNameModuleDeclaration =
+            parentDeclarations
+            |> Seq.tryPick (fun d ->
+                match d with
+                | :? INamedModuleDeclaration as signatureModule when
+                    signatureModule.GetSourceFile().IsFSharpSignatureFile -> Some signatureModule
+                | _ -> None)
+
+        signatureNameModuleDeclaration
+        |> Option.bind (fun signatureModule ->
+            signatureModule.Members
+            |> Seq.tryPick (fun sigMember ->
+                match sigMember with
+                | :? IBindingSignature as bindingSignature ->
+                    match bindingSignature.HeadPattern with
+                    | :? ITopReferencePat as bindingNamePat
+                        // This is a bit lucky to work.
+                        // There must be something more clever we can try
+                        when bindingNamePat.DeclaredName = implementationDeclaredName ->
+                        Some bindingSignature
+                    | _ -> None
+                | _ -> None)
+        )
+
+    let tryFindImplementationBindingInfo (pat: ITopReferencePat) =
+        if isNull pat then None else
+        let topLevelBinding = TopBindingNavigator.GetByHeadPattern(pat)
+        if isNull topLevelBinding then None else
+        let declaredElement = topLevelBinding.DeclaredElement :?> IFSharpMember
+        if isNull declaredElement then None else
+        let mfv = declaredElement.Mfv
+        if isNull mfv then None else
+        if not mfv.HasSignatureFile then None else
+        Some (topLevelBinding, declaredElement)
+
+    override x.Text = "Update mutability in signature"
+
+    override x.IsAvailable _ =
+        match tryFindImplementationBindingInfo error.Pat with
+        | None -> false
+        |Some (topLevelBinding, declaredElement) ->
+            match tryFindBindingSignature error.Pat.DeclaredName declaredElement with
+            | None -> false
+            | Some bindingSignature -> topLevelBinding.IsMutable <> bindingSignature.IsMutable
+
+    override x.ExecutePsiTransaction _ =
+        use writeCookie = WriteLockCookie.Create(error.Pat.IsPhysical())
+        use disableFormatter = new DisableCodeFormatter()
+
+        match tryFindImplementationBindingInfo error.Pat with
+        | None -> ()
+        |Some (topLevelBinding, declaredElement) ->
+            match tryFindBindingSignature error.Pat.DeclaredName declaredElement with
+            | None -> ()
+            | Some bindingSignature ->
+                bindingSignature.SetIsMutable(topLevelBinding.IsMutable)

--- a/ReSharper.FSharp/src/FSharp.Psi.Services/src/Daemon/Highlightings/FcsErrors.xml
+++ b/ReSharper.FSharp/src/FSharp.Psi.Services/src/Daemon/Highlightings/FcsErrors.xml
@@ -207,6 +207,17 @@
     <QuickFix>RemoveUnnecessaryUpcastFix</QuickFix>
   </Warning>
 
+  <Error staticGroup="FSharpErrors" name="ValueNotContainedMutabilityAttributesDiffer" ID="FS0034: but its signature specifies The mutability attributes differ">
+    <Parameter type="ITopReferencePat" name="pat"/>
+    <Parameter type="string" name="fcsMessage"/>
+    <Range>pat.GetNavigationRange()</Range>
+    <Message resourceName="Message" resourceType="Strings">
+      <Argument>fcsMessage</Argument>
+    </Message>
+    <Behavour overlapResolvePolicy="NONE"/>
+    <QuickFix>UpdateMutabilityInSignatureFix</QuickFix>
+  </Error>
+
   <Error staticGroup="FSharpErrors" name="VarBoundTwice" ID="FS0038: Pattern bound twice">
     <Parameter type="IReferencePat" name="pat"/>
     <Message resourceName="IsBoundMultipleTimesMessage" resourceType="Strings">

--- a/ReSharper.FSharp/src/FSharp.Psi/src/Impl/Tree/BindingSignature.cs
+++ b/ReSharper.FSharp/src/FSharp.Psi/src/Impl/Tree/BindingSignature.cs
@@ -1,4 +1,5 @@
 ﻿using JetBrains.ReSharper.Plugins.FSharp.Psi.Parsing;
+using JetBrains.ReSharper.Psi.ExtensionsAPI.Tree;
 
 namespace JetBrains.ReSharper.Plugins.FSharp.Psi.Impl.Tree
 {
@@ -8,8 +9,18 @@ namespace JetBrains.ReSharper.Plugins.FSharp.Psi.Impl.Tree
 
     public void SetIsMutable(bool value)
     {
-      if (!value)
-        throw new System.NotImplementedException();
+      if (!value && MutableKeyword != null)
+      {
+        if (MutableKeyword.PrevSibling is Whitespace whitespace)
+        {
+          ModificationUtil.DeleteChildRange(whitespace, MutableKeyword);
+        }
+        else
+        {
+          ModificationUtil.DeleteChild(MutableKeyword);
+        }
+        return;
+      }
 
       var headPat = HeadPattern;
       if (headPat != null)

--- a/ReSharper.FSharp/test/data/features/quickFixes/updateMutabilityInSignatureFix/Add Mutability - 01.fs
+++ b/ReSharper.FSharp/test/data/features/quickFixes/updateMutabilityInSignatureFix/Add Mutability - 01.fs
@@ -1,0 +1,3 @@
+module A
+
+let mutable a{caret} : int = 0

--- a/ReSharper.FSharp/test/data/features/quickFixes/updateMutabilityInSignatureFix/Add Mutability - 01.fs.gold
+++ b/ReSharper.FSharp/test/data/features/quickFixes/updateMutabilityInSignatureFix/Add Mutability - 01.fs.gold
@@ -1,0 +1,3 @@
+﻿module A
+
+let mutable a{caret} : int = 0

--- a/ReSharper.FSharp/test/data/features/quickFixes/updateMutabilityInSignatureFix/Add Mutability - 01.fsi
+++ b/ReSharper.FSharp/test/data/features/quickFixes/updateMutabilityInSignatureFix/Add Mutability - 01.fsi
@@ -1,0 +1,3 @@
+module A
+
+val a: int

--- a/ReSharper.FSharp/test/data/features/quickFixes/updateMutabilityInSignatureFix/Add Mutability - 01.fsi.gold
+++ b/ReSharper.FSharp/test/data/features/quickFixes/updateMutabilityInSignatureFix/Add Mutability - 01.fsi.gold
@@ -1,0 +1,3 @@
+﻿module A
+
+val mutable a: int

--- a/ReSharper.FSharp/test/data/features/quickFixes/updateMutabilityInSignatureFix/Remove Mutability - 01.fs
+++ b/ReSharper.FSharp/test/data/features/quickFixes/updateMutabilityInSignatureFix/Remove Mutability - 01.fs
@@ -1,0 +1,3 @@
+module A
+
+let a{caret} : int = 0

--- a/ReSharper.FSharp/test/data/features/quickFixes/updateMutabilityInSignatureFix/Remove Mutability - 01.fs.gold
+++ b/ReSharper.FSharp/test/data/features/quickFixes/updateMutabilityInSignatureFix/Remove Mutability - 01.fs.gold
@@ -1,0 +1,3 @@
+module A
+
+let a{caret} : int = 0

--- a/ReSharper.FSharp/test/data/features/quickFixes/updateMutabilityInSignatureFix/Remove Mutability - 01.fsi
+++ b/ReSharper.FSharp/test/data/features/quickFixes/updateMutabilityInSignatureFix/Remove Mutability - 01.fsi
@@ -1,0 +1,3 @@
+module A
+
+val mutable a: int

--- a/ReSharper.FSharp/test/data/features/quickFixes/updateMutabilityInSignatureFix/Remove Mutability - 01.fsi.gold
+++ b/ReSharper.FSharp/test/data/features/quickFixes/updateMutabilityInSignatureFix/Remove Mutability - 01.fsi.gold
@@ -1,0 +1,3 @@
+﻿module A
+
+val a: int

--- a/ReSharper.FSharp/test/src/FSharp.Intentions.Tests/FSharp.Intentions.Tests.fsproj
+++ b/ReSharper.FSharp/test/src/FSharp.Intentions.Tests/FSharp.Intentions.Tests.fsproj
@@ -117,6 +117,7 @@
     <Compile Include="src\QuickFixes\UpdateRecordFieldTypeInSignatureFixTest.fs" />
     <Compile Include="src\QuickFixes\RemovePatternArgumentFixTest.fs" />
     <Compile Include="src\QuickFixes\AddSetterFixTest.fs" />
+    <Compile Include="src\QuickFixes\UpdateMutabilityInSignatureFixTest.fs" />
     <Compile Include="src\QuickDoc\QuickDocTest.fs" />
   </ItemGroup>
 

--- a/ReSharper.FSharp/test/src/FSharp.Intentions.Tests/src/QuickFixes/UpdateMutabilityInSignatureFixTest.fs
+++ b/ReSharper.FSharp/test/src/FSharp.Intentions.Tests/src/QuickFixes/UpdateMutabilityInSignatureFixTest.fs
@@ -9,6 +9,4 @@ type UpdateMutabilityInSignatureFixTest() =
     inherit FSharpQuickFixTestBase<UpdateMutabilityInSignatureFix>()
     override x.RelativeTestDataPath = "features/quickFixes/updateMutabilityInSignatureFix"
     [<Test>] member x.``Add Mutability - 01`` () = x.DoNamedTestWithSignature()
-
     [<Test>] member x.``Remove Mutability - 01`` () = x.DoNamedTestWithSignature()
-

--- a/ReSharper.FSharp/test/src/FSharp.Intentions.Tests/src/QuickFixes/UpdateMutabilityInSignatureFixTest.fs
+++ b/ReSharper.FSharp/test/src/FSharp.Intentions.Tests/src/QuickFixes/UpdateMutabilityInSignatureFixTest.fs
@@ -9,3 +9,6 @@ type UpdateMutabilityInSignatureFixTest() =
     inherit FSharpQuickFixTestBase<UpdateMutabilityInSignatureFix>()
     override x.RelativeTestDataPath = "features/quickFixes/updateMutabilityInSignatureFix"
     [<Test>] member x.``Add Mutability - 01`` () = x.DoNamedTestWithSignature()
+
+    [<Test>] member x.``Remove Mutability - 01`` () = x.DoNamedTestWithSignature()
+

--- a/ReSharper.FSharp/test/src/FSharp.Intentions.Tests/src/QuickFixes/UpdateMutabilityInSignatureFixTest.fs
+++ b/ReSharper.FSharp/test/src/FSharp.Intentions.Tests/src/QuickFixes/UpdateMutabilityInSignatureFixTest.fs
@@ -1,0 +1,11 @@
+﻿namespace JetBrains.ReSharper.Plugins.FSharp.Tests.Intentions.QuickFixes
+
+open JetBrains.ReSharper.Plugins.FSharp.Psi.Features.Daemon.QuickFixes
+open JetBrains.ReSharper.Plugins.FSharp.Tests
+open NUnit.Framework
+
+[<FSharpTest>]
+type UpdateMutabilityInSignatureFixTest() =
+    inherit FSharpQuickFixTestBase<UpdateMutabilityInSignatureFix>()
+    override x.RelativeTestDataPath = "features/quickFixes/updateMutabilityInSignatureFix"
+    [<Test>] member x.``Add Mutability - 01`` () = x.DoNamedTestWithSignature()


### PR DESCRIPTION
We are interested in providing some quick fixes for `FS0034`.

See [FSComp.txt](https://github.com/dotnet/fsharp/blob/723b1dc6310d773070804c0d258b2227c77d1ef8/src/Compiler/FSComp.txt#L102-L125)

![ValueNotContainedMutabilityAttributesDiffer](https://github.com/JetBrains/resharper-fsharp/assets/2621499/8ed7a80e-8676-465d-9828-89490ab0fac8)

Eventually, we would hope to address the 'Type mismatch' errors once the `GetValSignatureText` API is available. In the meantime, we can start with the smaller ones, like this PR.