### PR TITLE
FSharpLanguageLevel: support F#8 with patches

### DIFF
--- a/ReSharper.FSharp/src/FSharp/FSharp.Common/src/ProjectModel/FSharpLanguageLevelProvider.fs
+++ b/ReSharper.FSharp/src/FSharp/FSharp.Common/src/ProjectModel/FSharpLanguageLevelProvider.fs
@@ -72,6 +72,7 @@ type FSharpLanguageLevelProjectProperty(lifetime, locks, projectPropertiesListen
             if minor < 4 then VersionMapping(FSharpLanguageLevel.FSharp60, FSharpLanguageLevel.FSharp70)
             elif minor >= 4 && minor <= 7 then VersionMapping(FSharpLanguageLevel.FSharp70, FSharpLanguageLevel.FSharp80)
             elif minor = 8 && build < 200 then VersionMapping(FSharpLanguageLevel.FSharp80, FSharpLanguageLevel.FSharp90)
+            // .NET 8.0.200
             elif minor = 8 then VersionMapping(FSharpLanguageLevel.FSharp8Patched, FSharpLanguageLevel.FSharp90)
             elif minor >= 9 then VersionMapping(FSharpLanguageLevel.FSharp90, FSharpLanguageLevel.Preview)
             else null

--- a/ReSharper.FSharp/src/FSharp/FSharp.Common/src/ProjectModel/FSharpLanguageLevelProvider.fs
+++ b/ReSharper.FSharp/src/FSharp/FSharp.Common/src/ProjectModel/FSharpLanguageLevelProvider.fs
@@ -73,7 +73,7 @@ type FSharpLanguageLevelProjectProperty(lifetime, locks, projectPropertiesListen
             elif minor >= 4 && minor <= 7 then VersionMapping(FSharpLanguageLevel.FSharp70, FSharpLanguageLevel.FSharp80)
             elif minor = 8 && build < 200 then VersionMapping(FSharpLanguageLevel.FSharp80, FSharpLanguageLevel.FSharp90)
             // .NET 8.0.200
-            elif minor = 8 then VersionMapping(FSharpLanguageLevel.FSharp8Patched, FSharpLanguageLevel.FSharp90)
+            elif minor = 8 then VersionMapping(FSharpLanguageLevel.FSharp81, FSharpLanguageLevel.FSharp90)
             elif minor >= 9 then VersionMapping(FSharpLanguageLevel.FSharp90, FSharpLanguageLevel.Preview)
             else null
         | _ -> null
@@ -112,7 +112,7 @@ type FSharpLanguageLevelProjectProperty(lifetime, locks, projectPropertiesListen
             if isNull levelByCompiler || levelByCompiler.LatestMinor <= FSharpLanguageLevel.FSharp80 then
                 FSharpLanguageLevel.FSharp80
             else
-                FSharpLanguageLevel.FSharp8Patched
+                FSharpLanguageLevel.FSharp81
 
         | FSharpLanguageVersion.FSharp90 -> FSharpLanguageLevel.FSharp90
         | FSharpLanguageVersion.Default -> (getFscPath configuration |> getLanguageLevelByCompiler).DefaultVersion

--- a/ReSharper.FSharp/src/FSharp/FSharp.Common/src/ProjectModel/FSharpLanguageLevelProvider.fs
+++ b/ReSharper.FSharp/src/FSharp/FSharp.Common/src/ProjectModel/FSharpLanguageLevelProvider.fs
@@ -45,7 +45,7 @@ type FSharpLanguageLevelProjectProperty(lifetime, locks, projectPropertiesListen
         project.ProjectProperties.TryGetConfiguration<IFSharpProjectConfiguration>(targetFrameworkId)
 
     let (|Version|) (version: Version) =
-        version.Major, version.Minor
+        version.Major, version.Minor, version.Build
 
     // TODO: more versions
     let getLanguageLevelByToolsetVersion () =
@@ -66,12 +66,13 @@ type FSharpLanguageLevelProjectProperty(lifetime, locks, projectPropertiesListen
     // todo: more versions
     let getLanguageLevelByCompilerVersion (fscVersion: Version): VersionMapping =
         match fscVersion with
-        | Version (10, 1000) -> VersionMapping(FSharpLanguageLevel.FSharp47, FSharpLanguageLevel.FSharp50)
-        | Version (11, 0) -> VersionMapping(FSharpLanguageLevel.FSharp50, FSharpLanguageLevel.FSharp60)
-        | Version (12, minor) ->
+        | Version (10, 1000, _) -> VersionMapping(FSharpLanguageLevel.FSharp47, FSharpLanguageLevel.FSharp50)
+        | Version (11, 0, _) -> VersionMapping(FSharpLanguageLevel.FSharp50, FSharpLanguageLevel.FSharp60)
+        | Version (12, minor, build) ->
             if minor < 4 then VersionMapping(FSharpLanguageLevel.FSharp60, FSharpLanguageLevel.FSharp70)
             elif minor >= 4 && minor <= 7 then VersionMapping(FSharpLanguageLevel.FSharp70, FSharpLanguageLevel.FSharp80)
-            elif minor = 8 then VersionMapping(FSharpLanguageLevel.FSharp80, FSharpLanguageLevel.FSharp90)
+            elif minor = 8 && build < 200 then VersionMapping(FSharpLanguageLevel.FSharp80, FSharpLanguageLevel.FSharp90)
+            elif minor = 8 then VersionMapping(FSharpLanguageLevel.FSharp8Patched, FSharpLanguageLevel.FSharp90)
             elif minor >= 9 then VersionMapping(FSharpLanguageLevel.FSharp90, FSharpLanguageLevel.Preview)
             else null
         | _ -> null
@@ -105,7 +106,13 @@ type FSharpLanguageLevelProjectProperty(lifetime, locks, projectPropertiesListen
         | FSharpLanguageVersion.FSharp50 -> FSharpLanguageLevel.FSharp50
         | FSharpLanguageVersion.FSharp60 -> FSharpLanguageLevel.FSharp60
         | FSharpLanguageVersion.FSharp70 -> FSharpLanguageLevel.FSharp70
-        | FSharpLanguageVersion.FSharp80 -> FSharpLanguageLevel.FSharp80
+        | FSharpLanguageVersion.FSharp80 ->
+            let levelByCompiler = getFscPath configuration |> getLanguageLevelByCompiler
+            if isNull levelByCompiler || levelByCompiler.LatestMinor <= FSharpLanguageLevel.FSharp80 then
+                FSharpLanguageLevel.FSharp80
+            else
+                FSharpLanguageLevel.FSharp8Patched
+
         | FSharpLanguageVersion.FSharp90 -> FSharpLanguageLevel.FSharp90
         | FSharpLanguageVersion.Default -> (getFscPath configuration |> getLanguageLevelByCompiler).DefaultVersion
         | FSharpLanguageVersion.LatestMajor -> (getFscPath configuration |> getLanguageLevelByCompiler).LatestMajor

--- a/ReSharper.FSharp/src/FSharp/FSharp.Common/src/ProjectModel/FSharpLanguageLevelProvider.fs
+++ b/ReSharper.FSharp/src/FSharp/FSharp.Common/src/ProjectModel/FSharpLanguageLevelProvider.fs
@@ -72,7 +72,6 @@ type FSharpLanguageLevelProjectProperty(lifetime, locks, projectPropertiesListen
             if minor < 4 then VersionMapping(FSharpLanguageLevel.FSharp60, FSharpLanguageLevel.FSharp70)
             elif minor >= 4 && minor <= 7 then VersionMapping(FSharpLanguageLevel.FSharp70, FSharpLanguageLevel.FSharp80)
             elif minor = 8 && build < 200 then VersionMapping(FSharpLanguageLevel.FSharp80, FSharpLanguageLevel.FSharp90)
-            // .NET 8.0.200
             elif minor = 8 then VersionMapping(FSharpLanguageLevel.FSharp81, FSharpLanguageLevel.FSharp90)
             elif minor >= 9 then VersionMapping(FSharpLanguageLevel.FSharp90, FSharpLanguageLevel.Preview)
             else null

--- a/ReSharper.FSharp/src/FSharp/FSharp.Common/src/ProjectModel/FSharpLanguageVersion.fs
+++ b/ReSharper.FSharp/src/FSharp/FSharp.Common/src/ProjectModel/FSharpLanguageVersion.fs
@@ -119,8 +119,8 @@ module FSharpLanguageLevel =
     let isFSharp80Supported (treeNode: ITreeNode) =
         ofTreeNode treeNode >= FSharpLanguageLevel.FSharp80
 
-    [<Extension; CompiledName("IsFSharp8PatchedSupported")>]
-    let isFSharp8PatchedSupported (treeNode: ITreeNode) =
+    [<Extension; CompiledName("IsFSharp81Supported")>]
+    let isFSharp81Supported (treeNode: ITreeNode) =
         ofTreeNode treeNode >= FSharpLanguageLevel.FSharp81
 
     [<Extension; CompiledName("IsFSharp90Supported")>]

--- a/ReSharper.FSharp/src/FSharp/FSharp.Common/src/ProjectModel/FSharpLanguageVersion.fs
+++ b/ReSharper.FSharp/src/FSharp/FSharp.Common/src/ProjectModel/FSharpLanguageVersion.fs
@@ -31,6 +31,9 @@ type FSharpLanguageLevel =
     /// Nested record field copy and update/shorthand lambda
     | FSharp80 = 80
 
+    /// Includes fixes for shorthand lambda
+    | FSharp8Patched = 81
+
     /// Nullness
     | FSharp90 = 90
 
@@ -62,7 +65,8 @@ module FSharpLanguageLevel =
         | FSharpLanguageLevel.FSharp50 -> FSharpLanguageVersion.FSharp50
         | FSharpLanguageLevel.FSharp60 -> FSharpLanguageVersion.FSharp60
         | FSharpLanguageLevel.FSharp70 -> FSharpLanguageVersion.FSharp70
-        | FSharpLanguageLevel.FSharp80 -> FSharpLanguageVersion.FSharp80
+        | FSharpLanguageLevel.FSharp80
+        | FSharpLanguageLevel.FSharp8Patched -> FSharpLanguageVersion.FSharp80
         | FSharpLanguageLevel.FSharp90 -> FSharpLanguageVersion.FSharp90
         | FSharpLanguageLevel.Preview -> FSharpLanguageVersion.Preview
         | _ -> failwithf $"Unexpected language level: {level}"
@@ -114,6 +118,10 @@ module FSharpLanguageLevel =
     [<Extension; CompiledName("IsFSharp80Supported")>]
     let isFSharp80Supported (treeNode: ITreeNode) =
         ofTreeNode treeNode >= FSharpLanguageLevel.FSharp80
+
+    [<Extension; CompiledName("IsFSharp8PatchedSupported")>]
+    let isFSharp8PatchedSupported (treeNode: ITreeNode) =
+        ofTreeNode treeNode >= FSharpLanguageLevel.FSharp8Patched
 
     [<Extension; CompiledName("IsFSharp90Supported")>]
     let isFSharp90Supported (treeNode: ITreeNode) =

--- a/ReSharper.FSharp/src/FSharp/FSharp.Common/src/ProjectModel/FSharpLanguageVersion.fs
+++ b/ReSharper.FSharp/src/FSharp/FSharp.Common/src/ProjectModel/FSharpLanguageVersion.fs
@@ -31,8 +31,8 @@ type FSharpLanguageLevel =
     /// Nested record field copy and update/shorthand lambda
     | FSharp80 = 80
 
-    /// Includes fixes for shorthand lambda
-    | FSharp8Patched = 81
+    /// Shorthand lambda fixes
+    | FSharp81 = 81
 
     /// Nullness
     | FSharp90 = 90
@@ -66,7 +66,7 @@ module FSharpLanguageLevel =
         | FSharpLanguageLevel.FSharp60 -> FSharpLanguageVersion.FSharp60
         | FSharpLanguageLevel.FSharp70 -> FSharpLanguageVersion.FSharp70
         | FSharpLanguageLevel.FSharp80
-        | FSharpLanguageLevel.FSharp8Patched -> FSharpLanguageVersion.FSharp80
+        | FSharpLanguageLevel.FSharp81 -> FSharpLanguageVersion.FSharp80
         | FSharpLanguageLevel.FSharp90 -> FSharpLanguageVersion.FSharp90
         | FSharpLanguageLevel.Preview -> FSharpLanguageVersion.Preview
         | _ -> failwithf $"Unexpected language level: {level}"
@@ -121,7 +121,7 @@ module FSharpLanguageLevel =
 
     [<Extension; CompiledName("IsFSharp8PatchedSupported")>]
     let isFSharp8PatchedSupported (treeNode: ITreeNode) =
-        ofTreeNode treeNode >= FSharpLanguageLevel.FSharp8Patched
+        ofTreeNode treeNode >= FSharpLanguageLevel.FSharp81
 
     [<Extension; CompiledName("IsFSharp90Supported")>]
     let isFSharp90Supported (treeNode: ITreeNode) =

--- a/ReSharper.FSharp/src/FSharp/FSharp.Psi.Daemon/src/Analyzers/LambdaAnalyzer.fs
+++ b/ReSharper.FSharp/src/FSharp/FSharp.Psi.Daemon/src/Analyzers/LambdaAnalyzer.fs
@@ -296,14 +296,14 @@ type LambdaAnalyzer() =
         inner null expr
 
     let getRootRefExprIfCanBeConvertedToDotLambda (pat: ILocalReferencePat) (lambda: ILambdaExpr) =
-        let isFSharp90Supported = FSharpLanguageLevel.isFSharp90Supported lambda
+        let isFSharp8PatchedSupported = FSharpLanguageLevel.isFSharp8PatchedSupported lambda
         let expr = lambda.Expression.IgnoreInnerParens()
         if not expr.IsSingleLine then null else
 
         let rootRefExpr = getRootRefExpr expr
         if isNull rootRefExpr ||
            rootRefExpr.ShortName <> pat.SourceName ||
-           not (isFSharp90Supported || isContextWithoutWildPats expr) then null else
+           not (isFSharp8PatchedSupported || isContextWithoutWildPats expr) then null else
 
         let patSymbol = pat.GetFcsSymbol()
         let mutable convertingUnsupported = false
@@ -315,7 +315,7 @@ type LambdaAnalyzer() =
             member x.ProcessBeforeInterior(treeNode) =
                 if treeNode == rootRefExpr then () else
                 match treeNode with
-                | :? IDotLambdaExpr -> convertingUnsupported <- not isFSharp90Supported
+                | :? IDotLambdaExpr -> convertingUnsupported <- not isFSharp8PatchedSupported
                 | :? IReferenceExpr as ref when not ref.IsQualified ->
                     if ref.ShortName <> rootRefExpr.ShortName then () else
                     let symbol = ref.Reference.GetFcsSymbol()
@@ -324,7 +324,7 @@ type LambdaAnalyzer() =
         })
         if convertingUnsupported then null
         //TODO: workaround for https://github.com/dotnet/fsharp/issues/16305
-        elif isFSharp90Supported || isLambdaArgOwnerSupported lambda false ValueNone then rootRefExpr
+        elif isFSharp8PatchedSupported || isLambdaArgOwnerSupported lambda false ValueNone then rootRefExpr
         else null
 
     let isApplicable (expr: IFSharpExpression) (pats: TreeNodeCollection<IFSharpPattern>) =

--- a/ReSharper.FSharp/src/FSharp/FSharp.Psi.Daemon/src/Analyzers/LambdaAnalyzer.fs
+++ b/ReSharper.FSharp/src/FSharp/FSharp.Psi.Daemon/src/Analyzers/LambdaAnalyzer.fs
@@ -296,14 +296,14 @@ type LambdaAnalyzer() =
         inner null expr
 
     let getRootRefExprIfCanBeConvertedToDotLambda (pat: ILocalReferencePat) (lambda: ILambdaExpr) =
-        let isFSharp8PatchedSupported = FSharpLanguageLevel.isFSharp8PatchedSupported lambda
+        let isFSharp81Supported = FSharpLanguageLevel.isFSharp81Supported lambda
         let expr = lambda.Expression.IgnoreInnerParens()
         if not expr.IsSingleLine then null else
 
         let rootRefExpr = getRootRefExpr expr
         if isNull rootRefExpr ||
            rootRefExpr.ShortName <> pat.SourceName ||
-           not (isFSharp8PatchedSupported || isContextWithoutWildPats expr) then null else
+           not (isFSharp81Supported || isContextWithoutWildPats expr) then null else
 
         let patSymbol = pat.GetFcsSymbol()
         let mutable convertingUnsupported = false
@@ -315,7 +315,7 @@ type LambdaAnalyzer() =
             member x.ProcessBeforeInterior(treeNode) =
                 if treeNode == rootRefExpr then () else
                 match treeNode with
-                | :? IDotLambdaExpr -> convertingUnsupported <- not isFSharp8PatchedSupported
+                | :? IDotLambdaExpr -> convertingUnsupported <- not isFSharp81Supported
                 | :? IReferenceExpr as ref when not ref.IsQualified ->
                     if ref.ShortName <> rootRefExpr.ShortName then () else
                     let symbol = ref.Reference.GetFcsSymbol()
@@ -324,7 +324,7 @@ type LambdaAnalyzer() =
         })
         if convertingUnsupported then null
         //TODO: workaround for https://github.com/dotnet/fsharp/issues/16305
-        elif isFSharp8PatchedSupported || isLambdaArgOwnerSupported lambda false ValueNone then rootRefExpr
+        elif isFSharp81Supported || isLambdaArgOwnerSupported lambda false ValueNone then rootRefExpr
         else null
 
     let isApplicable (expr: IFSharpExpression) (pats: TreeNodeCollection<IFSharpPattern>) =

--- a/ReSharper.FSharp/src/FSharp/FSharp.Psi.Intentions/src/QuickFixes/ReplaceLambdaWithDotLambdaFix.fs
+++ b/ReSharper.FSharp/src/FSharp/FSharp.Psi.Intentions/src/QuickFixes/ReplaceLambdaWithDotLambdaFix.fs
@@ -21,7 +21,7 @@ type ReplaceLambdaWithDotLambdaFix(warning: DotLambdaCanBeUsedWarning) =
 
     override x.IsAvailable _ =
        isValid lambda && isValid expr &&
-       (FSharpLanguageLevel.isFSharp90Supported expr || isContextWithoutWildPats expr)
+       (FSharpLanguageLevel.isFSharp8PatchedSupported expr || isContextWithoutWildPats expr)
 
     override x.Text = "Replace with shorthand lambda"
 

--- a/ReSharper.FSharp/src/FSharp/FSharp.Psi.Intentions/src/QuickFixes/ReplaceLambdaWithDotLambdaFix.fs
+++ b/ReSharper.FSharp/src/FSharp/FSharp.Psi.Intentions/src/QuickFixes/ReplaceLambdaWithDotLambdaFix.fs
@@ -21,7 +21,7 @@ type ReplaceLambdaWithDotLambdaFix(warning: DotLambdaCanBeUsedWarning) =
 
     override x.IsAvailable _ =
        isValid lambda && isValid expr &&
-       (FSharpLanguageLevel.isFSharp8PatchedSupported expr || isContextWithoutWildPats expr)
+       (FSharpLanguageLevel.isFSharp81Supported expr || isContextWithoutWildPats expr)
 
     override x.Text = "Replace with shorthand lambda"
 

--- a/ReSharper.FSharp/src/FSharp/FSharp.Psi.Services/src/Util/FSharpParensUtil.fs
+++ b/ReSharper.FSharp/src/FSharp/FSharp.Psi.Services/src/Util/FSharpParensUtil.fs
@@ -271,7 +271,7 @@ let rec needsParensImpl (allowHighPrecedenceAppParens: unit -> bool) (context: I
     if escapesTupleAppArg context expr then true else
     if expr :? IParenOrBeginEndExpr then false
 
-    elif expr :? IDotLambdaExpr && not (FSharpLanguageLevel.isFSharp90Supported expr) then true else
+    elif expr :? IDotLambdaExpr && not (FSharpLanguageLevel.isFSharp8PatchedSupported expr) then true else
 
     let expr = expr.IgnoreInnerParens()
     if isNull expr|| contextRequiresParens expr context then true else

--- a/ReSharper.FSharp/src/FSharp/FSharp.Psi.Services/src/Util/FSharpParensUtil.fs
+++ b/ReSharper.FSharp/src/FSharp/FSharp.Psi.Services/src/Util/FSharpParensUtil.fs
@@ -271,7 +271,7 @@ let rec needsParensImpl (allowHighPrecedenceAppParens: unit -> bool) (context: I
     if escapesTupleAppArg context expr then true else
     if expr :? IParenOrBeginEndExpr then false
 
-    elif expr :? IDotLambdaExpr && not (FSharpLanguageLevel.isFSharp8PatchedSupported expr) then true else
+    elif expr :? IDotLambdaExpr && not (FSharpLanguageLevel.isFSharp81Supported expr) then true else
 
     let expr = expr.IgnoreInnerParens()
     if isNull expr|| contextRequiresParens expr context then true else


### PR DESCRIPTION
Relax language level constraint for [RIDER-102956](https://youtrack.jetbrains.com/issue/RIDER-102956/Change-Replace-with-shorthand-lambda-refactoring-to-also-remove-parentheses) and [RIDER-122888](https://youtrack.jetbrains.com/issue/RIDER-122888/Missing-to-dot-lambda-CA)