### PR TITLE
Align bindingSignature with pars.fsy grammar rule.

### DIFF
--- a/ReSharper.FSharp/src/FSharp.Psi/src/FSharp.psi
+++ b/ReSharper.FSharp/src/FSharp.Psi/src/FSharp.psi
@@ -150,9 +150,9 @@ bindingSignature extras {
 }:
   attributeList<ATTRIBUTE_LIST, AttributeLists>*
   VAL<VAL, BindingKeyword>
-  accessModifier{ACCESS_MODIFIER, AccessModifier}?
   INLINE<INLINE, InlineKeyword>?
   MUTABLE<MUTABLE, MutableKeyword>?
+  accessModifier{ACCESS_MODIFIER, AccessModifier}?
   referencePat<HEAD_PATTERN, HeadPattern>
   returnTypeInfo<RETURN_INFO, ReturnTypeInfo>
   (


### PR DESCRIPTION
To align with https://github.com/dotnet/fsharp/blob/8eada0e8c6e28f077899b6757dba16f2dcfddbb8/src/Compiler/pars.fsy#L728