### PR TITLE
Fix RIDER-96095: decouple the plugin from IntelliLang

### DIFF
--- a/rider-fsharp/src/main/resources/META-INF/plugin.xml
+++ b/rider-fsharp/src/main/resources/META-INF/plugin.xml
@@ -8,22 +8,14 @@
   <version>0.9999</version>
 
   <depends>com.intellij.modules.rider</depends>
-  <depends>org.intellij.intelliLang</depends>
   <depends>rider.intellij.plugin.appender</depends>
 
   <content>
     <module name="intellij.rider.plugins.fsharp/llm" />
+    <module name="intellij.rider.plugins.fsharp/injections" />
   </content>
 
-  <extensions defaultExtensionNs="org.intellij.intelliLang">
-    <languageSupport implementation="com.jetbrains.rider.ideaInterop.fileTypes.fsharp.injections.FSharpInjectionSupport"/>
-    <injectionConfig config="fsharpInjections.xml" />
-  </extensions>
-
   <extensions defaultExtensionNs="com.intellij">
-    <sql.resolveExtension implementation="com.jetbrains.rider.ideaInterop.fileTypes.fsharp.injections.FSharpSqlDapperParameterResolveExtension"/>
-    <multiHostInjector implementation="com.jetbrains.rider.ideaInterop.fileTypes.fsharp.injections.FSharpConcatenationToInjectorAdapter" order="first" />
-    <concatenationAwareInjector implementation="com.jetbrains.rider.ideaInterop.fileTypes.fsharp.injections.FSharpConcatenationAwareInjector" />
     <fileType name="F#" language="F#" extensions="fs;fsi;ml;mli" implementationClass="com.jetbrains.rider.ideaInterop.fileTypes.fsharp.FSharpFileType" fieldName="INSTANCE"/>
     <fileType name="F# Script" language="F#" extensions="fsx;fsscript" implementationClass="com.jetbrains.rider.ideaInterop.fileTypes.fsharp.FSharpScriptFileType" fieldName="INSTANCE"/>
 

--- a/rider-fsharp/src/main/resources/intellij.rider.plugins.fsharp.injections.xml
+++ b/rider-fsharp/src/main/resources/intellij.rider.plugins.fsharp.injections.xml
@@ -1,0 +1,18 @@
+<idea-plugin package="com.jetbrains.rider.ideaInterop.fileTypes.fsharp.injections">
+
+    <dependencies>
+        <plugin id="com.intellij.ml.llm"/>
+        <plugin id="org.intellij.intelliLang"/>
+    </dependencies>
+
+    <extensions defaultExtensionNs="org.intellij.intelliLang">
+        <languageSupport implementation="com.jetbrains.rider.ideaInterop.fileTypes.fsharp.injections.FSharpInjectionSupport"/>
+        <injectionConfig config="fsharpInjections.xml" />
+    </extensions>
+
+    <extensions defaultExtensionNs="com.intellij">
+        <multiHostInjector implementation="com.jetbrains.rider.ideaInterop.fileTypes.fsharp.injections.FSharpConcatenationToInjectorAdapter" order="first" />
+        <concatenationAwareInjector implementation="com.jetbrains.rider.ideaInterop.fileTypes.fsharp.injections.FSharpConcatenationAwareInjector" />
+        <sql.resolveExtension implementation="com.jetbrains.rider.ideaInterop.fileTypes.fsharp.injections.FSharpSqlDapperParameterResolveExtension"/>
+    </extensions>
+</idea-plugin>


### PR DESCRIPTION
The plugin no longer has a strong dependency on IntelliLang. All the injection-dependent stuff has been moved to an optional v2 module.