### PR TITLE
SpecifyTypes: fix for attributed parameter

### DIFF
--- a/ReSharper.FSharp/src/FSharp/FSharp.Psi.Intentions/src/Intentions/FunctionAnnotationAction.fs
+++ b/ReSharper.FSharp/src/FSharp/FSharp.Psi.Intentions/src/Intentions/FunctionAnnotationAction.fs
@@ -44,6 +44,7 @@ module SpecifyTypes =
             let pattern = pattern.IgnoreInnerParens()
             match pattern with
             | :? ITypedPat | :? IUnitPat -> true
+            | :? IAttribPat as attribPat -> isAnnotated isTopLevel attribPat.Pattern
             | TupleLikePattern pat when isTopLevel -> pat.PatternsEnumerable |> Seq.forall (isAnnotated false)
             | _ -> false
 
@@ -132,6 +133,11 @@ module SpecifyTypes =
     let specifyPatternType displayContext (fcsType: FSharpType) (pattern: IFSharpPattern) =
         let pattern = pattern.IgnoreParentParens()
         let factory = pattern.CreateElementFactory()
+
+        let pattern =
+            match pattern.IgnoreInnerParens() with
+            | :? IAttribPat as attribPat -> attribPat.Pattern
+            | _ -> pattern
 
         let newPattern =
             match pattern.IgnoreInnerParens() with

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 13 - With attribute 01.fs
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 13 - With attribute 01.fs
@@ -1,0 +1,3 @@
+﻿module Module
+
+let f{caret} ([<Attr>] x): int = x + 1

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 13 - With attribute 01.fs.gold
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 13 - With attribute 01.fs.gold
@@ -1,0 +1,3 @@
+﻿module Module
+
+let f{caret} ([<Attr>] x: int): int = x + 1

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 14 - With attribute 02.fs
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 14 - With attribute 02.fs
@@ -1,0 +1,3 @@
+﻿module Module
+
+let f{caret} ([<Attr>] (x)): int = x + 1

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 14 - With attribute 02.fs.gold
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 14 - With attribute 02.fs.gold
@@ -1,0 +1,3 @@
+﻿module Module
+
+let f{caret} ([<Attr>] x: int): int = x + 1

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 15 - With attribute 03.fs
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 15 - With attribute 03.fs
@@ -1,0 +1,3 @@
+﻿module Module
+
+let f{caret} ([<Attr>] x, y): int = x + y

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 15 - With attribute 03.fs.gold
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 15 - With attribute 03.fs.gold
@@ -1,0 +1,3 @@
+﻿module Module
+
+let f{caret} ([<Attr>] x: int, y: int): int = x + y

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 16 - With attribute 04.fs
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 16 - With attribute 04.fs
@@ -1,0 +1,3 @@
+﻿module Module
+
+let f{caret} (([<Attr>] x), y): int = x + y

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 16 - With attribute 04.fs.gold
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/Function - Parameters - Pattern 16 - With attribute 04.fs.gold
@@ -1,0 +1,3 @@
+﻿module Module
+
+let f{caret} (([<Attr>] x: int), y: int): int = x + y

--- a/ReSharper.FSharp/test/data/features/intentions/specifyTypes/availability/Let bindings - Module 01.fs
+++ b/ReSharper.FSharp/test/data/features/intentions/specifyTypes/availability/Let bindings - Module 01.fs
@@ -12,3 +12,9 @@ let{off} ((x4{off}: int)): int = 1
 let{on} foo{on} {off}x {off}= {off}()
 
 let{off} f{off} {off}(): unit = ()
+
+let{on} f1{on} ([<Attr>] x): int = x + 1
+let{on} f2{on} (([<Attr>] (x))): int = x + 1
+let{off} f3{off} ([<Attr>] x: int): int = x + 1
+let{off} f4{off} ([<Attr>] (x: int)): int = x + 1
+let{off} f5{off} (([<Attr>] (x: int))): int = x + 1

--- a/ReSharper.FSharp/test/src/FSharp.Intentions.Tests/src/Intentions/SpecifyTypesTest.fs
+++ b/ReSharper.FSharp/test/src/FSharp.Intentions.Tests/src/Intentions/SpecifyTypesTest.fs
@@ -5,6 +5,7 @@ open JetBrains.ReSharper.Plugins.FSharp.Services.Formatter
 open JetBrains.ReSharper.TestFramework
 open NUnit.Framework
 
+[<AssertCorrectTreeStructure>]
 type SpecifyTypesActionTest() =
     inherit FSharpContextActionExecuteTestBase<FunctionAnnotationAction>()
 
@@ -35,6 +36,10 @@ type SpecifyTypesActionTest() =
     [<Test>] member x.``Function - Parameters - Pattern 10 - Nested tuple 02``() = x.DoNamedTest()
     [<Test>] member x.``Function - Parameters - Pattern 11 - Active pattern 01``() = x.DoNamedTest()
     [<Test>] member x.``Function - Parameters - Pattern 12 - Active pattern 02``() = x.DoNamedTest()
+    [<Test>] member x.``Function - Parameters - Pattern 13 - With attribute 01``() = x.DoNamedTest()
+    [<Test>] member x.``Function - Parameters - Pattern 14 - With attribute 02``() = x.DoNamedTest()
+    [<Test>] member x.``Function - Parameters - Pattern 15 - With attribute 03``() = x.DoNamedTest()
+    [<Test>] member x.``Function - Parameters - Pattern 16 - With attribute 04``() = x.DoNamedTest()
 
     [<Test>] member x.``Function - Return - Function 01``() = x.DoNamedTest()
     [<Test>] member x.``Function - Return - Function 02``() = x.DoNamedTest()


### PR DESCRIPTION
`TypedPat` is nested in `AttributePat`, what is currently ignored in `SpecifyTypes` -- so a wrong tree is produced, and also action is available even when a pattern with attribute is typed. The `AssertCorrectTreeStructure` attribute for tests is also very useful.