### PR TITLE
Type Providers: recreate generative provided type instead of return stale

### DIFF
--- a/ReSharper.FSharp/src/FSharp/FSharp.TypeProviders.Protocol/src/Models/ProxyProvidedTypeWithContext.cs
+++ b/ReSharper.FSharp/src/FSharp/FSharp.TypeProviders.Protocol/src/Models/ProxyProvidedTypeWithContext.cs
@@ -149,7 +149,7 @@ namespace JetBrains.ReSharper.Plugins.FSharp.TypeProviders.Protocol.Models
       ProxyProvidedConstructorInfoWithContext.Create(myProvidedType.GetConstructors(), Context);
 
     public override ProvidedType ApplyContext(ProvidedTypeContext context) =>
-      Create(this, context);
+      Create(myProvidedType, context);
 
     public override ProvidedAssembly Assembly => myProvidedType.Assembly;
 

--- a/rider-fsharp/testData/solutions/TypeProviderLibrary/TypeProviderLibrary/ProvidersErrors.fs
+++ b/rider-fsharp/testData/solutions/TypeProviderLibrary/TypeProviderLibrary/ProvidersErrors.fs
@@ -17,3 +17,6 @@ let abstractInstance = AbstractType()
 SimpleErasedType().ReadonlyStringProperty <- ""
 
 type NumberRegex = Regex< 1 >
+
+let f (x: PetStore.Pet): string = x.Category.Name
+let g (x: PetStore.OperationTypes.UpdatePetWithForm_formUrlEncoded): string = x.Name

--- a/rider-fsharp/testData/typeProviders/GenerativeTypeProvidersTest/change abbreviation/gold/change abbreviation.gold
+++ b/rider-fsharp/testData/typeProviders/GenerativeTypeProvidersTest/change abbreviation/gold/change abbreviation.gold
@@ -21,6 +21,7 @@ Provided Assemblies:
 Provided Abbreviations:
 GUID(GenerativeTypeProvider)-A6CC28E6[.NETStandard,Version=v2.0] = 
 	GenerativeTypeProvider.SimpleGenerativeTypeAbbr
+	GenerativeTypeProvider.SimpleGenerativeTypeAbbr+GenerativeSubtype
 
 [Out-Process dump]:
 
@@ -77,6 +78,7 @@ Provided Assemblies:
 Provided Abbreviations:
 GUID(GenerativeTypeProvider)-A6CC28E6[.NETStandard,Version=v2.0] = 
 	GenerativeTypeProvider.SimpleGenerativeTypeAbbr1
+	GenerativeTypeProvider.SimpleGenerativeTypeAbbr1+GenerativeSubtype
 
 [Out-Process dump]:
 

--- a/rider-fsharp/testData/typeProviders/TypeProvidersCacheTest/checkCachesWhenProjectReloading/gold/checkCachesWhenProjectReloading_after.gold
+++ b/rider-fsharp/testData/typeProviders/TypeProvidersCacheTest/checkCachesWhenProjectReloading/gold/checkCachesWhenProjectReloading_after.gold
@@ -119,8 +119,16 @@ GUID(TypeProviderLibrary)-B9287C3D[.NETStandard,Version=v2.0] =
 	TypeProviderLibrary.SimpleGenerativeProvider+S
 	TypeProviderLibrary.SimpleGenerativeProvider+S+GenerativeSubtype
 	TypeProviderLibrary.SwaggerProvider+PetStore
+	TypeProviderLibrary.SwaggerProvider+PetStore+ApiResponse
+	TypeProviderLibrary.SwaggerProvider+PetStore+Category
 	TypeProviderLibrary.SwaggerProvider+PetStore+Client
 	TypeProviderLibrary.SwaggerProvider+PetStore+OperationTypes
+	TypeProviderLibrary.SwaggerProvider+PetStore+OperationTypes+UpdatePetWithForm_formUrlEncoded
+	TypeProviderLibrary.SwaggerProvider+PetStore+OperationTypes+UploadFile_formData
+	TypeProviderLibrary.SwaggerProvider+PetStore+Order
+	TypeProviderLibrary.SwaggerProvider+PetStore+Pet
+	TypeProviderLibrary.SwaggerProvider+PetStore+Tag
+	TypeProviderLibrary.SwaggerProvider+PetStore+User
 
 [Out-Process dump]:
 
@@ -193,6 +201,7 @@ SwaggerProvider.PetStore+OperationTypes+UploadFile_formData tp: 33 (from generat
 SwaggerProvider.PetStore+Order tp: 33 (from generated assembly)
 SwaggerProvider.PetStore+Pet tp: 33 (from generated assembly)
 SwaggerProvider.PetStore+Tag tp: 33 (from generated assembly)
+SwaggerProvider.PetStore+Tag[] tp: 33 (from generated assembly)
 SwaggerProvider.PetStore+User tp: 33 (from generated assembly)
 SwaggerProvider.SwaggerClientProvider tp: 34 (from SwaggerProvider.Runtime, Version=1.0.0.0, Culture=neutral)
 System.Collections.Generic.IEnumerable`1[FSharp.Text.RegexProvider.Regex,pattern="(?<AreaCode>^\\d{3})-(?<PhoneNumber>\\d{3}-\\d{4}$)",noMethodPrefix="True"+MatchType] tp: 32 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
@@ -210,6 +219,7 @@ Microsoft.FSharp.Control.FSharpHandler`1 tps: 35 (from FSharp.Core, Version=6.0.
 Microsoft.FSharp.Control.FSharpHandler`1[System.String] tps: 35 (from FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
 Microsoft.FSharp.Core.FSharpFunc`2 tps: 32 (from FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
 Microsoft.FSharp.Core.FSharpFunc`2[System.Text.RegularExpressions.Match,System.String] tps: 32 (from FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
+Microsoft.FSharp.Core.FSharpOption`1[System.Int64] tps: 33 (from FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
 Microsoft.FSharp.Core.Unit tps: 33|35 (from FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
 ProviderImplementation.InternalType tps: 35 (from TestTypeProviders, Version=1.0.0.0, Culture=neutral, PublicKeyToken=333a98252ac829ae)
 ProviderImplementation.IPrintable tps: 35 (from TestTypeProviders, Version=1.0.0.0, Culture=neutral, PublicKeyToken=333a98252ac829ae)
@@ -226,6 +236,7 @@ System.Object tps: 25|26|27|28|29|30|31 (from mscorlib, Version=4.0.0.0, Culture
 System.Object tps: 19|32|33|34|35|36 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
 System.String tps: 32|33|35|36 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
 System.String tps: 27 (from mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
+System.String[] tps: 33 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
 System.Text.RegularExpressions.Capture tps: 32 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
 System.Text.RegularExpressions.Group tps: 32 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
 System.Text.RegularExpressions.Match tps: 32 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
@@ -239,7 +250,7 @@ System.Threading.Tasks.Task`1[System.String] tps: 33 (from netstandard, Version=
 System.TimeSpan tps: 32 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
 System.ValueType tps: 27 (from mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
 System.ValueType tps: 32|33|35 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
-System.Void tps: 35|36 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
+System.Void tps: 33|35|36 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
 T tps: 32|35 (from FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
 TResult tps: 33 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
 TResult tps: 32 (from FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
@@ -259,12 +270,12 @@ SwaggerProvider.Runtime, Version=1.0.0.0, Culture=neutral tps: 33|34
 TestTypeProviders, Version=1.0.0.0, Culture=neutral, PublicKeyToken=333a98252ac829ae tps: 35|36
 
 ProvidedConstructorInfo:
-Count: 14
+Count: 20
 
 ProvidedMethodInfo:
-Count: 128
+Count: 177
 
 ProvidedPropertyInfo:
-Count: 15
+Count: 25
 
 SevereHighlighters:

--- a/rider-fsharp/testData/typeProviders/TypeProvidersCacheTest/checkCachesWhenProjectReloading/gold/checkCachesWhenProjectReloading_before.gold
+++ b/rider-fsharp/testData/typeProviders/TypeProvidersCacheTest/checkCachesWhenProjectReloading/gold/checkCachesWhenProjectReloading_before.gold
@@ -119,8 +119,16 @@ GUID(TypeProviderLibrary)-B9287C3D[.NETStandard,Version=v2.0] =
 	TypeProviderLibrary.SimpleGenerativeProvider+S
 	TypeProviderLibrary.SimpleGenerativeProvider+S+GenerativeSubtype
 	TypeProviderLibrary.SwaggerProvider+PetStore
+	TypeProviderLibrary.SwaggerProvider+PetStore+ApiResponse
+	TypeProviderLibrary.SwaggerProvider+PetStore+Category
 	TypeProviderLibrary.SwaggerProvider+PetStore+Client
 	TypeProviderLibrary.SwaggerProvider+PetStore+OperationTypes
+	TypeProviderLibrary.SwaggerProvider+PetStore+OperationTypes+UpdatePetWithForm_formUrlEncoded
+	TypeProviderLibrary.SwaggerProvider+PetStore+OperationTypes+UploadFile_formData
+	TypeProviderLibrary.SwaggerProvider+PetStore+Order
+	TypeProviderLibrary.SwaggerProvider+PetStore+Pet
+	TypeProviderLibrary.SwaggerProvider+PetStore+Tag
+	TypeProviderLibrary.SwaggerProvider+PetStore+User
 
 [Out-Process dump]:
 
@@ -193,6 +201,7 @@ SwaggerProvider.PetStore+OperationTypes+UploadFile_formData tp: 15 (from generat
 SwaggerProvider.PetStore+Order tp: 15 (from generated assembly)
 SwaggerProvider.PetStore+Pet tp: 15 (from generated assembly)
 SwaggerProvider.PetStore+Tag tp: 15 (from generated assembly)
+SwaggerProvider.PetStore+Tag[] tp: 15 (from generated assembly)
 SwaggerProvider.PetStore+User tp: 15 (from generated assembly)
 SwaggerProvider.SwaggerClientProvider tp: 16 (from SwaggerProvider.Runtime, Version=1.0.0.0, Culture=neutral)
 System.Collections.Generic.IEnumerable`1[FSharp.Text.RegexProvider.Regex,pattern="(?<AreaCode>^\\d{3})-(?<PhoneNumber>\\d{3}-\\d{4}$)",noMethodPrefix="True"+MatchType] tp: 14 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
@@ -210,6 +219,7 @@ Microsoft.FSharp.Control.FSharpHandler`1 tps: 17 (from FSharp.Core, Version=6.0.
 Microsoft.FSharp.Control.FSharpHandler`1[System.String] tps: 17 (from FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
 Microsoft.FSharp.Core.FSharpFunc`2 tps: 14 (from FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
 Microsoft.FSharp.Core.FSharpFunc`2[System.Text.RegularExpressions.Match,System.String] tps: 14 (from FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
+Microsoft.FSharp.Core.FSharpOption`1[System.Int64] tps: 15 (from FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
 Microsoft.FSharp.Core.Unit tps: 15|17 (from FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
 ProviderImplementation.InternalType tps: 17 (from TestTypeProviders, Version=1.0.0.0, Culture=neutral, PublicKeyToken=333a98252ac829ae)
 ProviderImplementation.IPrintable tps: 17 (from TestTypeProviders, Version=1.0.0.0, Culture=neutral, PublicKeyToken=333a98252ac829ae)
@@ -226,6 +236,7 @@ System.Object tps: 1|14|15|16|17|18 (from netstandard, Version=2.0.0.0, Culture=
 System.Object tps: 7|8|9|10|11|12|13 (from mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
 System.String tps: 14|15|17|18 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
 System.String tps: 9 (from mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
+System.String[] tps: 15 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
 System.Text.RegularExpressions.Capture tps: 14 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
 System.Text.RegularExpressions.Group tps: 14 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
 System.Text.RegularExpressions.Match tps: 14 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
@@ -239,7 +250,7 @@ System.Threading.Tasks.Task`1[System.String] tps: 15 (from netstandard, Version=
 System.TimeSpan tps: 14 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
 System.ValueType tps: 14|15|17 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
 System.ValueType tps: 9 (from mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
-System.Void tps: 17|18 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
+System.Void tps: 15|17|18 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
 T tps: 14|17 (from FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
 TResult tps: 14 (from FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
 TResult tps: 15 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
@@ -259,12 +270,12 @@ SwaggerProvider.Runtime, Version=1.0.0.0, Culture=neutral tps: 15|16
 TestTypeProviders, Version=1.0.0.0, Culture=neutral, PublicKeyToken=333a98252ac829ae tps: 17|18
 
 ProvidedConstructorInfo:
-Count: 14
+Count: 20
 
 ProvidedMethodInfo:
-Count: 128
+Count: 177
 
 ProvidedPropertyInfo:
-Count: 15
+Count: 25
 
 SevereHighlighters:

--- a/rider-fsharp/testData/typeProviders/TypeProvidersCacheTest/invalidation/gold/invalidation_after.gold
+++ b/rider-fsharp/testData/typeProviders/TypeProvidersCacheTest/invalidation/gold/invalidation_after.gold
@@ -119,8 +119,16 @@ GUID(TypeProviderLibrary)-B9287C3D[.NETStandard,Version=v2.0] =
 	TypeProviderLibrary.SimpleGenerativeProvider+S
 	TypeProviderLibrary.SimpleGenerativeProvider+S+GenerativeSubtype
 	TypeProviderLibrary.SwaggerProvider+PetStore
+	TypeProviderLibrary.SwaggerProvider+PetStore+ApiResponse
+	TypeProviderLibrary.SwaggerProvider+PetStore+Category
 	TypeProviderLibrary.SwaggerProvider+PetStore+Client
 	TypeProviderLibrary.SwaggerProvider+PetStore+OperationTypes
+	TypeProviderLibrary.SwaggerProvider+PetStore+OperationTypes+UpdatePetWithForm_formUrlEncoded
+	TypeProviderLibrary.SwaggerProvider+PetStore+OperationTypes+UploadFile_formData
+	TypeProviderLibrary.SwaggerProvider+PetStore+Order
+	TypeProviderLibrary.SwaggerProvider+PetStore+Pet
+	TypeProviderLibrary.SwaggerProvider+PetStore+Tag
+	TypeProviderLibrary.SwaggerProvider+PetStore+User
 
 [Out-Process dump]:
 
@@ -193,6 +201,7 @@ SwaggerProvider.PetStore+OperationTypes+UploadFile_formData tp: 15 (from generat
 SwaggerProvider.PetStore+Order tp: 15 (from generated assembly)
 SwaggerProvider.PetStore+Pet tp: 15 (from generated assembly)
 SwaggerProvider.PetStore+Tag tp: 15 (from generated assembly)
+SwaggerProvider.PetStore+Tag[] tp: 15 (from generated assembly)
 SwaggerProvider.PetStore+User tp: 15 (from generated assembly)
 SwaggerProvider.SwaggerClientProvider tp: 16 (from SwaggerProvider.Runtime, Version=1.0.0.0, Culture=neutral)
 System.Collections.Generic.IEnumerable`1[FSharp.Text.RegexProvider.Regex,pattern="(?<AreaCode>^\\d{3})-(?<PhoneNumber>\\d{3}-\\d{4}$)",noMethodPrefix="True"+MatchType] tp: 14 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
@@ -210,6 +219,7 @@ Microsoft.FSharp.Control.FSharpHandler`1 tps: 17 (from FSharp.Core, Version=6.0.
 Microsoft.FSharp.Control.FSharpHandler`1[System.String] tps: 17 (from FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
 Microsoft.FSharp.Core.FSharpFunc`2 tps: 14 (from FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
 Microsoft.FSharp.Core.FSharpFunc`2[System.Text.RegularExpressions.Match,System.String] tps: 14 (from FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
+Microsoft.FSharp.Core.FSharpOption`1[System.Int64] tps: 15 (from FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
 Microsoft.FSharp.Core.Unit tps: 15|17 (from FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
 ProviderImplementation.InternalType tps: 17 (from TestTypeProviders, Version=1.0.0.0, Culture=neutral, PublicKeyToken=333a98252ac829ae)
 ProviderImplementation.IPrintable tps: 17 (from TestTypeProviders, Version=1.0.0.0, Culture=neutral, PublicKeyToken=333a98252ac829ae)
@@ -226,6 +236,7 @@ System.Object tps: 1|14|15|16|17|18 (from netstandard, Version=2.0.0.0, Culture=
 System.Object tps: 7|8|10|11|12|13|20 (from mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
 System.String tps: 14|15|17|18 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
 System.String tps: 20 (from mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
+System.String[] tps: 15 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
 System.Text.RegularExpressions.Capture tps: 14 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
 System.Text.RegularExpressions.Group tps: 14 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
 System.Text.RegularExpressions.Match tps: 14 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
@@ -239,7 +250,7 @@ System.Threading.Tasks.Task`1[System.String] tps: 15 (from netstandard, Version=
 System.TimeSpan tps: 14 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
 System.ValueType tps: 14|15|17 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
 System.ValueType tps: 20 (from mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
-System.Void tps: 17|18 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
+System.Void tps: 15|17|18 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
 T tps: 14|17 (from FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
 TResult tps: 14 (from FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
 TResult tps: 15 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
@@ -259,12 +270,12 @@ SwaggerProvider.Runtime, Version=1.0.0.0, Culture=neutral tps: 15|16
 TestTypeProviders, Version=1.0.0.0, Culture=neutral, PublicKeyToken=333a98252ac829ae tps: 17|18
 
 ProvidedConstructorInfo:
-Count: 14
+Count: 20
 
 ProvidedMethodInfo:
-Count: 128
+Count: 177
 
 ProvidedPropertyInfo:
-Count: 15
+Count: 25
 
 SevereHighlighters:

--- a/rider-fsharp/testData/typeProviders/TypeProvidersCacheTest/invalidation/gold/invalidation_before.gold
+++ b/rider-fsharp/testData/typeProviders/TypeProvidersCacheTest/invalidation/gold/invalidation_before.gold
@@ -118,8 +118,16 @@ GUID(TypeProviderLibrary)-B9287C3D[.NETStandard,Version=v2.0] =
 	TypeProviderLibrary.SimpleGenerativeProvider+S
 	TypeProviderLibrary.SimpleGenerativeProvider+S+GenerativeSubtype
 	TypeProviderLibrary.SwaggerProvider+PetStore
+	TypeProviderLibrary.SwaggerProvider+PetStore+ApiResponse
+	TypeProviderLibrary.SwaggerProvider+PetStore+Category
 	TypeProviderLibrary.SwaggerProvider+PetStore+Client
 	TypeProviderLibrary.SwaggerProvider+PetStore+OperationTypes
+	TypeProviderLibrary.SwaggerProvider+PetStore+OperationTypes+UpdatePetWithForm_formUrlEncoded
+	TypeProviderLibrary.SwaggerProvider+PetStore+OperationTypes+UploadFile_formData
+	TypeProviderLibrary.SwaggerProvider+PetStore+Order
+	TypeProviderLibrary.SwaggerProvider+PetStore+Pet
+	TypeProviderLibrary.SwaggerProvider+PetStore+Tag
+	TypeProviderLibrary.SwaggerProvider+PetStore+User
 
 [Out-Process dump]:
 
@@ -191,6 +199,7 @@ SwaggerProvider.PetStore+OperationTypes+UploadFile_formData tp: 15 (from generat
 SwaggerProvider.PetStore+Order tp: 15 (from generated assembly)
 SwaggerProvider.PetStore+Pet tp: 15 (from generated assembly)
 SwaggerProvider.PetStore+Tag tp: 15 (from generated assembly)
+SwaggerProvider.PetStore+Tag[] tp: 15 (from generated assembly)
 SwaggerProvider.PetStore+User tp: 15 (from generated assembly)
 SwaggerProvider.SwaggerClientProvider tp: 16 (from SwaggerProvider.Runtime, Version=1.0.0.0, Culture=neutral)
 System.Collections.Generic.IEnumerable`1[FSharp.Text.RegexProvider.Regex,pattern="(?<AreaCode>^\\d{3})-(?<PhoneNumber>\\d{3}-\\d{4}$)",noMethodPrefix="True"+MatchType] tp: 14 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
@@ -208,6 +217,7 @@ Microsoft.FSharp.Control.FSharpHandler`1 tps: 17 (from FSharp.Core, Version=6.0.
 Microsoft.FSharp.Control.FSharpHandler`1[System.String] tps: 17 (from FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
 Microsoft.FSharp.Core.FSharpFunc`2 tps: 14 (from FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
 Microsoft.FSharp.Core.FSharpFunc`2[System.Text.RegularExpressions.Match,System.String] tps: 14 (from FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
+Microsoft.FSharp.Core.FSharpOption`1[System.Int64] tps: 15 (from FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
 Microsoft.FSharp.Core.Unit tps: 15|17 (from FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
 ProviderImplementation.InternalType tps: 17 (from TestTypeProviders, Version=1.0.0.0, Culture=neutral, PublicKeyToken=333a98252ac829ae)
 ProviderImplementation.IPrintable tps: 17 (from TestTypeProviders, Version=1.0.0.0, Culture=neutral, PublicKeyToken=333a98252ac829ae)
@@ -224,6 +234,7 @@ System.Object tps: 1|14|15|16|17|18 (from netstandard, Version=2.0.0.0, Culture=
 System.Object tps: 7|8|10|11|12|13|19 (from mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
 System.String tps: 14|15|17|18 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
 System.String tps: 19 (from mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
+System.String[] tps: 15 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
 System.Text.RegularExpressions.Capture tps: 14 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
 System.Text.RegularExpressions.Group tps: 14 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
 System.Text.RegularExpressions.Match tps: 14 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
@@ -237,7 +248,7 @@ System.Threading.Tasks.Task`1[System.String] tps: 15 (from netstandard, Version=
 System.TimeSpan tps: 14 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
 System.ValueType tps: 14|15|17 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
 System.ValueType tps: 19 (from mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
-System.Void tps: 17|18 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
+System.Void tps: 15|17|18 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
 T tps: 14|17 (from FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
 TResult tps: 14 (from FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
 TResult tps: 15 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
@@ -257,13 +268,13 @@ SwaggerProvider.Runtime, Version=1.0.0.0, Culture=neutral tps: 15|16
 TestTypeProviders, Version=1.0.0.0, Culture=neutral, PublicKeyToken=333a98252ac829ae tps: 17|18
 
 ProvidedConstructorInfo:
-Count: 14
+Count: 20
 
 ProvidedMethodInfo:
-Count: 128
+Count: 177
 
 ProvidedPropertyInfo:
-Count: 15
+Count: 25
 
 SevereHighlighters:
 ReSharper Error Unresolved - (348, 352) - Test - 

--- a/rider-fsharp/testData/typeProviders/TypeProvidersCacheTest/projectsWithEqualProviders/gold/projectsWithEqualProviders.gold
+++ b/rider-fsharp/testData/typeProviders/TypeProvidersCacheTest/projectsWithEqualProviders/gold/projectsWithEqualProviders.gold
@@ -134,8 +134,16 @@ GUID(TypeProviderLibrary)-B9287C3D[.NETStandard,Version=v2.0] =
 	TypeProviderLibrary.SimpleGenerativeProvider+S
 	TypeProviderLibrary.SimpleGenerativeProvider+S+GenerativeSubtype
 	TypeProviderLibrary.SwaggerProvider+PetStore
+	TypeProviderLibrary.SwaggerProvider+PetStore+ApiResponse
+	TypeProviderLibrary.SwaggerProvider+PetStore+Category
 	TypeProviderLibrary.SwaggerProvider+PetStore+Client
 	TypeProviderLibrary.SwaggerProvider+PetStore+OperationTypes
+	TypeProviderLibrary.SwaggerProvider+PetStore+OperationTypes+UpdatePetWithForm_formUrlEncoded
+	TypeProviderLibrary.SwaggerProvider+PetStore+OperationTypes+UploadFile_formData
+	TypeProviderLibrary.SwaggerProvider+PetStore+Order
+	TypeProviderLibrary.SwaggerProvider+PetStore+Pet
+	TypeProviderLibrary.SwaggerProvider+PetStore+Tag
+	TypeProviderLibrary.SwaggerProvider+PetStore+User
 
 [Out-Process dump]:
 
@@ -220,6 +228,7 @@ SwaggerProvider.PetStore+OperationTypes+UploadFile_formData tp: 15 (from generat
 SwaggerProvider.PetStore+Order tp: 15 (from generated assembly)
 SwaggerProvider.PetStore+Pet tp: 15 (from generated assembly)
 SwaggerProvider.PetStore+Tag tp: 15 (from generated assembly)
+SwaggerProvider.PetStore+Tag[] tp: 15 (from generated assembly)
 SwaggerProvider.PetStore+User tp: 15 (from generated assembly)
 SwaggerProvider.SwaggerClientProvider tp: 16 (from SwaggerProvider.Runtime, Version=1.0.0.0, Culture=neutral)
 System.Collections.Generic.IEnumerable`1[FSharp.Text.RegexProvider.Regex,pattern="(?<AreaCode>^\\d{3})-(?<PhoneNumber>\\d{3}-\\d{4}$)",noMethodPrefix="True"+MatchType] tp: 14 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
@@ -240,6 +249,7 @@ Microsoft.FSharp.Control.FSharpHandler`1 tps: 17 (from FSharp.Core, Version=6.0.
 Microsoft.FSharp.Control.FSharpHandler`1[System.String] tps: 17 (from FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
 Microsoft.FSharp.Core.FSharpFunc`2 tps: 14|19 (from FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
 Microsoft.FSharp.Core.FSharpFunc`2[System.Text.RegularExpressions.Match,System.String] tps: 14 (from FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
+Microsoft.FSharp.Core.FSharpOption`1[System.Int64] tps: 15 (from FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
 Microsoft.FSharp.Core.Unit tps: 15|17 (from FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
 ProviderImplementation.InternalType tps: 17 (from TestTypeProviders, Version=1.0.0.0, Culture=neutral, PublicKeyToken=333a98252ac829ae)
 ProviderImplementation.IPrintable tps: 17 (from TestTypeProviders, Version=1.0.0.0, Culture=neutral, PublicKeyToken=333a98252ac829ae)
@@ -256,6 +266,7 @@ System.Object tps: 1|14|15|16|17|18|19 (from netstandard, Version=2.0.0.0, Cultu
 System.Object tps: 7|8|9|10|11|12|13 (from mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
 System.String tps: 14|15|17|18|19 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
 System.String tps: 9 (from mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
+System.String[] tps: 15 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
 System.Text.RegularExpressions.Capture tps: 14 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
 System.Text.RegularExpressions.Group tps: 14|19 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
 System.Text.RegularExpressions.Match tps: 14|19 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
@@ -269,7 +280,7 @@ System.Threading.Tasks.Task`1[System.String] tps: 15 (from netstandard, Version=
 System.TimeSpan tps: 14|19 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
 System.ValueType tps: 14|15|17 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
 System.ValueType tps: 9 (from mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
-System.Void tps: 17|18 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
+System.Void tps: 15|17|18 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
 T tps: 14|17 (from FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
 TResult tps: 14 (from FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
 TResult tps: 15 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
@@ -289,12 +300,12 @@ SwaggerProvider.Runtime, Version=1.0.0.0, Culture=neutral tps: 15|16
 TestTypeProviders, Version=1.0.0.0, Culture=neutral, PublicKeyToken=333a98252ac829ae tps: 17|18
 
 ProvidedConstructorInfo:
-Count: 23
+Count: 29
 
 ProvidedMethodInfo:
-Count: 191
+Count: 240
 
 ProvidedPropertyInfo:
-Count: 23
+Count: 33
 
 SevereHighlighters:

--- a/rider-fsharp/testData/typeProviders/TypeProvidersCacheTest/typing/gold/typing.gold
+++ b/rider-fsharp/testData/typeProviders/TypeProvidersCacheTest/typing/gold/typing.gold
@@ -119,8 +119,16 @@ GUID(TypeProviderLibrary)-B9287C3D[.NETStandard,Version=v2.0] =
 	TypeProviderLibrary.SimpleGenerativeProvider+S
 	TypeProviderLibrary.SimpleGenerativeProvider+S+GenerativeSubtype
 	TypeProviderLibrary.SwaggerProvider+PetStore
+	TypeProviderLibrary.SwaggerProvider+PetStore+ApiResponse
+	TypeProviderLibrary.SwaggerProvider+PetStore+Category
 	TypeProviderLibrary.SwaggerProvider+PetStore+Client
 	TypeProviderLibrary.SwaggerProvider+PetStore+OperationTypes
+	TypeProviderLibrary.SwaggerProvider+PetStore+OperationTypes+UpdatePetWithForm_formUrlEncoded
+	TypeProviderLibrary.SwaggerProvider+PetStore+OperationTypes+UploadFile_formData
+	TypeProviderLibrary.SwaggerProvider+PetStore+Order
+	TypeProviderLibrary.SwaggerProvider+PetStore+Pet
+	TypeProviderLibrary.SwaggerProvider+PetStore+Tag
+	TypeProviderLibrary.SwaggerProvider+PetStore+User
 
 [Out-Process dump]:
 
@@ -193,6 +201,7 @@ SwaggerProvider.PetStore+OperationTypes+UploadFile_formData tp: 15 (from generat
 SwaggerProvider.PetStore+Order tp: 15 (from generated assembly)
 SwaggerProvider.PetStore+Pet tp: 15 (from generated assembly)
 SwaggerProvider.PetStore+Tag tp: 15 (from generated assembly)
+SwaggerProvider.PetStore+Tag[] tp: 15 (from generated assembly)
 SwaggerProvider.PetStore+User tp: 15 (from generated assembly)
 SwaggerProvider.SwaggerClientProvider tp: 16 (from SwaggerProvider.Runtime, Version=1.0.0.0, Culture=neutral)
 System.Collections.Generic.IEnumerable`1[FSharp.Text.RegexProvider.Regex,pattern="(?<AreaCode>^\\d{3})-(?<PhoneNumber>\\d{3}-\\d{4}$)",noMethodPrefix="True"+MatchType] tp: 14 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
@@ -210,6 +219,7 @@ Microsoft.FSharp.Control.FSharpHandler`1 tps: 17 (from FSharp.Core, Version=6.0.
 Microsoft.FSharp.Control.FSharpHandler`1[System.String] tps: 17 (from FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
 Microsoft.FSharp.Core.FSharpFunc`2 tps: 14 (from FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
 Microsoft.FSharp.Core.FSharpFunc`2[System.Text.RegularExpressions.Match,System.String] tps: 14 (from FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
+Microsoft.FSharp.Core.FSharpOption`1[System.Int64] tps: 15 (from FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
 Microsoft.FSharp.Core.Unit tps: 15|17 (from FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
 ProviderImplementation.InternalType tps: 17 (from TestTypeProviders, Version=1.0.0.0, Culture=neutral, PublicKeyToken=333a98252ac829ae)
 ProviderImplementation.IPrintable tps: 17 (from TestTypeProviders, Version=1.0.0.0, Culture=neutral, PublicKeyToken=333a98252ac829ae)
@@ -226,6 +236,7 @@ System.Object tps: 1|14|15|16|17|18 (from netstandard, Version=2.0.0.0, Culture=
 System.Object tps: 7|8|9|10|11|12|13 (from mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
 System.String tps: 14|15|17|18 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
 System.String tps: 9 (from mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
+System.String[] tps: 15 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
 System.Text.RegularExpressions.Capture tps: 14 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
 System.Text.RegularExpressions.Group tps: 14 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
 System.Text.RegularExpressions.Match tps: 14 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
@@ -239,7 +250,7 @@ System.Threading.Tasks.Task`1[System.String] tps: 15 (from netstandard, Version=
 System.TimeSpan tps: 14 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
 System.ValueType tps: 14|15|17 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
 System.ValueType tps: 9 (from mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
-System.Void tps: 17|18 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
+System.Void tps: 15|17|18 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
 T tps: 14|17 (from FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
 TResult tps: 14 (from FSharp.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
 TResult tps: 15 (from netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51)
@@ -259,12 +270,12 @@ SwaggerProvider.Runtime, Version=1.0.0.0, Culture=neutral tps: 15|16
 TestTypeProviders, Version=1.0.0.0, Culture=neutral, PublicKeyToken=333a98252ac829ae tps: 17|18
 
 ProvidedConstructorInfo:
-Count: 14
+Count: 20
 
 ProvidedMethodInfo:
-Count: 128
+Count: 177
 
 ProvidedPropertyInfo:
-Count: 15
+Count: 25
 
 SevereHighlighters:


### PR DESCRIPTION
Fix for https://youtrack.jetbrains.com/issue/RIDER-106899/YamlConfig-instance-type-detected-as-incompatible-with-itself-when-in-a-function-in-another-file

- [x] Update gold