### PR TITLE
F# Interactive: fix output syntax highlighting

### DIFF
--- a/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/highlighting/FSharpSyntaxHighlighterFactory.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/ideaInterop/fileTypes/fsharp/highlighting/FSharpSyntaxHighlighterFactory.kt
@@ -8,8 +8,10 @@ import com.intellij.psi.tree.IElementType
 import com.jetbrains.rider.ideaInterop.fileTypes.fsharp.lexer.FSharpLexer
 import com.jetbrains.rider.ideaInterop.fileTypes.fsharp.lexer.FSharpTokenType.*
 
-class FSharpSyntaxHighlighter : SyntaxHighlighterBase() {
+open class FSharpSyntaxHighlighter : SyntaxHighlighterBase() {
   companion object {
+    val Instance = FSharpSyntaxHighlighter()
+
     private val keywords = IDENT_KEYWORDS.types.map { it to FSharpTextAttributeKeys.KEYWORD }
     private val pp_keywords = PP_KEYWORDS.types.map { it to FSharpTextAttributeKeys.PREPROCESSOR_KEYWORD }
     private val strings = STRINGS.types.map { it to FSharpTextAttributeKeys.STRING }
@@ -27,4 +29,16 @@ class FSharpSyntaxHighlighter : SyntaxHighlighterBase() {
 
   override fun getHighlightingLexer() = FSharpLexer()
   override fun getTokenHighlights(tokenType: IElementType): Array<TextAttributesKey> = pack(ourKeys[tokenType])
+}
+
+
+class FsiOutputSyntaxHighlighter : FSharpSyntaxHighlighter() {
+  companion object {
+    val Instance = FsiOutputSyntaxHighlighter()
+  }
+
+  override fun getTokenHighlights(tokenType: IElementType): Array<TextAttributesKey> {
+    return if (tokenType == TokenType.BAD_CHARACTER) TextAttributesKey.EMPTY_ARRAY
+    else super.getTokenHighlights(tokenType)
+  }
 }

--- a/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/FsiInputOutputProcessor.kt
+++ b/rider-fsharp/src/main/java/com/jetbrains/rider/plugins/fsharp/services/fsi/FsiInputOutputProcessor.kt
@@ -8,13 +8,15 @@ import com.intellij.openapi.editor.markup.HighlighterLayer
 import com.intellij.openapi.editor.markup.HighlighterTargetArea
 import com.intellij.util.concurrency.ThreadingAssertions
 import com.jetbrains.rider.ideaInterop.fileTypes.fsharp.highlighting.FSharpSyntaxHighlighter
+import com.jetbrains.rider.ideaInterop.fileTypes.fsharp.highlighting.FsiOutputSyntaxHighlighter
 import com.jetbrains.rider.plugins.fsharp.services.fsi.consoleRunners.FsiConsoleRunnerBase
 
 class FsiInputOutputProcessor(private val fsiRunner: FsiConsoleRunnerBase) {
   private var isInitialText = true
   private var nextOutputTextIsFirst = true
 
-  private val fSharpSyntaxHighlighter = FSharpSyntaxHighlighter()
+  private val fSharpSyntaxHighlighter = FSharpSyntaxHighlighter.Instance
+  private val fsiOutputSyntaxHighlighter = FsiOutputSyntaxHighlighter.Instance
 
   private fun fsiIconWithTooltipOnOutputText(outputType: ConsoleViewContentType): IconWithTooltip? {
     if (nextOutputTextIsFirst) {
@@ -44,7 +46,7 @@ class FsiInputOutputProcessor(private val fsiRunner: FsiConsoleRunnerBase) {
 
       when (outputType) {
         ConsoleViewContentType.NORMAL_OUTPUT ->
-          printText(text, fsiResultIconWithTooltip, fSharpSyntaxHighlighter, outputType)
+          printText(text, fsiResultIconWithTooltip, fsiOutputSyntaxHighlighter, outputType)
 
         ConsoleViewContentType.ERROR_OUTPUT ->
           printText(text, fsiResultIconWithTooltip, null, outputType)


### PR DESCRIPTION
Before:

![image](https://github.com/JetBrains/resharper-fsharp/assets/26364714/fc3e8097-50af-4a08-a811-eeb79aab4461)


After:

![image](https://github.com/JetBrains/resharper-fsharp/assets/26364714/27a9a5c8-dcf6-4553-a362-4855f7483639)