### PR TITLE
Language injections: fix F# external annotations detection for the Rider bundle

### DIFF
--- a/ReSharper.FSharp/src/FSharp/FSharp.Psi/src/Annotations/FSharpExternalAnnotationsFileProvider.cs
+++ b/ReSharper.FSharp/src/FSharp/FSharp.Psi/src/Annotations/FSharpExternalAnnotationsFileProvider.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using JetBrains.Application;
+using JetBrains.Metadata.Utils;
+using JetBrains.ReSharper.Psi.ExtensionsAPI.ExternalAnnotations;
+using JetBrains.Util;
+
+namespace JetBrains.ReSharper.Plugins.FSharp.Psi.Annotations
+{
+  // TODO: fix for application packages detection in the platform
+  [ShellComponent]
+  public class FSharpExternalAnnotationsFileProvider : IExternalAnnotationsFileProvider
+  {
+    private readonly OneToSetMap<string, VirtualFileSystemPath> myAnnotations;
+
+    public FSharpExternalAnnotationsFileProvider()
+    {
+      myAnnotations = new OneToSetMap<string, VirtualFileSystemPath>(StringComparer.OrdinalIgnoreCase);
+
+      var executingFolder = Assembly.GetExecutingAssembly().TryGetPath().ToVirtualFileSystemPath().Parent;
+      var annotationsFolder = executingFolder / "Extensions" / "com.jetbrains.rider.fsharp" / "annotations";
+      if (!annotationsFolder.ExistsDirectory) return;
+
+      foreach (var file in annotationsFolder.GetChildFiles()) myAnnotations.Add(file.NameWithoutExtension, file);
+    }
+
+    public IEnumerable<VirtualFileSystemPath> GetAnnotationsFiles(AssemblyNameInfo assemblyName = null,
+      VirtualFileSystemPath assemblyLocation = null)
+    {
+      return assemblyName == null ? myAnnotations.Values : myAnnotations[assemblyName.Name];
+    }
+  }
+}

--- a/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/markup/injections/FSharpLanguageInjectionTest.kt
+++ b/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/markup/injections/FSharpLanguageInjectionTest.kt
@@ -56,7 +56,6 @@ class FSharpLanguageInjectionTest : BaseTestWithMarkup() {
   fun testInjectionByFunction() = doTest()
 
   @Test
-  @Mute("RIDER-102632")
   @TestEnvironment(solution = "FableApp")
   fun testInjectionByExternalAnnotation() = doTest()
 }


### PR DESCRIPTION
Fix for https://youtrack.jetbrains.com/issue/RIDER-102632

There is a problem with the folder structure in the Rider bundle, and it is unclear when it can be fixed, so this PR suggests manually specifying the path to external annotations for the plugin.