### PR TITLE
Psi/Frontend: add FSharpScriptFileImpl

### DIFF
--- a/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/FSharpParserDefinition.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/FSharpParserDefinition.kt
@@ -12,7 +12,6 @@ import com.intellij.psi.util.PsiUtilCore
 import com.jetbrains.rd.platform.util.getLogger
 import com.jetbrains.rider.ideaInterop.fileTypes.fsharp.lexer.FSharpLexer
 import com.jetbrains.rider.ideaInterop.fileTypes.fsharp.lexer.FSharpTokenType
-import com.jetbrains.rider.ideaInterop.fileTypes.fsharp.psi.FSharpFile
 import com.jetbrains.rider.ideaInterop.fileTypes.fsharp.psi.impl.FSharpElementTypes
 import com.jetbrains.rider.ideaInterop.fileTypes.fsharp.psi.impl.FSharpFileImpl
 import com.jetbrains.rider.ideaInterop.fileTypes.fsharp.psi.impl.FSharpScriptFileImpl
@@ -35,10 +34,10 @@ class FSharpParserDefinition : ParserDefinition {
     }
 
     override fun createFile(viewProvider: FileViewProvider) =
-        when (val extension = viewProvider.fileType.defaultExtension) {
-            "fs" -> FSharpFileImpl(viewProvider)
-            "fsx" -> FSharpScriptFileImpl(viewProvider)
-            else -> error("Unexpected file type $extension")
+        when (val fileType = viewProvider.fileType) {
+            FSharpFileType -> FSharpFileImpl(viewProvider)
+            FSharpScriptFileType -> FSharpScriptFileImpl(viewProvider)
+            else -> error("Unexpected file type $fileType")
       }
 
     override fun getFileNodeType(): IFileElementType = FSharpElementTypes.FILE

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/FSharpParserDefinition.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/FSharpParserDefinition.kt
@@ -12,8 +12,10 @@ import com.intellij.psi.util.PsiUtilCore
 import com.jetbrains.rd.platform.util.getLogger
 import com.jetbrains.rider.ideaInterop.fileTypes.fsharp.lexer.FSharpLexer
 import com.jetbrains.rider.ideaInterop.fileTypes.fsharp.lexer.FSharpTokenType
+import com.jetbrains.rider.ideaInterop.fileTypes.fsharp.psi.FSharpFile
 import com.jetbrains.rider.ideaInterop.fileTypes.fsharp.psi.impl.FSharpElementTypes
 import com.jetbrains.rider.ideaInterop.fileTypes.fsharp.psi.impl.FSharpFileImpl
+import com.jetbrains.rider.ideaInterop.fileTypes.fsharp.psi.impl.FSharpScriptFileImpl
 
 class FSharpParserDefinition : ParserDefinition {
     private val logger = getLogger<FSharpParserDefinition>()
@@ -32,6 +34,12 @@ class FSharpParserDefinition : ParserDefinition {
         return PsiUtilCore.NULL_PSI_ELEMENT
     }
 
-    override fun createFile(viewProvider: FileViewProvider) = FSharpFileImpl(viewProvider)
+    override fun createFile(viewProvider: FileViewProvider) =
+        when (val extension = viewProvider.fileType.defaultExtension) {
+            "fs" -> FSharpFileImpl(viewProvider)
+            "fsx" -> FSharpScriptFileImpl(viewProvider)
+            else -> error("Unexpected file type $extension")
+      }
+
     override fun getFileNodeType(): IFileElementType = FSharpElementTypes.FILE
 }

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/psi/impl/FSharpFileImpl.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/psi/impl/FSharpFileImpl.kt
@@ -4,8 +4,13 @@ import com.intellij.extapi.psi.PsiFileBase
 import com.intellij.psi.FileViewProvider
 import com.jetbrains.rider.ideaInterop.fileTypes.fsharp.FSharpFileType
 import com.jetbrains.rider.ideaInterop.fileTypes.fsharp.FSharpLanguage
+import com.jetbrains.rider.ideaInterop.fileTypes.fsharp.FSharpScriptFileType
 import com.jetbrains.rider.ideaInterop.fileTypes.fsharp.psi.FSharpFile
 
 class FSharpFileImpl(viewProvider: FileViewProvider) : FSharpFile, PsiFileBase(viewProvider, FSharpLanguage) {
   override fun getFileType() = FSharpFileType
+}
+
+class FSharpScriptFileImpl(viewProvider: FileViewProvider) : FSharpFile, PsiFileBase(viewProvider, FSharpLanguage) {
+  override fun getFileType() = FSharpScriptFileType
 }

--- a/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/parser/FSharpDummyParserTest.kt
+++ b/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/parser/FSharpDummyParserTest.kt
@@ -1,9 +1,19 @@
 package com.jetbrains.rider.plugins.fsharp.test.cases.parser
 
+import com.intellij.psi.PsiFile
 import com.jetbrains.rider.ideaInterop.fileTypes.fsharp.FSharpParserDefinition
+import com.jetbrains.rider.ideaInterop.fileTypes.fsharp.psi.impl.FSharpFileImpl
+import com.jetbrains.rider.ideaInterop.fileTypes.fsharp.psi.impl.FSharpScriptFileImpl
 import com.jetbrains.rider.test.RiderFrontendParserTest
+import org.junit.Assert
 
 class FSharpDummyParserTests : RiderFrontendParserTest("", "fs", FSharpParserDefinition()) {
+  override fun parseFile(name: String?, text: String?): PsiFile {
+    val file = super.parseFile(name, text)
+    Assert.assertTrue(file is FSharpFileImpl)
+    return file
+  }
+
   fun `test empty`() = doTest()
   fun `test concatenation 01 - simple`() = doTest()
   fun `test concatenation 02 - space before plus`() = doTest()
@@ -30,4 +40,15 @@ class FSharpDummyParserTests : RiderFrontendParserTest("", "fs", FSharpParserDef
   fun `test unfinished 02 - interpolated 01`() = doTest()
   fun `test unfinished 02 - interpolated 02`() = doTest()
   fun `test unfinished 03 - interpolated in interpolated`() = doTest()
+}
+
+
+class FSharpScriptDummyParserTests : RiderFrontendParserTest("", "fsx", FSharpParserDefinition()) {
+  override fun parseFile(name: String?, text: String?): PsiFile {
+    val file = super.parseFile(name, text)
+    Assert.assertTrue(file is FSharpScriptFileImpl)
+    return file
+  }
+
+  fun `test empty`() = doTest()
 }

--- a/rider-fsharp/testData/parser/FSharpScriptDummyParserTests/empty.txt
+++ b/rider-fsharp/testData/parser/FSharpScriptDummyParserTests/empty.txt
@@ -1,0 +1,2 @@
+FSharpFile
+  <empty list>


### PR DESCRIPTION
it is necessary to distinguish standard files from scripts