### PR TITLE
Quick fixes/Import type: fix the text for modules

### DIFF
--- a/ReSharper.FSharp/src/FSharp/FSharp.Psi.Intentions/Resources/Strings.Designer.fs
+++ b/ReSharper.FSharp/src/FSharp/FSharp.Psi.Intentions/Resources/Strings.Designer.fs
@@ -45,3 +45,4 @@ type public Strings() =
     static member FSharpDisableInFileWithDirective_Text = Strings.ResourceManager.GetString("FSharpDisableInFileWithDirective_Text")
     static member FSharpDisableAndRestoreWithDirectives_Text = Strings.ResourceManager.GetString("FSharpDisableAndRestoreWithDirectives_Text")
     static member FSharpImportExtensionMember_MultipleChoices_Text = Strings.ResourceManager.GetString("FSharpImportExtensionMember_MultipleChoices_Text")
+    static member FSharpImportModule_Text = Strings.ResourceManager.GetString("FSharpImportModule_Text")

--- a/ReSharper.FSharp/src/FSharp/FSharp.Psi.Intentions/Resources/Strings.resx
+++ b/ReSharper.FSharp/src/FSharp/FSharp.Psi.Intentions/Resources/Strings.resx
@@ -37,4 +37,7 @@
     <data name="FSharpImportExtensionMember_MultipleChoices_Text" xml:space="preserve">
         <value>Import extension {0} '{1}' (multiple choices…)?</value>
     </data>
+    <data name="FSharpImportModule_Text" xml:space="preserve">
+        <value>Import module '{0}'</value>
+    </data>
 </root>

--- a/ReSharper.FSharp/src/FSharp/FSharp.Psi.Intentions/src/QuickFixes/FSharpImportTypeFix.fs
+++ b/ReSharper.FSharp/src/FSharp/FSharp.Psi.Intentions/src/QuickFixes/FSharpImportTypeFix.fs
@@ -3,6 +3,7 @@ namespace JetBrains.ReSharper.Plugins.FSharp.Psi.Features.Daemon.QuickFixes
 open JetBrains.ReSharper.Intentions.QuickFixes
 open JetBrains.ReSharper.Plugins.FSharp.Psi
 open JetBrains.ReSharper.Plugins.FSharp.Psi.Impl
+open JetBrains.ReSharper.Plugins.FSharp.Psi.Intentions.Resources
 open JetBrains.ReSharper.Plugins.FSharp.Psi.Services.Util
 open JetBrains.ReSharper.Psi
 open JetBrains.ReSharper.Psi.Caches
@@ -18,6 +19,10 @@ module FSharpImportTypeFix =
 
 type FSharpImportTypeFix(reference) =
     inherit ImportTypeFix(reference)
+
+    override this.Format(typeElement: ITypeElement) =
+        if typeElement :? IFSharpModule then Strings.FSharpImportModule_Text
+        else base.Format(typeElement)
 
     override this.GetSymbolScope(context) =
         let symbolCache = context.GetPsiServices().Symbols

--- a/ReSharper.FSharp/test/data/features/quickFixes/importType/availability/Module 01.fs
+++ b/ReSharper.FSharp/test/data/features/quickFixes/importType/availability/Module 01.fs
@@ -1,0 +1,6 @@
+module Test
+
+module A =
+    module M = ()
+
+M{caret}

--- a/ReSharper.FSharp/test/data/features/quickFixes/importType/availability/Module 01.fs.gold
+++ b/ReSharper.FSharp/test/data/features/quickFixes/importType/availability/Module 01.fs.gold
@@ -1,0 +1,17 @@
+﻿module Test
+
+module A =
+    module M = ()
+
+|M|(0)
+
+------------------------------------------------
+0: The value or constructor 'M' is not defined.
+QUICKFIXES:
+Import missing references in file
+--Import missing references in project
+--Import missing references in solution
+Import module 'Test.A.M'
+--Import module 'M' in file
+--Import module 'M' in project
+--Import module 'M' in solution

--- a/ReSharper.FSharp/test/src/FSharp.Intentions.Tests/src/QuickFixes/ImportTypeTest.fs
+++ b/ReSharper.FSharp/test/src/FSharp.Intentions.Tests/src/QuickFixes/ImportTypeTest.fs
@@ -91,6 +91,7 @@ type ImportTypeAvailabilityTest() =
     override x.RelativeTestDataPath = "features/quickFixes/importType/availability"
 
     [<Test>] member x.``Static member 01``() = x.DoNamedTest()
+    [<Test>] member x.``Module 01``() = x.DoNamedTest()
 
 
 [<AbstractClass; FSharpTest>]


### PR DESCRIPTION
This will allow the user to distinguish types from modules in cases of name conflicts