### PR TITLE
Inlay Hints: Add bulb actions for type hints

### DIFF
--- a/ReSharper.FSharp/src/FSharp/FSharp.Psi.Daemon/FSharp.Psi.Daemon.fsproj
+++ b/ReSharper.FSharp/src/FSharp/FSharp.Psi.Daemon/FSharp.Psi.Daemon.fsproj
@@ -27,6 +27,7 @@
     <Compile Include="src\Options\FSharpTypeHintOptionsPage.fs" />
     <Compile Include="src\Options\FSharpTypeHintsOptionsRegistrator.fs" />
     <Compile Include="src\ReadLockCookieUtil.fs" />
+    <Compile Include="src\Highlightings\FSharpTypeHintBulbActionsProvider.fs" />
     <Compile Include="src\Highlightings\TypeHintHighlighting.fs" />
     <Compile Include="src\ContextHighlighters\FSharpMatchingBraceContextHighlighter.fs" />
     <Compile Include="src\QuickDoc\FSharpQuickDocProvider.fs" />

--- a/ReSharper.FSharp/src/FSharp/FSharp.Psi.Daemon/src/Highlightings/FSharpTypeHintBulbActionsProvider.fs
+++ b/ReSharper.FSharp/src/FSharp/FSharp.Psi.Daemon/src/Highlightings/FSharpTypeHintBulbActionsProvider.fs
@@ -1,0 +1,39 @@
+module JetBrains.ReSharper.Plugins.FSharp.Psi.Daemon.Highlightings.FSharpTypeHintsBulbActionsProvider
+
+open System
+open System.Linq.Expressions
+open JetBrains.Application.I18n
+open JetBrains.Application.Settings
+open JetBrains.Application.UI.Controls.BulbMenu.Anchors
+open JetBrains.ReSharper.Feature.Services.Daemon
+open JetBrains.ReSharper.Feature.Services.InlayHints
+open JetBrains.ReSharper.Plugins.FSharp.Psi.Daemon.Options
+open JetBrains.ReSharper.Plugins.FSharp.Settings
+open JetBrains.TextControl.DocumentMarkup.Adornments
+
+type ActionStrings = JetBrains.ReSharper.Feature.Services.Resources.Strings
+type Strings = JetBrains.ReSharper.Plugins.FSharp.Psi.Daemon.Resources.Strings
+
+[<AbstractClass>]
+type FSharpTypeHintBulbActionsProvider(setting: Expression<Func<FSharpTypeHintOptions, PushToHintMode>>, settingTitle) =
+    interface IInlayHintBulbActionsProvider with
+        member x.CreateChangeVisibilityActions(settingsStore: ISettingsStore, _: IHighlighting, anchor: IAnchor) =
+            IntraTextAdornmentDataModelHelper.CreateChangeVisibilityActions<FSharpTypeHintOptions>(
+                settingsStore, setting, anchor, ActionStrings.ChangeVisibilityFor__Caption.Format(settingTitle: string)
+            )
+
+        member x.CreateChangeVisibilityBulbMenuItems(settingsStore: ISettingsStore, _: IHighlighting) =
+            IntraTextAdornmentDataModelHelper.CreateChangeVisibilityBulbMenuItems<FSharpTypeHintOptions>(
+                settingsStore, setting, BulbMenuAnchors.FirstClassContextItems,
+                ActionStrings.ChangeVisibilityFor__Caption.Format(settingTitle: string)
+            )
+
+        member _.GetOptionsPageId() = nameof(FSharpTypeHintsOptionsPage)
+
+type FSharpTopLevelMembersTypeHintBulbActionsProvider private () =
+    inherit FSharpTypeHintBulbActionsProvider(_.ShowTypeHintsForTopLevelMembers, Strings.FSharpTypeHints_TopLevelMembersSettings_Header)
+    static member val Instance = FSharpTopLevelMembersTypeHintBulbActionsProvider()
+
+type FSharpLocalBindingTypeHintBulbActionsProvider private () =
+    inherit FSharpTypeHintBulbActionsProvider(_.ShowTypeHintsForLocalBindings, Strings.FSharpTypeHints_LocalBindingsSettings_Header)
+    static member val Instance = FSharpLocalBindingTypeHintBulbActionsProvider()

--- a/ReSharper.FSharp/src/FSharp/FSharp.Psi.Daemon/src/Highlightings/FSharpTypeHintBulbActionsProvider.fs
+++ b/ReSharper.FSharp/src/FSharp/FSharp.Psi.Daemon/src/Highlightings/FSharpTypeHintBulbActionsProvider.fs
@@ -31,9 +31,9 @@ type FSharpTypeHintBulbActionsProvider(setting: Expression<Func<FSharpTypeHintOp
         member _.GetOptionsPageId() = nameof(FSharpTypeHintsOptionsPage)
 
 type FSharpTopLevelMembersTypeHintBulbActionsProvider private () =
-    inherit FSharpTypeHintBulbActionsProvider(_.ShowTypeHintsForTopLevelMembers, Strings.FSharpTypeHints_TopLevelMembersSettings_Header)
+    inherit FSharpTypeHintBulbActionsProvider((fun x -> x.ShowTypeHintsForTopLevelMembers), Strings.FSharpTypeHints_TopLevelMembersSettings_Header)
     static member val Instance = FSharpTopLevelMembersTypeHintBulbActionsProvider()
 
 type FSharpLocalBindingTypeHintBulbActionsProvider private () =
-    inherit FSharpTypeHintBulbActionsProvider(_.ShowTypeHintsForLocalBindings, Strings.FSharpTypeHints_LocalBindingsSettings_Header)
+    inherit FSharpTypeHintBulbActionsProvider((fun x -> x.ShowTypeHintsForLocalBindings), Strings.FSharpTypeHints_LocalBindingsSettings_Header)
     static member val Instance = FSharpLocalBindingTypeHintBulbActionsProvider()


### PR DESCRIPTION
Actions available via the right-click on an inlay hint

![{FAE93199-E2C5-4549-984E-DE309367282E}](https://github.com/user-attachments/assets/a74e1aaa-37a2-40e7-b1e1-29adea3648d1)


![{2F5AAA6E-85AF-4E40-9A20-76C7BCA93581}](https://github.com/user-attachments/assets/352497f1-fdb6-49d8-98ba-f4af79d9b1e7)
