### PR TITLE
Import/union cases: store case names in union parts

### DIFF
--- a/ReSharper.FSharp/src/FSharp/FSharp.Psi/src/Impl/Cache2/FSharpCacheVersion.cs
+++ b/ReSharper.FSharp/src/FSharp/FSharp.Psi/src/Impl/Cache2/FSharpCacheVersion.cs
@@ -4,7 +4,7 @@ using JetBrains.Serialization;
 
 namespace JetBrains.ReSharper.Plugins.FSharp.Psi.Impl.Cache2
 {
-  [PolymorphicMarshaller(53)]
+  [PolymorphicMarshaller(54)]
   public class FSharpCacheVersion
   {
     [UsedImplicitly] public static UnsafeReader.ReadDelegate<object> ReadDelegate = _ => new FSharpCacheVersion();

--- a/ReSharper.FSharp/src/FSharp/FSharp.Psi/src/Impl/Cache2/Parts/ILAssemblyTypeAbbreviationPart.cs
+++ b/ReSharper.FSharp/src/FSharp/FSharp.Psi/src/Impl/Cache2/Parts/ILAssemblyTypeAbbreviationPart.cs
@@ -2,13 +2,14 @@ using JetBrains.Annotations;
 using JetBrains.ReSharper.Plugins.FSharp.Psi.Tree;
 using JetBrains.ReSharper.Plugins.FSharp.Util;
 using JetBrains.ReSharper.Psi.ExtensionsAPI.Caches2;
+using JetBrains.Util;
 
 namespace JetBrains.ReSharper.Plugins.FSharp.Psi.Impl.Cache2.Parts;
 
 internal class ILAssemblyTypeAbbreviationPart : TypeAbbreviationOrDeclarationPartBase, Class.IClassPart
 {
     public ILAssemblyTypeAbbreviationPart([NotNull] IFSharpTypeDeclaration declaration,
-        [NotNull] ICacheBuilder cacheBuilder) : base(declaration, cacheBuilder, PartKind.Class)
+        [NotNull] ICacheBuilder cacheBuilder) : base(declaration, cacheBuilder, PartKind.Class, EmptyArray<string>.Instance)
     {
     }
 

--- a/ReSharper.FSharp/src/FSharp/FSharp.Psi/src/Impl/Cache2/Parts/TypeAbbreviationOrDeclarationPart.cs
+++ b/ReSharper.FSharp/src/FSharp/FSharp.Psi/src/Impl/Cache2/Parts/TypeAbbreviationOrDeclarationPart.cs
@@ -10,7 +10,7 @@ namespace JetBrains.ReSharper.Plugins.FSharp.Psi.Impl.Cache2.Parts
   internal class TypeAbbreviationOrDeclarationPart : TypeAbbreviationOrDeclarationPartBase, Class.IClassPart
   {
     public TypeAbbreviationOrDeclarationPart([NotNull] IFSharpTypeDeclaration declaration,
-      [NotNull] ICacheBuilder cacheBuilder) : base(declaration, cacheBuilder, PartKind.Class)
+      [NotNull] ICacheBuilder cacheBuilder, string[] caseNames) : base(declaration, cacheBuilder, PartKind.Class, caseNames)
     {
     }
 
@@ -26,7 +26,7 @@ namespace JetBrains.ReSharper.Plugins.FSharp.Psi.Impl.Cache2.Parts
   internal class StructTypeAbbreviationOrDeclarationPart : TypeAbbreviationOrDeclarationPartBase, IFSharpStructPart
   {
     public StructTypeAbbreviationOrDeclarationPart([NotNull] IFSharpTypeDeclaration declaration,
-      [NotNull] ICacheBuilder cacheBuilder) : base(declaration, cacheBuilder, PartKind.Struct)
+      [NotNull] ICacheBuilder cacheBuilder, string[] caseNames) : base(declaration, cacheBuilder, PartKind.Struct, caseNames)
     {
     }
 
@@ -46,9 +46,12 @@ namespace JetBrains.ReSharper.Plugins.FSharp.Psi.Impl.Cache2.Parts
   internal abstract class TypeAbbreviationOrDeclarationPartBase : UnionPartBase, ITypeAbbreviationOrDeclarationPart
   {
     protected TypeAbbreviationOrDeclarationPartBase([NotNull] IFSharpTypeDeclaration declaration,
-      [NotNull] ICacheBuilder cacheBuilder, PartKind partKind) : base(declaration, cacheBuilder, false, true, partKind)
+      [NotNull] ICacheBuilder cacheBuilder, PartKind partKind, string[] caseNames)
+      : base(declaration, cacheBuilder, false, caseNames, partKind)
     {
     }
+
+    public override bool IsSingleCase => true;
 
     protected TypeAbbreviationOrDeclarationPartBase(IReader reader) : base(reader)
     {

--- a/ReSharper.FSharp/src/FSharp/FSharp.Psi/src/Impl/Cache2/Parts/UnionPart.cs
+++ b/ReSharper.FSharp/src/FSharp/FSharp.Psi/src/Impl/Cache2/Parts/UnionPart.cs
@@ -13,7 +13,7 @@ namespace JetBrains.ReSharper.Plugins.FSharp.Psi.Impl.Cache2.Parts
   internal class UnionPart : UnionPartBase, Class.IClassPart
   {
     public UnionPart([NotNull] IFSharpTypeDeclaration declaration, [NotNull] ICacheBuilder cacheBuilder, bool hasNestedTypes,
-      bool isSingleCase) : base(declaration, cacheBuilder, hasNestedTypes, isSingleCase, PartKind.Class)
+      string[] caseNames) : base(declaration, cacheBuilder, hasNestedTypes, caseNames, PartKind.Class)
     {
     }
 
@@ -31,7 +31,7 @@ namespace JetBrains.ReSharper.Plugins.FSharp.Psi.Impl.Cache2.Parts
   internal class StructUnionPart : UnionPartBase, IFSharpStructPart
   {
     public StructUnionPart([NotNull] IFSharpTypeDeclaration declaration, [NotNull] ICacheBuilder cacheBuilder,
-      bool isSingleCase) : base(declaration, cacheBuilder, false, isSingleCase, PartKind.Struct)
+      string[] caseNames) : base(declaration, cacheBuilder, false, caseNames, PartKind.Struct)
     {
     }
 
@@ -54,21 +54,23 @@ namespace JetBrains.ReSharper.Plugins.FSharp.Psi.Impl.Cache2.Parts
   internal abstract class UnionPartBase : StructuralTypePartBase, IUnionPart
   {
     public bool HasNestedTypes { get; }
-    public bool IsSingleCase { get; }
+    public string[] CaseNames { get; }
     public AccessRights RepresentationAccessRights { get; }
 
+    public virtual bool IsSingleCase => CaseNames.Length == 1;
+
     protected UnionPartBase([NotNull] IFSharpTypeDeclaration declaration, [NotNull] ICacheBuilder cacheBuilder,
-      bool hasNestedTypes, bool isSingleCase, PartKind partKind) : base(declaration, cacheBuilder, partKind)
+      bool hasNestedTypes, string[] caseNames, PartKind partKind) : base(declaration, cacheBuilder, partKind)
     {
       HasNestedTypes = hasNestedTypes;
       RepresentationAccessRights = declaration.GetRepresentationAccessRights();
-      IsSingleCase = isSingleCase;
+      CaseNames = caseNames;
     }
 
     protected UnionPartBase(IReader reader) : base(reader)
     {
       HasNestedTypes = reader.ReadBool();
-      IsSingleCase = reader.ReadBool();
+      CaseNames = reader.ReadStringArray();
       RepresentationAccessRights = (AccessRights) reader.ReadByte();
     }
 
@@ -77,6 +79,7 @@ namespace JetBrains.ReSharper.Plugins.FSharp.Psi.Impl.Cache2.Parts
       base.Write(writer);
       writer.WriteBool(HasNestedTypes);
       writer.WriteBool(IsSingleCase);
+      writer.WriteStringArray(CaseNames);
       writer.WriteByte((byte) RepresentationAccessRights);
     }
 
@@ -127,6 +130,7 @@ namespace JetBrains.ReSharper.Plugins.FSharp.Psi.Impl.Cache2.Parts
   {
     bool HasNestedTypes { get; }
     bool IsSingleCase { get; }
+    string[] CaseNames { get; }
     IList<IUnionCase> Cases { get; }
     TreeNodeCollection<IUnionCaseDeclaration> CaseDeclarations { get; }
   }

--- a/ReSharper.FSharp/src/FSharp/FSharp.Psi/src/Impl/FSharpImplUtil.cs
+++ b/ReSharper.FSharp/src/FSharp/FSharp.Psi/src/Impl/FSharpImplUtil.cs
@@ -337,7 +337,7 @@ namespace JetBrains.ReSharper.Plugins.FSharp.Psi.Impl
     public static string[] GetUnionCaseNames(this ITypeElement typeElement) =>
       typeElement is IFSharpCompiledTypeElement { Representation: FSharpCompiledTypeRepresentation.Union repr }
         ? repr.cases
-        : typeElement.GetSourceUnionCases().Select(unionCase => unionCase.SourceName).ToArray();
+        : GetPart<IUnionPart>(typeElement)?.CaseNames ?? EmptyArray<string>.Instance;
 
     [CanBeNull]
     public static FSharpUnionTagsClass GetUnionTagsClass([CanBeNull] this ITypeElement type) =>

--- a/ReSharper.FSharp/src/FSharp/FSharp.Psi/src/Impl/Tree/UnionRepresentation.cs
+++ b/ReSharper.FSharp/src/FSharp/FSharp.Psi/src/Impl/Tree/UnionRepresentation.cs
@@ -23,7 +23,7 @@ namespace JetBrains.ReSharper.Plugins.FSharp.Psi.Impl.Tree
           return myHasNestedTypes.Value;
 
         lock (this)
-          return myHasNestedTypes ??= TypePartKind != PartKind.Struct && UnionCases.Count > 1;
+          return myHasNestedTypes ??= TypePartKind != PartKind.Struct && UnionCasesEnumerable.Count() > 1;
       }
     }
 


### PR DESCRIPTION
Fixes a code completion perf regression coming from parsing the declarations for getting the union case names.