### PR TITLE
LambdaAnalyzer: improves for built-in functions

### DIFF
--- a/ReSharper.FSharp/src/FSharp/FSharp.Psi.Daemon/src/Analyzers/LambdaAnalyzer.fs
+++ b/ReSharper.FSharp/src/FSharp/FSharp.Psi.Daemon/src/Analyzers/LambdaAnalyzer.fs
@@ -207,7 +207,7 @@ type LambdaAnalyzer() =
             if hasOptionalArg then null else ctor arg
         | _ -> ctor arg
 
-    let tryCreateWarningForBuiltInFun (ctor: ILambdaExpr * string -> #IHighlighting) (lambda: ILambdaExpr, funName: string as arg) isFSharp6Supported =
+    let tryCreateWarningForBuiltInFun ctor (lambda: ILambdaExpr, funName: string as arg) isFSharp6Supported =
         if not (resolvesToPredefinedFunction lambda.RArrow funName "LambdaAnalyzer") then null else
         tryCreateWarning ctor arg isFSharp6Supported
 

--- a/ReSharper.FSharp/src/FSharp/FSharp.Psi.Daemon/src/Analyzers/LambdaAnalyzer.fs
+++ b/ReSharper.FSharp/src/FSharp/FSharp.Psi.Daemon/src/Analyzers/LambdaAnalyzer.fs
@@ -90,6 +90,9 @@ type LambdaAnalyzer() =
 
         compareArgsRec expr 0 null
 
+    let resolvesToPredefinedFunction (context: ILambdaExpr) funName =
+        resolvesToPredefinedFunction context.RArrow funName "LambdaAnalyzer"
+
     let hasExplicitConversion (lambda: ILambdaExpr) =
         let expr = lambda.Expression.IgnoreInnerParens()
 
@@ -338,14 +341,17 @@ type LambdaAnalyzer() =
                     if isFunctionInApp expr &funExpr &arg then
                         RedundantApplicationWarning(funExpr, arg) :> _
                     else
+                        if not (resolvesToPredefinedFunction lambda "id") then null else
                         tryCreateWarning LambdaCanBeReplacedWithBuiltinFunctionWarning (lambda,  "id") isFSharp60Supported :> _
                 else
                     match pat with
                     | :? ITuplePat as pat when not pat.IsStruct && pat.PatternsEnumerable.CountIs(2) ->
                         let tuplePats = pat.Patterns
                         if compareArg tuplePats[0] expr then
+                            if not (resolvesToPredefinedFunction lambda "fst") then null else
                             tryCreateWarning LambdaCanBeReplacedWithBuiltinFunctionWarning (lambda, "fst") isFSharp60Supported :> _
                         elif compareArg tuplePats[1] expr then
+                            if not (resolvesToPredefinedFunction lambda "snd") then null else
                             tryCreateWarning LambdaCanBeReplacedWithBuiltinFunctionWarning (lambda, "snd") isFSharp60Supported :> _
                         else null
                     | :? ILocalReferencePat as pat when isFSharp80Supported ->

--- a/ReSharper.FSharp/test/data/features/daemon/lambdaAnalyzer/Not available.fs
+++ b/ReSharper.FSharp/test/data/features/daemon/lambdaAnalyzer/Not available.fs
@@ -47,3 +47,8 @@ let (|One|Other|) x =
 <@ fun x -> x @>
 <@@ fun x -> x @@>
 <@ fun x -> f 1 x @>
+
+let id, fst, snd = 1, 2, 3
+fun x -> x
+fun (x, y) -> x
+fun (x, y) -> y

--- a/ReSharper.FSharp/test/data/features/daemon/lambdaAnalyzer/Not available.fs.gold
+++ b/ReSharper.FSharp/test/data/features/daemon/lambdaAnalyzer/Not available.fs.gold
@@ -48,6 +48,11 @@ let (|One|Other|) x =
 <@@ fun x -> x @@>
 <@ fun x -> f 1 x @>
 
+let id, fst, snd = 1, 2, 3
+fun x -> x
+fun (x, y) -> x
+fun (x, y) -> y
+
 ---------------------------------------------------------
 (0): ReSharper Dead Code: Redundant application
 (1): ReSharper Dead Code: Redundant application

--- a/ReSharper.FSharp/test/src/FSharp.Intentions.Tests/src/QuickFixes/ReplaceLambdaWithBuiltinFunctionTest.fs
+++ b/ReSharper.FSharp/test/src/FSharp.Intentions.Tests/src/QuickFixes/ReplaceLambdaWithBuiltinFunctionTest.fs
@@ -18,9 +18,9 @@ type ReplaceLambdaWithBuiltinFunctionTest() =
 
     [<Test>] member x.``Snd``() = x.DoNamedTest()
 
-    [<Test; NotAvailable>] member x.``Id - Names collision - not available``() = x.DoNamedTest()
-    [<Test; NotAvailable>] member x.``Fst - Names collision - not available``() = x.DoNamedTest()
-    [<Test; NotAvailable>] member x.``Snd - Names collision - not available``() = x.DoNamedTest()
+    [<Test; NoHighlightingFound>] member x.``Id - Names collision - not available``() = x.DoNamedTest()
+    [<Test; NoHighlightingFound>] member x.``Fst - Names collision - not available``() = x.DoNamedTest()
+    [<Test; NoHighlightingFound>] member x.``Snd - Names collision - not available``() = x.DoNamedTest()
 
 
 [<FSharpTest>]


### PR DESCRIPTION
Do not suggest warning without quickfix for a built-in function