### PR TITLE
UseDotLambdaSyntaxFix: remove redundant parens (fix)

### DIFF
--- a/ReSharper.FSharp/src/FSharp/FSharp.Psi.Intentions/src/QuickFixes/ReplaceLambdaWithDotLambdaFix.fs
+++ b/ReSharper.FSharp/src/FSharp/FSharp.Psi.Intentions/src/QuickFixes/ReplaceLambdaWithDotLambdaFix.fs
@@ -38,6 +38,6 @@ type ReplaceLambdaWithDotLambdaFix(warning: DotLambdaCanBeUsedWarning) =
 
         let exprToReplace: ITreeNode =
             let possibleParenExpr = lambda.IgnoreParentParens(includingBeginEndExpr = false)
-            if needsParens possibleParenExpr lambda then lambda else possibleParenExpr
+            if needsParens possibleParenExpr dotLambda then lambda else possibleParenExpr
 
         ModificationUtil.ReplaceChild(exprToReplace, dotLambda) |> ignore

--- a/ReSharper.FSharp/test/data/features/quickFixes/useDotLambdaSyntaxFix/File scoped - Remove parens.fs.gold
+++ b/ReSharper.FSharp/test/data/features/quickFixes/useDotLambdaSyntaxFix/File scoped - Remove parens.fs.gold
@@ -4,7 +4,7 @@ f(_{caret}.ToString())
 f x(_.ToString())x
 
 open System.Linq
-[1;2;3] |> List.map (_.ToString())
+[1;2;3] |> List.map _.ToString()
 [1;2;3] |> List.map(_.ToString())
-[1;2;3] |> List.map (_.ToString())|> List.map id
+[1;2;3] |> List.map _.ToString()|> List.map id
 [1;2;3].Select(_.GetHashCode()).Where(_.Equals)

--- a/ReSharper.FSharp/test/data/features/quickFixes/useDotLambdaSyntaxFix/File scoped.fs.gold
+++ b/ReSharper.FSharp/test/data/features/quickFixes/useDotLambdaSyntaxFix/File scoped.fs.gold
@@ -7,8 +7,8 @@ ignore <| _.ToString()
 ignore <| _.ToString()
 ignore <| _.Prop[0]
 ignore <| _.Prop.[0]
-[1] |> _.ToString(fun x -> x.ToString()) |> ignore
-[1] |> _.Equals(let x = 5 in x) |> ignore
+[1] |> (_.ToString(fun x -> x.ToString())) |> ignore
+[1] |> (_.Equals(let x = 5 in x)) |> ignore
 type A1 = member _.M() = _.ToString()
 
 let f (a, (b, c)) = fun x -> _.ToString()


### PR DESCRIPTION
The logic is changed back to how it was before a recent formatter update.

<img width="1939" height="1929" alt="image" src="https://github.com/user-attachments/assets/cf8f49e4-7da8-4978-a4cf-b739daf9b195" />
