### PR TITLE
Specify Types: support named patterns and members

### DIFF
--- a/ReSharper.FSharp/src/FSharp/FSharp.Common/src/Util/FSharpGlobalUtil.fs
+++ b/ReSharper.FSharp/src/FSharp/FSharp.Common/src/Util/FSharpGlobalUtil.fs
@@ -36,9 +36,6 @@ module FSharpGlobalUtil =
     let (|NotNull|_|) value =
         if isNotNull value then Some value else None
 
-    let inline (?>) (x: 'a) ([<InlineIfLambda>] f: 'a -> 'b) =
-        if isNull x then null else f x
-
 
 [<AutoOpen>]
 module FSharpGlobalAbbreviations =

--- a/ReSharper.FSharp/src/FSharp/FSharp.Common/src/Util/FSharpGlobalUtil.fs
+++ b/ReSharper.FSharp/src/FSharp/FSharp.Common/src/Util/FSharpGlobalUtil.fs
@@ -36,6 +36,9 @@ module FSharpGlobalUtil =
     let (|NotNull|_|) value =
         if isNotNull value then Some value else None
 
+    let inline (?>) (x: 'a) ([<InlineIfLambda>] f: 'a -> 'b) =
+        if isNull x then null else f x
+
 
 [<AutoOpen>]
 module FSharpGlobalAbbreviations =

--- a/ReSharper.FSharp/src/FSharp/FSharp.Psi.Intentions/src/Intentions/DataProviders.fs
+++ b/ReSharper.FSharp/src/FSharp/FSharp.Psi.Intentions/src/Intentions/DataProviders.fs
@@ -63,8 +63,8 @@ let isAtParametersOwnerKeywordOrIdentifier (dataProvider: IContextActionDataProv
         match owner with
         | :? IBinding as binding ->
             let keyword = binding.BindingKeyword
-            let identifier =
-                binding.HeadPattern.IgnoreInnerParens().As<IReferencePat>() ?> _.Identifier
+            let refPat = binding.HeadPattern.IgnoreInnerParens().As<IReferencePat>()
+            let identifier = if isNull refPat then null else refPat.Identifier
             keyword, identifier
 
         | :? IMemberDeclaration as memberDeclaration ->

--- a/ReSharper.FSharp/src/FSharp/FSharp.Psi.Intentions/src/Intentions/FunctionAnnotationAction.fs
+++ b/ReSharper.FSharp/src/FSharp/FSharp.Psi.Intentions/src/Intentions/FunctionAnnotationAction.fs
@@ -215,7 +215,7 @@ module SpecifyTypes =
 
         | _ -> ()
 
-module SpecifyTypesAction =
+module SpecifyTypesActionHelper =
     open SpecifyTypes
     let executePsiTransaction (node: ITreeNode) (availability: Availability) =
         use writeCookie = WriteLockCookie.Create(node.IsPhysical())
@@ -240,7 +240,7 @@ type AnnotationActionBase<'a when 'a: not struct and 'a :> ITreeNode>(dataProvid
     override x.ExecutePsiTransaction _ =
         let node = x.ContextNode
         let availability = SpecifyTypes.getAvailability node
-        SpecifyTypesAction.executePsiTransaction node availability
+        SpecifyTypesActionHelper.executePsiTransaction node availability
 
 [<ContextAction(Name = "AnnotateFunction", GroupType = typeof<FSharpContextActions>,
                 Description = "Annotate binding or member with parameter types and return type")>]
@@ -271,7 +271,7 @@ type private SpecifyTypeAction(node: ITreeNode, availability: SpecifyTypes.Avail
     override this.Text = "Add type annotation"
 
     override this.ExecutePsiTransaction(_, _) =
-        SpecifyTypesAction.executePsiTransaction node availability
+        SpecifyTypesActionHelper.executePsiTransaction node availability
         null
 
 [<SolutionComponent(Instantiation.DemandAnyThreadSafe)>]

--- a/ReSharper.FSharp/src/FSharp/FSharp.Psi.Intentions/src/Intentions/FunctionAnnotationAction.fs
+++ b/ReSharper.FSharp/src/FSharp/FSharp.Psi.Intentions/src/Intentions/FunctionAnnotationAction.fs
@@ -190,7 +190,7 @@ module SpecifyTypes =
             specifyParameterTypes types (fun x -> x[0].Type) enumerate parameters true
         else
             let types = getFunctionTypeArgs true mfv.FullType
-            specifyParameterTypes types id _.GenericArguments parameters true
+            specifyParameterTypes types id (_.GenericArguments) parameters true
 
     let rec specifyTypes (node: ITreeNode) (availability: Availability) =
         match node with

--- a/ReSharper.FSharp/src/FSharp/FSharp.Psi.Intentions/src/Intentions/FunctionAnnotationAction.fs
+++ b/ReSharper.FSharp/src/FSharp/FSharp.Psi.Intentions/src/Intentions/FunctionAnnotationAction.fs
@@ -141,6 +141,15 @@ module SpecifyTypes =
             | :? IAttribPat as attribPat -> attribPat.Pattern
             | _ -> pattern
 
+        let pattern, fcsType =
+            match pattern with
+            | :? IOptionalValPat -> pattern, fcsType.GenericArguments[0]
+            | _ ->
+
+            let optionalValPat = OptionalValPatNavigator.GetByPattern(pattern)
+            if isNull optionalValPat then pattern, fcsType
+            else (optionalValPat : IFSharpPattern), fcsType.GenericArguments[0]
+
         let newPattern =
             match pattern.IgnoreInnerParens() with
             | :? ITuplePat as tuplePat -> addParens factory tuplePat
@@ -178,7 +187,7 @@ module SpecifyTypes =
         if mfv.IsMember then
             let selectMany x = x |> Seq.map (fun x -> [|x|] :> IList<_>)
             let types = mfv.CurriedParameterGroups
-            specifyParameterTypes types _.Item(0).Type selectMany parameters true
+            specifyParameterTypes types (_.Item(0).Type) selectMany parameters true
         else
             let types = getFunctionTypeArgs true mfv.FullType
             specifyParameterTypes types id _.GenericArguments parameters true

--- a/ReSharper.FSharp/src/FSharp/FSharp.Psi.Intentions/src/Intentions/FunctionAnnotationAction.fs
+++ b/ReSharper.FSharp/src/FSharp/FSharp.Psi.Intentions/src/Intentions/FunctionAnnotationAction.fs
@@ -259,9 +259,9 @@ type AnnotationActionBase<'a when 'a: not struct and 'a :> ITreeNode>(dataProvid
         let availability = SpecifyTypes.getAvailability node
         SpecifyTypesActionHelper.executePsiTransaction node availability
 
-[<ContextAction(Name = "AnnotateFunction", GroupType = typeof<FSharpContextActions>,
+[<ContextAction(Name = "AnnotateMemberOrFunction", GroupType = typeof<FSharpContextActions>,
                 Description = "Annotate binding or member with parameter types and return type")>]
-type MfvAnnotationAction(dataProvider: FSharpContextActionDataProvider) =
+type MemberAndFunctionAnnotationAction(dataProvider: FSharpContextActionDataProvider) =
     inherit AnnotationActionBase<IParameterOwnerMemberDeclaration>(dataProvider)
 
     override this.IsAvailable(node: IParameterOwnerMemberDeclaration) =

--- a/ReSharper.FSharp/src/FSharp/FSharp.Psi.Intentions/src/Intentions/FunctionAnnotationAction.fs
+++ b/ReSharper.FSharp/src/FSharp/FSharp.Psi.Intentions/src/Intentions/FunctionAnnotationAction.fs
@@ -187,7 +187,7 @@ module SpecifyTypes =
         if mfv.IsMember then
             let selectMany x = x |> Seq.map (fun x -> [|x|] :> IList<_>)
             let types = mfv.CurriedParameterGroups
-            specifyParameterTypes types (_.Item(0).Type) selectMany parameters true
+            specifyParameterTypes types (fun x -> x[0].Type) selectMany parameters true
         else
             let types = getFunctionTypeArgs true mfv.FullType
             specifyParameterTypes types id _.GenericArguments parameters true

--- a/ReSharper.FSharp/src/FSharp/FSharp.Psi.Intentions/src/Intentions/FunctionAnnotationAction.fs
+++ b/ReSharper.FSharp/src/FSharp/FSharp.Psi.Intentions/src/Intentions/FunctionAnnotationAction.fs
@@ -234,6 +234,7 @@ module SpecifyTypes =
 
 module SpecifyTypesActionHelper =
     open SpecifyTypes
+
     let executePsiTransaction (node: ITreeNode) (availability: Availability) =
         use writeCookie = WriteLockCookie.Create(node.IsPhysical())
         use disableFormatter = new DisableCodeFormatter()
@@ -245,12 +246,13 @@ type AnnotationActionBase<'a when 'a: not struct and 'a :> ITreeNode>(dataProvid
     inherit FSharpContextActionBase(dataProvider)
 
     abstract member IsAvailable: 'a -> bool
+
     member x.ContextNode = dataProvider.GetSelectedElement<'a>()
 
     override x.IsAvailable(_: IUserDataHolder) =
         let node = x.ContextNode
 
-        isNotNull node && isValid (node :> ITreeNode) &&
+        isValid (node :> ITreeNode) &&
         x.IsAvailable(node) &&
         SpecifyTypes.getAvailability node |> _.IsAvailable
 

--- a/ReSharper.FSharp/src/FSharp/FSharp.Psi.Intentions/src/Intentions/FunctionAnnotationAction.fs
+++ b/ReSharper.FSharp/src/FSharp/FSharp.Psi.Intentions/src/Intentions/FunctionAnnotationAction.fs
@@ -260,7 +260,7 @@ type AnnotationActionBase<'a when 'a: not struct and 'a :> ITreeNode>(dataProvid
         SpecifyTypesActionHelper.executePsiTransaction node availability
 
 [<ContextAction(Name = "AnnotateMemberOrFunction", GroupType = typeof<FSharpContextActions>,
-                Description = "Annotate binding or member with parameter types and return type")>]
+                Description = "Specify parameter types and the return type for the binding or type member")>]
 type MemberAndFunctionAnnotationAction(dataProvider: FSharpContextActionDataProvider) =
     inherit AnnotationActionBase<IParameterOwnerMemberDeclaration>(dataProvider)
 

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Member 01 - Method.fs
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Member 01 - Method.fs
@@ -1,0 +1,4 @@
+module Module
+
+type A() =
+    member this.M{caret}(x, y) = x.ToString() + y

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Member 01 - Method.fs.gold
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Member 01 - Method.fs.gold
@@ -1,4 +1,4 @@
 ﻿module Module
 
 type A() =
-    member this.M{caret}(x, y): string = x.ToString() + y
+    member this.M{caret}(x: 'a, y: string): string = x.ToString() + y

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Member 01 - Method.fs.gold
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Member 01 - Method.fs.gold
@@ -1,0 +1,4 @@
+﻿module Module
+
+type A() =
+    member this.M{caret}(x, y): string = x.ToString() + y

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Member 02 - Property.fs
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Member 02 - Property.fs
@@ -1,0 +1,4 @@
+module Module
+
+type A() =
+    member this.P{caret} = 1

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Member 02 - Property.fs.gold
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Member 02 - Property.fs.gold
@@ -1,0 +1,4 @@
+﻿module Module
+
+type A() =
+    member this.P: int{caret} = 1

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Member 03 - Method - Param groups.fs
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Member 03 - Method - Param groups.fs
@@ -1,0 +1,5 @@
+module Module
+
+type A =
+    member x.M{caret} (a, b) c =
+        (a ||> String.concat) + b + (c ||> String.concat)

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Member 03 - Method - Param groups.fs.gold
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Member 03 - Method - Param groups.fs.gold
@@ -1,0 +1,5 @@
+﻿module Module
+
+type A =
+    member x.M{caret} (a: string * 'a, b: string) (c: string * string seq): string =
+        (a ||> String.concat) + b + (c ||> String.concat)

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Member 04 - Extension 01.fs
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Member 04 - Extension 01.fs
@@ -1,0 +1,6 @@
+module Module
+
+type IEnumerableExtensions =
+    [<Extension>]
+    static member M{caret}(xs: IEnumerable<string>, a) =
+        Seq.contains (a ||> String.concat) xs 

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Member 04 - Extension 01.fs.gold
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Member 04 - Extension 01.fs.gold
@@ -1,0 +1,6 @@
+﻿module Module
+
+type IEnumerableExtensions =
+    [<Extension>]
+    static member M{caret}(xs: IEnumerable<string>, a: string * 'a): bool =
+        Seq.contains (a ||> String.concat) xs 

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Member 05 - Extension 02.fs
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Member 05 - Extension 02.fs
@@ -1,0 +1,4 @@
+module Module
+
+type System.String with
+    member this.M{caret}(a) = a ||> String.concat

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Member 05 - Extension 02.fs.gold
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Member 05 - Extension 02.fs.gold
@@ -1,0 +1,4 @@
+﻿module Module
+
+type System.String with
+    member this.M{caret}(a: string * string seq): string = a ||> String.concat

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Member 06 - Optional param.fs
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Member 06 - Optional param.fs
@@ -1,0 +1,4 @@
+module Module
+
+type A =
+    member _.M{caret} ?x = x.Value + 1

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Member 06 - Optional param.fs.gold
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Member 06 - Optional param.fs.gold
@@ -1,0 +1,4 @@
+﻿module Module
+
+type A =
+    member _.M({caret}?x: int): int = x.Value + 1

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Member 07 - Optional param - With attribute.fs
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Member 07 - Optional param - With attribute.fs
@@ -1,0 +1,4 @@
+﻿module Module
+
+type A =
+    member _.M{caret}([<Attr>] ?x) = x.Value + 1

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Member 07 - Optional param - With attribute.fs.gold
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Member 07 - Optional param - With attribute.fs.gold
@@ -1,0 +1,4 @@
+﻿module Module
+
+type A =
+    member _.M{caret}([<Attr>] ?x: int): int = x.Value + 1

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Pattern 01.fs
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Pattern 01.fs
@@ -1,0 +1,3 @@
+module Module
+
+let f x{caret}: int = x + 1

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Pattern 01.fs.gold
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Pattern 01.fs.gold
@@ -1,0 +1,3 @@
+﻿module Module
+
+let f (x: int){caret}: int = x + 1

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Pattern 02 - Optional.fs
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Pattern 02 - Optional.fs
@@ -1,0 +1,4 @@
+module Module
+
+type A =
+    member _.M ?{caret}x = x.Value + 1

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Pattern 02 - Optional.fs.gold
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Pattern 02 - Optional.fs.gold
@@ -1,0 +1,4 @@
+﻿module Module
+
+type A =
+    member _.M(?{caret}x: int) = x.Value + 1

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/availability/Class - member - 01.fs
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/availability/Class - member - 01.fs
@@ -7,9 +7,11 @@ type NumberPrinter(num) =
     member{on} _.print2{on}(x): int = x + 1
     member{off} _.print3{off}(x: int): int = x + 1
 
-    member x.P1{on} = 1
-    member x.P2{off}: int = 1
+    member{on} x.P1{on} = 1
+    member{off} x.P2{off}: int = 1
 
-    member x.P3{off}
+    member{off} x.P3{off}
         with get{off}() = num
         and set{off}(y: int) = ()
+
+    member{off} val P4{off} = 3

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/availability/Class - member - 01.fs
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/availability/Class - member - 01.fs
@@ -1,5 +1,15 @@
 module Module
 
 type NumberPrinter(num) =
-    // Class members aren't supported yet
-    member x.print{off}() = sprintf{off} "%d" num
+
+    member{on} x{off}.print{on}() = sprintf{off} "%d" num
+    member{off} _.print1{off}(): unit = ()
+    member{on} _.print2{on}(x): int = x + 1
+    member{off} _.print3{off}(x: int): int = x + 1
+
+    member x.P1{on} = 1
+    member x.P2{off}: int = 1
+
+    member x.P3{off}
+        with get{off}() = num
+        and set{off}(y: int) = ()

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/availability/Let bindings - Expr 01.fs
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/availability/Let bindings - Expr 01.fs
@@ -1,9 +1,12 @@
 do
     {off}
 
-    let x{on} = 1
+    let{on} x{on} = 1
     let{off} x{off}: int = 1
 
+    let{on} (x{on}) = 1
+    let{off} (x{off}): int = 1
+    let{off} (x{off}: int) = 1
     let{off} (x{off}: int): int = 1
     let{off} ((x{off}: int)): int = 1
 

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/availability/Let bindings - Expr 01.fs
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/availability/Let bindings - Expr 01.fs
@@ -10,5 +10,5 @@ do
     let{off} (x{off}: int): int = 1
     let{off} ((x{off}: int)): int = 1
 
-    let{on} foo{on} {off}x {off}= {off}()
+    let{on} rec{off} foo{on} {off}x {off}= {off}()
     (){off}

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/availability/Let bindings - Module 01.fs
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/availability/Let bindings - Module 01.fs
@@ -11,7 +11,8 @@ let{off} ((x4{off}: int)): int = 1
 {off}[<CompiledName{off}("Foo")>]{off}
 let{on} foo{on} {off}x {off}= {off}()
 
-let{off} f{off} {off}(): unit = ()
+let{off} rec f{off} {off}(): unit = ()
+and{on} g{on} x = x + 1
 
 let{on} f1{on} ([<Attr>] x): int = x + 1
 let{on} f2{on} (([<Attr>] (x))): int = x + 1

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/availability/Patterns - 01.fs
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/availability/Patterns - 01.fs
@@ -1,0 +1,9 @@
+module Module
+
+let{off} f{off} x{on}: int = x + 1
+let{off} g{off} (Some{off}(x{on})) = x + 1
+
+let{off} (x{off}) = 1
+
+type A(x{on}) =
+    member{off} this{off}.M{off}(y{on}) = x + y

--- a/ReSharper.FSharp/test/src/FSharp.Intentions.Tests/src/Intentions/SpecifyTypesTest.fs
+++ b/ReSharper.FSharp/test/src/FSharp.Intentions.Tests/src/Intentions/SpecifyTypesTest.fs
@@ -67,6 +67,8 @@ type SpecifyTypesActionTest() =
     [<Test>] member x.``Member 03 - Method - Param groups`` () = x.DoNamedTest()
     [<Test>] member x.``Member 04 - Extension 01`` () = x.DoNamedTest()
     [<Test>] member x.``Member 05 - Extension 02`` () = x.DoNamedTest()
+    [<Test>] member x.``Member 06 - Optional param`` () = x.DoNamedTest()
+
 
 // Most tests are in TypeHintContextActionsTests
 [<AssertCorrectTreeStructure>]
@@ -76,6 +78,7 @@ type SpecifyPatternTypeActionTest() =
     override x.ExtraPath = "specifyTypes"
 
     [<Test>] member x.``Pattern 01``() = x.DoNamedTest()
+    [<Test>] member x.``Pattern 02 - Optional``() = x.DoNamedTest()
 
 
 type SpecifyTypesActionAvailabilityTest() =

--- a/ReSharper.FSharp/test/src/FSharp.Intentions.Tests/src/Intentions/SpecifyTypesTest.fs
+++ b/ReSharper.FSharp/test/src/FSharp.Intentions.Tests/src/Intentions/SpecifyTypesTest.fs
@@ -64,6 +64,9 @@ type SpecifyTypesActionTest() =
 
     [<Test>] member x.``Member 01 - Method`` () = x.DoNamedTest()
     [<Test>] member x.``Member 02 - Property`` () = x.DoNamedTest()
+    [<Test>] member x.``Member 03 - Method - Param groups`` () = x.DoNamedTest()
+    [<Test>] member x.``Member 04 - Extension 01`` () = x.DoNamedTest()
+    [<Test>] member x.``Member 05 - Extension 02`` () = x.DoNamedTest()
 
 // Most tests are in TypeHintContextActionsTests
 [<AssertCorrectTreeStructure>]

--- a/ReSharper.FSharp/test/src/FSharp.Intentions.Tests/src/Intentions/SpecifyTypesTest.fs
+++ b/ReSharper.FSharp/test/src/FSharp.Intentions.Tests/src/Intentions/SpecifyTypesTest.fs
@@ -7,7 +7,7 @@ open NUnit.Framework
 
 [<AssertCorrectTreeStructure>]
 type SpecifyTypesActionTest() =
-    inherit FSharpContextActionExecuteTestBase<FunctionAnnotationAction>()
+    inherit FSharpContextActionExecuteTestBase<MfvAnnotationAction>()
 
     override x.ExtraPath = "specifyTypes"
 
@@ -62,9 +62,21 @@ type SpecifyTypesActionTest() =
     [<Test>] member x.``Function - Recursive - Function 03`` () = x.DoNamedTest()
     [<Test>] member x.``Function - Recursive - Function 04`` () = x.DoNamedTest()
 
+    [<Test>] member x.``Member 01 - Method`` () = x.DoNamedTest()
+    [<Test>] member x.``Member 02 - Property`` () = x.DoNamedTest()
+
+// Most tests are in TypeHintContextActionsTests
+[<AssertCorrectTreeStructure>]
+type SpecifyPatternTypeActionTest() =
+    inherit FSharpContextActionExecuteTestBase<PatternAnnotationAction>()
+
+    override x.ExtraPath = "specifyTypes"
+
+    [<Test>] member x.``Pattern 01``() = x.DoNamedTest()
+
 
 type SpecifyTypesActionAvailabilityTest() =
-    inherit FSharpContextActionAvailabilityTestBase<FunctionAnnotationAction>()
+    inherit FSharpContextActionAvailabilityTestBase<MfvAnnotationAction>()
 
     override x.ExtraPath = "specifyTypes"
 
@@ -76,3 +88,10 @@ type SpecifyTypesActionAvailabilityTest() =
     [<Test>] member x.``LetBang - 01`` () = x.DoNamedTest()
     [<Test>] member x.``UseBang - 01`` () = x.DoNamedTest()
     [<Test>] member x.``AndBang - 01`` () = x.DoNamedTest()
+
+type SpecifyPatternTypeActionAvailabilityTest() =
+    inherit FSharpContextActionAvailabilityTestBase<PatternAnnotationAction>()
+
+    override x.ExtraPath = "specifyTypes"
+
+    [<Test>] member x.``Patterns - 01``() = x.DoNamedTest()

--- a/ReSharper.FSharp/test/src/FSharp.Intentions.Tests/src/Intentions/SpecifyTypesTest.fs
+++ b/ReSharper.FSharp/test/src/FSharp.Intentions.Tests/src/Intentions/SpecifyTypesTest.fs
@@ -7,7 +7,7 @@ open NUnit.Framework
 
 [<AssertCorrectTreeStructure>]
 type SpecifyTypesActionTest() =
-    inherit FSharpContextActionExecuteTestBase<MfvAnnotationAction>()
+    inherit FSharpContextActionExecuteTestBase<MemberAndFunctionAnnotationAction>()
 
     override x.ExtraPath = "specifyTypes"
 
@@ -82,7 +82,7 @@ type SpecifyPatternTypeActionTest() =
 
 
 type SpecifyTypesActionAvailabilityTest() =
-    inherit FSharpContextActionAvailabilityTestBase<MfvAnnotationAction>()
+    inherit FSharpContextActionAvailabilityTestBase<MemberAndFunctionAnnotationAction>()
 
     override x.ExtraPath = "specifyTypes"
 

--- a/ReSharper.FSharp/test/src/FSharp.Intentions.Tests/src/Intentions/SpecifyTypesTest.fs
+++ b/ReSharper.FSharp/test/src/FSharp.Intentions.Tests/src/Intentions/SpecifyTypesTest.fs
@@ -68,6 +68,7 @@ type SpecifyTypesActionTest() =
     [<Test>] member x.``Member 04 - Extension 01`` () = x.DoNamedTest()
     [<Test>] member x.``Member 05 - Extension 02`` () = x.DoNamedTest()
     [<Test>] member x.``Member 06 - Optional param`` () = x.DoNamedTest()
+    [<Test>] member x.``Member 07 - Optional param - With attribute``() = x.DoNamedTest()
 
 
 // Most tests are in TypeHintContextActionsTests


### PR DESCRIPTION
Additional entry point for `specify types` via context actions. Currently supported the same scenarios as for inlay hints materialization.

The following PR's will add support for primary constructors / properties with accessors, etc