### PR TITLE
Frontend/Injections: fix tests

### DIFF
--- a/rider-fsharp/src/main/resources/intellij.rider.plugins.fsharp.injections.xml
+++ b/rider-fsharp/src/main/resources/intellij.rider.plugins.fsharp.injections.xml
@@ -1,7 +1,6 @@
 <idea-plugin package="com.jetbrains.rider.ideaInterop.fileTypes.fsharp.injections">
 
     <dependencies>
-        <plugin id="com.intellij.ml.llm"/>
         <module name="intellij.platform.langInjection"/>
     </dependencies>
 

--- a/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/markup/injections/FSharpLanguageInjectionTest.kt
+++ b/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/markup/injections/FSharpLanguageInjectionTest.kt
@@ -1,7 +1,6 @@
 package com.jetbrains.rider.plugins.fsharp.test.cases.markup.injections
 
 import com.intellij.codeInsight.daemon.impl.HighlightInfoType
-import com.jetbrains.rider.test.annotations.Mute
 import com.jetbrains.rider.test.annotations.Solution
 import com.jetbrains.rider.test.annotations.TestSettings
 import com.jetbrains.rider.test.base.BaseTestWithMarkup
@@ -34,11 +33,9 @@ class FSharpLanguageInjectionTest : BaseTestWithMarkup() {
   @Test
   fun testInjectionByCommentInVerbatimStrings() = doTest()
 
-  @Mute("RIDER-123576")
   @Test
   fun testInjectionByCommentInRegularInterpolatedStrings() = doTest()
 
-  @Mute("RIDER-123576")
   @Test
   fun testInjectionByCommentInVerbatimInterpolatedStrings() = doTest()
 
@@ -46,23 +43,18 @@ class FSharpLanguageInjectionTest : BaseTestWithMarkup() {
   fun testInjectionByCommentInTripleQuotedStrings() = doTest()
 
   //TODO: fix lexer for second case
-  @Mute("RIDER-123576")
   @Test
   fun testInjectionByCommentInRawStrings() = doTest()
 
-  @Mute("RIDER-123576")
   @Test
   fun testInjectionByCommentInTripleQuotedInterpolatedStrings() = doTest()
 
-  @Mute("RIDER-123576")
   @Test
   fun testEscapeSequences() = doTest()
 
-  @Mute("RIDER-123576")
   @Test
   fun testInjectionByAnnotation() = doTest()
 
-  @Mute("RIDER-123576")
   @Test
   fun testInjectionByFunction() = doTest()
 }

--- a/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/markup/injections/FSharpSqlAutomaticInjectionTest.kt
+++ b/rider-fsharp/src/test/kotlin/com/jetbrains/rider/plugins/fsharp/test/cases/markup/injections/FSharpSqlAutomaticInjectionTest.kt
@@ -1,6 +1,5 @@
 package com.jetbrains.rider.plugins.fsharp.test.cases.markup.injections
 
-import com.jetbrains.rider.test.annotations.Mute
 import com.jetbrains.rider.test.annotations.Solution
 import com.jetbrains.rider.test.annotations.TestSettings
 import com.jetbrains.rider.test.base.RiderSqlInjectionTestBase
@@ -12,7 +11,6 @@ import org.testng.annotations.Test
 @Solution("CoreConsoleApp")
 class FSharpSqlAutomaticInjectionTest : RiderSqlInjectionTestBase() {
 
-  @Mute("RIDER-123576")
   @Test
   fun `test auto injections`() = doTest()
 

--- a/rider-fsharp/src/test/testData/markup/injections/FSharpLanguageInjectionTest/testInjectionByCommentInRegularInterpolatedStrings/gold/Program.gold
+++ b/rider-fsharp/src/test/testData/markup/injections/FSharpLanguageInjectionTest/testInjectionByCommentInRegularInterpolatedStrings/gold/Program.gold
@@ -1,13 +1,13 @@
 // language=json
-var s1 = $"<frontend:INJECTED_FRAGMENT>[ ]</frontend:INJECTED_FRAGMENT>"
+let s1 = $"<frontend:INJECTED_FRAGMENT>[ ]</frontend:INJECTED_FRAGMENT>"
 
 // language=json
-var s2 = $"<frontend:INJECTED_FRAGMENT>[ {{ \"key\": \"</frontend:INJECTED_FRAGMENT>{42}<frontend:INJECTED_FRAGMENT>\" }} ]</frontend:INJECTED_FRAGMENT>"
+let s2 = $"<frontend:INJECTED_FRAGMENT>[ {{ \"key\": \"</frontend:INJECTED_FRAGMENT>{42}<frontend:INJECTED_FRAGMENT>\" }} ]</frontend:INJECTED_FRAGMENT>"
 
-var s3 = (*language=xml*) $"<frontend:INJECTED_FRAGMENT><tag1><tag2 attr=\"</frontend:INJECTED_FRAGMENT>{s1}<frontend:INJECTED_FRAGMENT>\"/></tag1></frontend:INJECTED_FRAGMENT>"
+let s3 = (*language=xml*) $"<frontend:INJECTED_FRAGMENT><tag1><tag2 attr=\"</frontend:INJECTED_FRAGMENT>{s1}<frontend:INJECTED_FRAGMENT>\"/></tag1></frontend:INJECTED_FRAGMENT>"
 
 // language=sql
-var s4 = $"<frontend:INJECTED_FRAGMENT> </frontend:INJECTED_FRAGMENT>{5}<frontend:INJECTED_FRAGMENT> select *</frontend:INJECTED_FRAGMENT>"
+let s4 = $"<frontend:INJECTED_FRAGMENT> </frontend:INJECTED_FRAGMENT>{5}<frontend:INJECTED_FRAGMENT> select *</frontend:INJECTED_FRAGMENT>"
 
 // language=css
-var s5 = $".unfinished {
+let s5 = $".unfinished {

--- a/rider-fsharp/src/test/testData/markup/injections/FSharpLanguageInjectionTest/testInjectionByCommentInRegularInterpolatedStrings/source/Program.fs
+++ b/rider-fsharp/src/test/testData/markup/injections/FSharpLanguageInjectionTest/testInjectionByCommentInRegularInterpolatedStrings/source/Program.fs
@@ -1,13 +1,13 @@
 // language=json
-var s1 = $"[ ]"
+let s1 = $"[ ]"
 
 // language=json
-var s2 = $"[ {{ \"key\": \"{42}\" }} ]"
+let s2 = $"[ {{ \"key\": \"{42}\" }} ]"
 
-var s3 = (*language=xml*) $"<tag1><tag2 attr=\"{s1}\"/></tag1>"
+let s3 = (*language=xml*) $"<tag1><tag2 attr=\"{s1}\"/></tag1>"
 
 // language=sql
-var s4 = $" {5} select *"
+let s4 = $" {5} select *"
 
 // language=css
-var s5 = $".unfinished {
+let s5 = $".unfinished {


### PR DESCRIPTION
When splitting the modules, an unnecessary dependency on ml.llm was introduced, resulting in injections not working correctly in tests at all.