### PR TITLE
FunctionAnnotationAction: improvements for top-level tuple patterns

### DIFF
--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 01 - Tuple.fs.gold
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 01 - Tuple.fs.gold
@@ -1,4 +1,4 @@
 ﻿module Module
 
-let f{caret} ((a, b): int * int) : int =
+let f{caret} (a: int, b: int) : int =
     a + b

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 06 - Tuple with as 01.fs
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 06 - Tuple with as 01.fs
@@ -1,0 +1,4 @@
+module Module
+
+let f{caret} (a, b as c) =
+    a + b

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 06 - Tuple with as 01.fs.gold
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 06 - Tuple with as 01.fs.gold
@@ -1,0 +1,4 @@
+﻿module Module
+
+let f{caret} (a: int, b: int as c) : int =
+    a + b

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 07 - Tuple with as 02.fs
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 07 - Tuple with as 02.fs
@@ -1,0 +1,4 @@
+module Module
+
+let f{caret} (a: int, b as c) =
+    a + b

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 07 - Tuple with as 02.fs.gold
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 07 - Tuple with as 02.fs.gold
@@ -1,0 +1,4 @@
+﻿module Module
+
+let f{caret} (a: int, b: int as c) : int =
+    a + b

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 08 - Tuple with as 03.fs
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 08 - Tuple with as 03.fs
@@ -1,0 +1,4 @@
+module Module
+
+let f{caret} ((a, b) as c) =
+    a + b

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 08 - Tuple with as 03.fs.gold
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 08 - Tuple with as 03.fs.gold
@@ -1,0 +1,4 @@
+﻿module Module
+
+let f{caret} ((a: int, b: int) as c) : int =
+    a + b

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 09 - Nested tuple 01.fs
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 09 - Nested tuple 01.fs
@@ -1,0 +1,4 @@
+module Module
+
+let f{caret} ((a, b)) =
+    a + b

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 09 - Nested tuple 01.fs.gold
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 09 - Nested tuple 01.fs.gold
@@ -1,0 +1,4 @@
+﻿module Module
+
+let f{caret} ((a: int, b: int)) : int =
+    a + b

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 10 - Nested tuple 02.fs
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 10 - Nested tuple 02.fs
@@ -1,0 +1,4 @@
+module Module
+
+let f{caret} ((a, b), c) =
+    a + b + c

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 10 - Nested tuple 02.fs.gold
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 10 - Nested tuple 02.fs.gold
@@ -1,0 +1,4 @@
+﻿module Module
+
+let f{caret} ((a, b): int * int, c: int) : int =
+    a + b + c

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 11 - Active pattern 01.fs
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 11 - Active pattern 01.fs
@@ -1,0 +1,5 @@
+module Module
+
+let (|TryParseBool|_|) (_: string) = Some(true)
+
+let f{caret} (TryParseBool enabled) = ()

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 11 - Active pattern 01.fs.gold
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 11 - Active pattern 01.fs.gold
@@ -1,0 +1,5 @@
+﻿module Module
+
+let (|TryParseBool|_|) (_: string) = Some(true)
+
+let f{caret} (TryParseBool enabled: string) : unit = ()

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 12 - Active pattern 02.fs
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 12 - Active pattern 02.fs
@@ -1,0 +1,5 @@
+module Module
+
+let (|TryParseBool|_|) (_: string) = Some(true)
+
+let f{caret} (TryParseBool enabled as x) = ()

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 12 - Active pattern 02.fs.gold
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 12 - Active pattern 02.fs.gold
@@ -1,0 +1,5 @@
+﻿module Module
+
+let (|TryParseBool|_|) (_: string) = Some(true)
+
+let f{caret} (TryParseBool enabled as x: string) : unit = ()

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/availability/Let bindings - Tuples 01.fs
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/availability/Let bindings - Tuples 01.fs
@@ -1,0 +1,10 @@
+do
+    let f1{on} (a, b): int = a + b
+    let f2{on} (a: int, (b: int, c: int)): int = 1
+    let f3{on} (a: int, b as c): int = 1
+
+    let g1{off} (a: int, (b, c): int * int): int = 1
+    let g2{off} (a: int, b: int as c): int = 1
+    let g3{off} (a, b as c: int * int): int = 1
+
+    ()

--- a/ReSharper.FSharp/test/src/FSharp.Intentions.Tests/src/Intentions/SpecifyTypesTest.fs
+++ b/ReSharper.FSharp/test/src/FSharp.Intentions.Tests/src/Intentions/SpecifyTypesTest.fs
@@ -33,6 +33,8 @@ type SpecifyTypesActionTest() =
     [<Test>] member x.``Function - Parameters - Pattern 08 - Tuple with as 03``() = x.DoNamedTest()
     [<Test>] member x.``Function - Parameters - Pattern 09 - Nested tuple 01``() = x.DoNamedTest()
     [<Test>] member x.``Function - Parameters - Pattern 10 - Nested tuple 02``() = x.DoNamedTest()
+    [<Test>] member x.``Function - Parameters - Pattern 11 - Active pattern 01``() = x.DoNamedTest()
+    [<Test>] member x.``Function - Parameters - Pattern 12 - Active pattern 02``() = x.DoNamedTest()
 
     [<Test>] member x.``Function - Return - Function 01``() = x.DoNamedTest()
     [<Test>] member x.``Function - Return - Function 02``() = x.DoNamedTest()

--- a/ReSharper.FSharp/test/src/FSharp.Intentions.Tests/src/Intentions/SpecifyTypesTest.fs
+++ b/ReSharper.FSharp/test/src/FSharp.Intentions.Tests/src/Intentions/SpecifyTypesTest.fs
@@ -28,6 +28,11 @@ type SpecifyTypesActionTest() =
     [<Test>] member x.``Function - Parameters - Pattern 03 - List``() = x.DoNamedTest()
     [<Test>] member x.``Function - Parameters - Pattern 04 - As``() = x.DoNamedTest()
     [<Test>] member x.``Function - Parameters - Pattern 05 - Param owner``() = x.DoNamedTest()
+    [<Test>] member x.``Function - Parameters - Pattern 06 - Tuple with as 01``() = x.DoNamedTest()
+    [<Test>] member x.``Function - Parameters - Pattern 07 - Tuple with as 02``() = x.DoNamedTest()
+    [<Test>] member x.``Function - Parameters - Pattern 08 - Tuple with as 03``() = x.DoNamedTest()
+    [<Test>] member x.``Function - Parameters - Pattern 09 - Nested tuple 01``() = x.DoNamedTest()
+    [<Test>] member x.``Function - Parameters - Pattern 10 - Nested tuple 02``() = x.DoNamedTest()
 
     [<Test>] member x.``Function - Return - Function 01``() = x.DoNamedTest()
     [<Test>] member x.``Function - Return - Function 02``() = x.DoNamedTest()
@@ -58,6 +63,7 @@ type SpecifyTypesActionAvailabilityTest() =
 
     [<Test>] member x.``Let bindings - Expr 01``() = x.DoNamedTest()
     [<Test>] member x.``Let bindings - Module 01``() = x.DoNamedTest()
+    [<Test>] member x.``Let bindings - Tuples 01``() = x.DoNamedTest()
 
     [<Test>] member x.``Class - member - 01``() = x.DoNamedTest()
     [<Test>] member x.``LetBang - 01`` () = x.DoNamedTest()


### PR DESCRIPTION
Fix for [RIDER-119806](https://youtrack.jetbrains.com/issue/RIDER-119806/F-annotate-fails-for-a-function-with-tuples)

It is also consistent with parameter info (and xml docs) now

![image](https://github.com/user-attachments/assets/5638a166-fcea-4bf3-a1c8-39255ea2da6b)
![image](https://github.com/user-attachments/assets/5d2ca15b-c611-4057-b930-5f4ec6eec730)
