### PR TITLE
Type Providers: unify apply static arguments

### DIFF
--- a/ReSharper.FSharp/src/FSharp/FSharp.TypeProviders.Protocol/src/Models/ProxyProvidedType.cs
+++ b/ReSharper.FSharp/src/FSharp/FSharp.TypeProviders.Protocol/src/Models/ProxyProvidedType.cs
@@ -183,7 +183,7 @@ namespace JetBrains.ReSharper.Plugins.FSharp.TypeProviders.Protocol.Models
     public override ProvidedType ApplyStaticArguments(ITypeProvider provider, string[] fullTypePathAfterArguments,
       object[] staticArgs)
     {
-      var key = string.Join(".", fullTypePathAfterArguments);
+      var key = string.Join(".", fullTypePathAfterArguments) + (IsErased ? "" : "+" + string.Join(",", staticArgs));
       var staticArgDescriptions = staticArgs.Select(PrimitiveTypesBoxer.BoxToServerStaticArg).ToArray();
 
       var result = TypeProvidersContext.AppliedProvidedTypesCache.GetOrCreate((EntityId, key), TypeProvider,

--- a/ReSharper.FSharp/src/FSharp/FSharp.TypeProviders.Protocol/src/Models/ProxyProvidedType.cs
+++ b/ReSharper.FSharp/src/FSharp/FSharp.TypeProviders.Protocol/src/Models/ProxyProvidedType.cs
@@ -176,28 +176,14 @@ namespace JetBrains.ReSharper.Plugins.FSharp.TypeProviders.Protocol.Models
 
     public override ProvidedParameterInfo[] GetStaticParameters(ITypeProvider provider) => myStaticParameters.Value;
 
-    public override ProvidedType ApplyStaticArguments(ITypeProvider provider, string[] fullTypePathAfterArguments,
-      object[] staticArgs) => IsErased
-      ? ApplyStaticArguments(fullTypePathAfterArguments, staticArgs)
-      : ApplyStaticArgumentsGenerative(fullTypePathAfterArguments, staticArgs);
-
-    private ProvidedType ApplyStaticArguments(string[] fullTypePathAfterArguments, object[] staticArgs)
-    {
-      var staticArgDescriptions = staticArgs.Select(PrimitiveTypesBoxer.BoxToServerStaticArg).ToArray();
-      return TypeProvidersContext.ProvidedTypesCache.GetOrCreate(
-        TypeProvidersContext.Connection.ExecuteWithCatch(
-          () => RdProvidedTypeProcessModel.ApplyStaticArguments.Sync(
-            new ApplyStaticArgumentsParameters(EntityId, fullTypePathAfterArguments, staticArgDescriptions),
-            RpcTimeouts.Maximal)),
-        TypeProvider);
-    }
-
+    // Note for generative types:
     // Since we distinguish different generative types by assembly name
     // and, at the same time, even for the same types, the generated assembly names will be different,
     // we will cache such types on the ReSharper side to avoid leaks.
-    private ProvidedType ApplyStaticArgumentsGenerative(string[] fullTypePathAfterArguments, object[] staticArgs)
+    public override ProvidedType ApplyStaticArguments(ITypeProvider provider, string[] fullTypePathAfterArguments,
+      object[] staticArgs)
     {
-      var key = string.Join(".", fullTypePathAfterArguments) + "+" + string.Join(",", staticArgs);
+      var key = string.Join(".", fullTypePathAfterArguments);
       var staticArgDescriptions = staticArgs.Select(PrimitiveTypesBoxer.BoxToServerStaticArg).ToArray();
 
       var result = TypeProvidersContext.AppliedProvidedTypesCache.GetOrCreate((EntityId, key), TypeProvider,


### PR DESCRIPTION
This PR contains refactoring for `ProvidedType.ApplyStaticArguments` by unifying its logic between generative and erased provided types.

Because of this, erased provided types will not be created and even requested from out-of-process in the case if static args or abbreviation name has not changed.

But it also means that legacy type providers which do not support proper invalidation and invalidate as a side-effect of each typing will not do it anymore. 

- [ ] Testing