### PR TITLE
FSharpArgumentsOwnerUtil: fix for property initializers

### DIFF
--- a/ReSharper.FSharp/src/FSharp/FSharp.Psi/src/Impl/FSharpArgumentsOwnerUtil.cs
+++ b/ReSharper.FSharp/src/FSharp/FSharp.Psi/src/Impl/FSharpArgumentsOwnerUtil.cs
@@ -48,7 +48,10 @@ namespace JetBrains.ReSharper.Plugins.FSharp.Psi.Impl
           if (paramGroup.Count == 0)
             return EmptyList<IArgument>.Instance;
 
-          if (paramGroup.Count == 1)
+          // RIDER-125426
+          // argExpr could be a tuple with a corresponding single param group parameter
+          // if it additionally contains property initializers
+          if (paramGroup.Count == 1 && argExpr is not ITupleExpr)
             return new[] {argExpr as IArgument};
 
           var tupleExprs =

--- a/ReSharper.FSharp/test/data/features/daemon/regexp/Detection 04.fs
+++ b/ReSharper.FSharp/test/data/features/daemon/regexp/Detection 04.fs
@@ -1,0 +1,26 @@
+﻿module Test
+
+open System.Diagnostics.CodeAnalysis
+open System.ComponentModel.DataAnnotations
+
+type RegexAttr([<StringSyntax(StringSyntaxAttribute.Regex)>] pattern: string) =
+    inherit System.Attribute()
+
+    new(_: int) = RegexAttr("\d")
+    new([<StringSyntax(StringSyntaxAttribute.Regex)>] pattern: string, _: int) = RegexAttr(pattern)
+
+    [<StringSyntax(StringSyntaxAttribute.Regex)>]
+    member val Pattern = "" with get, set
+
+
+[<RegularExpression("\d", ErrorMessage = "")>]
+let _ = ""
+
+[<RegexAttr("\d", Pattern = "\d")>]
+let _ = ""
+
+[<RegexAttr(1, Pattern = "\d")>]
+let _ = ""
+
+[<RegexAttr("\d", 1, Pattern = "\d")>]
+let _ = ""

--- a/ReSharper.FSharp/test/data/features/daemon/regexp/Detection 04.fs.gold
+++ b/ReSharper.FSharp/test/data/features/daemon/regexp/Detection 04.fs.gold
@@ -1,0 +1,35 @@
+﻿module Test
+
+open System.Diagnostics.CodeAnalysis
+open System.ComponentModel.DataAnnotations
+
+type RegexAttr([<StringSyntax(StringSyntaxAttribute.Regex)>] pattern: string) =
+    inherit System.Attribute()
+
+    new(_: int) = RegexAttr("|\d|(0)")
+    new([<StringSyntax(StringSyntaxAttribute.Regex)>] pattern: string, _: int) = RegexAttr(pattern)
+
+    [<StringSyntax(StringSyntaxAttribute.Regex)>]
+    member val Pattern = "" with get, set
+
+
+[<RegularExpression("|\d|(1)", ErrorMessage = "")>]
+let _ = ""
+
+[<RegexAttr("|\d|(2)", Pattern = "|\d|(3)")>]
+let _ = ""
+
+[<RegexAttr(1, Pattern = "|\d|(4)")>]
+let _ = ""
+
+[<RegexAttr("|\d|(5)", 1, Pattern = "|\d|(6)")>]
+let _ = ""
+
+---------------------------------------------------------
+(0): ReSharper Regex Identifier: 
+(1): ReSharper Regex Identifier: 
+(2): ReSharper Regex Identifier: 
+(3): ReSharper Regex Identifier: 
+(4): ReSharper Regex Identifier: 
+(5): ReSharper Regex Identifier: 
+(6): ReSharper Regex Identifier: 

--- a/ReSharper.FSharp/test/src/FSharp.Intentions.Tests/src/Daemon/RegexpHighlightingTest.fs
+++ b/ReSharper.FSharp/test/src/FSharp.Intentions.Tests/src/Daemon/RegexpHighlightingTest.fs
@@ -29,5 +29,6 @@ type RegexpHighlightingTest() =
 
     [<Test>] member x.``Detection 02 - Regex type provider``() = x.DoNamedTest()
     [<Test>] member x.``Detection 03 - Active pattern``() = x.DoNamedTest()
+    [<Test>] member x.``Detection 04``() = x.DoNamedTest()
 
     [<Test>] member x.``Injection 01 - Comments``() = x.DoNamedTest()


### PR DESCRIPTION
Fix for [RIDER-125426](https://youtrack.jetbrains.com/issue/RIDER-125426/Regex-is-not-highlighted-in-attributes-if-other-properties-are-set)